### PR TITLE
#2 — Data models + Drift schema v1

### DIFF
--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'enums.dart';
+
+part 'database.g.dart';
+
+class FoodEntries extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  DateTimeColumn get timestamp => dateTime()();
+  IntColumn get kcal => integer()();
+  RealColumn get proteinG => real()();
+  TextColumn get mealType => textEnum<MealType>()();
+  TextColumn get entryType => textEnum<FoodEntryType>()();
+  TextColumn get note => text().nullable()();
+}
+
+class WorkoutSessions extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  DateTimeColumn get startedAt => dateTime()();
+  DateTimeColumn get endedAt => dateTime().nullable()();
+  TextColumn get note => text().nullable()();
+}
+
+class ExerciseSets extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  IntColumn get sessionId =>
+      integer().references(WorkoutSessions, #id, onDelete: KeyAction.cascade)();
+  TextColumn get exerciseName => text()();
+  IntColumn get reps => integer()();
+  RealColumn get weight => real()();
+  TextColumn get weightUnit => textEnum<WeightUnit>()();
+  TextColumn get status => textEnum<WorkoutSetStatus>()();
+  IntColumn get orderIndex => integer()();
+}
+
+class BodyWeightLogs extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  DateTimeColumn get timestamp => dateTime()();
+  RealColumn get value => real()();
+  TextColumn get unit => textEnum<WeightUnit>()();
+}
+
+@DriftDatabase(tables: [FoodEntries, WorkoutSessions, ExerciseSets, BodyWeightLogs])
+class AppDatabase extends _$AppDatabase {
+  AppDatabase() : super(_openConnection());
+
+  AppDatabase.forTesting(super.executor);
+
+  @override
+  int get schemaVersion => 1;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+        onCreate: (m) => m.createAll(),
+        onUpgrade: (m, from, to) async {
+          // v1 has no prior schemas; intentionally empty.
+          // When schemaVersion advances: add a manual backup step
+          // (see vault/05 Architecture/Runbooks.md) before running migrations.
+        },
+        beforeOpen: (details) async {
+          await customStatement('PRAGMA foreign_keys = ON');
+        },
+      );
+}
+
+LazyDatabase _openConnection() {
+  return LazyDatabase(() async {
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File(p.join(dir.path, 'liftlog.sqlite'));
+    return NativeDatabase.createInBackground(file);
+  });
+}

--- a/lib/data/database.g.dart
+++ b/lib/data/database.g.dart
@@ -1,0 +1,2694 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'database.dart';
+
+// ignore_for_file: type=lint
+class $FoodEntriesTable extends FoodEntries
+    with TableInfo<$FoodEntriesTable, FoodEntry> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $FoodEntriesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _timestampMeta = const VerificationMeta(
+    'timestamp',
+  );
+  @override
+  late final GeneratedColumn<DateTime> timestamp = GeneratedColumn<DateTime>(
+    'timestamp',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _kcalMeta = const VerificationMeta('kcal');
+  @override
+  late final GeneratedColumn<int> kcal = GeneratedColumn<int>(
+    'kcal',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _proteinGMeta = const VerificationMeta(
+    'proteinG',
+  );
+  @override
+  late final GeneratedColumn<double> proteinG = GeneratedColumn<double>(
+    'protein_g',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<MealType, String> mealType =
+      GeneratedColumn<String>(
+        'meal_type',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      ).withConverter<MealType>($FoodEntriesTable.$convertermealType);
+  @override
+  late final GeneratedColumnWithTypeConverter<FoodEntryType, String> entryType =
+      GeneratedColumn<String>(
+        'entry_type',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      ).withConverter<FoodEntryType>($FoodEntriesTable.$converterentryType);
+  static const VerificationMeta _noteMeta = const VerificationMeta('note');
+  @override
+  late final GeneratedColumn<String> note = GeneratedColumn<String>(
+    'note',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    timestamp,
+    kcal,
+    proteinG,
+    mealType,
+    entryType,
+    note,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'food_entries';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<FoodEntry> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('timestamp')) {
+      context.handle(
+        _timestampMeta,
+        timestamp.isAcceptableOrUnknown(data['timestamp']!, _timestampMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_timestampMeta);
+    }
+    if (data.containsKey('kcal')) {
+      context.handle(
+        _kcalMeta,
+        kcal.isAcceptableOrUnknown(data['kcal']!, _kcalMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_kcalMeta);
+    }
+    if (data.containsKey('protein_g')) {
+      context.handle(
+        _proteinGMeta,
+        proteinG.isAcceptableOrUnknown(data['protein_g']!, _proteinGMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_proteinGMeta);
+    }
+    if (data.containsKey('note')) {
+      context.handle(
+        _noteMeta,
+        note.isAcceptableOrUnknown(data['note']!, _noteMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  FoodEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return FoodEntry(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      timestamp: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}timestamp'],
+      )!,
+      kcal: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}kcal'],
+      )!,
+      proteinG: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}protein_g'],
+      )!,
+      mealType: $FoodEntriesTable.$convertermealType.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}meal_type'],
+        )!,
+      ),
+      entryType: $FoodEntriesTable.$converterentryType.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}entry_type'],
+        )!,
+      ),
+      note: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}note'],
+      ),
+    );
+  }
+
+  @override
+  $FoodEntriesTable createAlias(String alias) {
+    return $FoodEntriesTable(attachedDatabase, alias);
+  }
+
+  static JsonTypeConverter2<MealType, String, String> $convertermealType =
+      const EnumNameConverter<MealType>(MealType.values);
+  static JsonTypeConverter2<FoodEntryType, String, String> $converterentryType =
+      const EnumNameConverter<FoodEntryType>(FoodEntryType.values);
+}
+
+class FoodEntry extends DataClass implements Insertable<FoodEntry> {
+  final int id;
+  final DateTime timestamp;
+  final int kcal;
+  final double proteinG;
+  final MealType mealType;
+  final FoodEntryType entryType;
+  final String? note;
+  const FoodEntry({
+    required this.id,
+    required this.timestamp,
+    required this.kcal,
+    required this.proteinG,
+    required this.mealType,
+    required this.entryType,
+    this.note,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['timestamp'] = Variable<DateTime>(timestamp);
+    map['kcal'] = Variable<int>(kcal);
+    map['protein_g'] = Variable<double>(proteinG);
+    {
+      map['meal_type'] = Variable<String>(
+        $FoodEntriesTable.$convertermealType.toSql(mealType),
+      );
+    }
+    {
+      map['entry_type'] = Variable<String>(
+        $FoodEntriesTable.$converterentryType.toSql(entryType),
+      );
+    }
+    if (!nullToAbsent || note != null) {
+      map['note'] = Variable<String>(note);
+    }
+    return map;
+  }
+
+  FoodEntriesCompanion toCompanion(bool nullToAbsent) {
+    return FoodEntriesCompanion(
+      id: Value(id),
+      timestamp: Value(timestamp),
+      kcal: Value(kcal),
+      proteinG: Value(proteinG),
+      mealType: Value(mealType),
+      entryType: Value(entryType),
+      note: note == null && nullToAbsent ? const Value.absent() : Value(note),
+    );
+  }
+
+  factory FoodEntry.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return FoodEntry(
+      id: serializer.fromJson<int>(json['id']),
+      timestamp: serializer.fromJson<DateTime>(json['timestamp']),
+      kcal: serializer.fromJson<int>(json['kcal']),
+      proteinG: serializer.fromJson<double>(json['proteinG']),
+      mealType: $FoodEntriesTable.$convertermealType.fromJson(
+        serializer.fromJson<String>(json['mealType']),
+      ),
+      entryType: $FoodEntriesTable.$converterentryType.fromJson(
+        serializer.fromJson<String>(json['entryType']),
+      ),
+      note: serializer.fromJson<String?>(json['note']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'timestamp': serializer.toJson<DateTime>(timestamp),
+      'kcal': serializer.toJson<int>(kcal),
+      'proteinG': serializer.toJson<double>(proteinG),
+      'mealType': serializer.toJson<String>(
+        $FoodEntriesTable.$convertermealType.toJson(mealType),
+      ),
+      'entryType': serializer.toJson<String>(
+        $FoodEntriesTable.$converterentryType.toJson(entryType),
+      ),
+      'note': serializer.toJson<String?>(note),
+    };
+  }
+
+  FoodEntry copyWith({
+    int? id,
+    DateTime? timestamp,
+    int? kcal,
+    double? proteinG,
+    MealType? mealType,
+    FoodEntryType? entryType,
+    Value<String?> note = const Value.absent(),
+  }) => FoodEntry(
+    id: id ?? this.id,
+    timestamp: timestamp ?? this.timestamp,
+    kcal: kcal ?? this.kcal,
+    proteinG: proteinG ?? this.proteinG,
+    mealType: mealType ?? this.mealType,
+    entryType: entryType ?? this.entryType,
+    note: note.present ? note.value : this.note,
+  );
+  FoodEntry copyWithCompanion(FoodEntriesCompanion data) {
+    return FoodEntry(
+      id: data.id.present ? data.id.value : this.id,
+      timestamp: data.timestamp.present ? data.timestamp.value : this.timestamp,
+      kcal: data.kcal.present ? data.kcal.value : this.kcal,
+      proteinG: data.proteinG.present ? data.proteinG.value : this.proteinG,
+      mealType: data.mealType.present ? data.mealType.value : this.mealType,
+      entryType: data.entryType.present ? data.entryType.value : this.entryType,
+      note: data.note.present ? data.note.value : this.note,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('FoodEntry(')
+          ..write('id: $id, ')
+          ..write('timestamp: $timestamp, ')
+          ..write('kcal: $kcal, ')
+          ..write('proteinG: $proteinG, ')
+          ..write('mealType: $mealType, ')
+          ..write('entryType: $entryType, ')
+          ..write('note: $note')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(id, timestamp, kcal, proteinG, mealType, entryType, note);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is FoodEntry &&
+          other.id == this.id &&
+          other.timestamp == this.timestamp &&
+          other.kcal == this.kcal &&
+          other.proteinG == this.proteinG &&
+          other.mealType == this.mealType &&
+          other.entryType == this.entryType &&
+          other.note == this.note);
+}
+
+class FoodEntriesCompanion extends UpdateCompanion<FoodEntry> {
+  final Value<int> id;
+  final Value<DateTime> timestamp;
+  final Value<int> kcal;
+  final Value<double> proteinG;
+  final Value<MealType> mealType;
+  final Value<FoodEntryType> entryType;
+  final Value<String?> note;
+  const FoodEntriesCompanion({
+    this.id = const Value.absent(),
+    this.timestamp = const Value.absent(),
+    this.kcal = const Value.absent(),
+    this.proteinG = const Value.absent(),
+    this.mealType = const Value.absent(),
+    this.entryType = const Value.absent(),
+    this.note = const Value.absent(),
+  });
+  FoodEntriesCompanion.insert({
+    this.id = const Value.absent(),
+    required DateTime timestamp,
+    required int kcal,
+    required double proteinG,
+    required MealType mealType,
+    required FoodEntryType entryType,
+    this.note = const Value.absent(),
+  }) : timestamp = Value(timestamp),
+       kcal = Value(kcal),
+       proteinG = Value(proteinG),
+       mealType = Value(mealType),
+       entryType = Value(entryType);
+  static Insertable<FoodEntry> custom({
+    Expression<int>? id,
+    Expression<DateTime>? timestamp,
+    Expression<int>? kcal,
+    Expression<double>? proteinG,
+    Expression<String>? mealType,
+    Expression<String>? entryType,
+    Expression<String>? note,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (timestamp != null) 'timestamp': timestamp,
+      if (kcal != null) 'kcal': kcal,
+      if (proteinG != null) 'protein_g': proteinG,
+      if (mealType != null) 'meal_type': mealType,
+      if (entryType != null) 'entry_type': entryType,
+      if (note != null) 'note': note,
+    });
+  }
+
+  FoodEntriesCompanion copyWith({
+    Value<int>? id,
+    Value<DateTime>? timestamp,
+    Value<int>? kcal,
+    Value<double>? proteinG,
+    Value<MealType>? mealType,
+    Value<FoodEntryType>? entryType,
+    Value<String?>? note,
+  }) {
+    return FoodEntriesCompanion(
+      id: id ?? this.id,
+      timestamp: timestamp ?? this.timestamp,
+      kcal: kcal ?? this.kcal,
+      proteinG: proteinG ?? this.proteinG,
+      mealType: mealType ?? this.mealType,
+      entryType: entryType ?? this.entryType,
+      note: note ?? this.note,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (timestamp.present) {
+      map['timestamp'] = Variable<DateTime>(timestamp.value);
+    }
+    if (kcal.present) {
+      map['kcal'] = Variable<int>(kcal.value);
+    }
+    if (proteinG.present) {
+      map['protein_g'] = Variable<double>(proteinG.value);
+    }
+    if (mealType.present) {
+      map['meal_type'] = Variable<String>(
+        $FoodEntriesTable.$convertermealType.toSql(mealType.value),
+      );
+    }
+    if (entryType.present) {
+      map['entry_type'] = Variable<String>(
+        $FoodEntriesTable.$converterentryType.toSql(entryType.value),
+      );
+    }
+    if (note.present) {
+      map['note'] = Variable<String>(note.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('FoodEntriesCompanion(')
+          ..write('id: $id, ')
+          ..write('timestamp: $timestamp, ')
+          ..write('kcal: $kcal, ')
+          ..write('proteinG: $proteinG, ')
+          ..write('mealType: $mealType, ')
+          ..write('entryType: $entryType, ')
+          ..write('note: $note')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $WorkoutSessionsTable extends WorkoutSessions
+    with TableInfo<$WorkoutSessionsTable, WorkoutSession> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $WorkoutSessionsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _startedAtMeta = const VerificationMeta(
+    'startedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> startedAt = GeneratedColumn<DateTime>(
+    'started_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _endedAtMeta = const VerificationMeta(
+    'endedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> endedAt = GeneratedColumn<DateTime>(
+    'ended_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _noteMeta = const VerificationMeta('note');
+  @override
+  late final GeneratedColumn<String> note = GeneratedColumn<String>(
+    'note',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [id, startedAt, endedAt, note];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'workout_sessions';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<WorkoutSession> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('started_at')) {
+      context.handle(
+        _startedAtMeta,
+        startedAt.isAcceptableOrUnknown(data['started_at']!, _startedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_startedAtMeta);
+    }
+    if (data.containsKey('ended_at')) {
+      context.handle(
+        _endedAtMeta,
+        endedAt.isAcceptableOrUnknown(data['ended_at']!, _endedAtMeta),
+      );
+    }
+    if (data.containsKey('note')) {
+      context.handle(
+        _noteMeta,
+        note.isAcceptableOrUnknown(data['note']!, _noteMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  WorkoutSession map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return WorkoutSession(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      startedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}started_at'],
+      )!,
+      endedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}ended_at'],
+      ),
+      note: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}note'],
+      ),
+    );
+  }
+
+  @override
+  $WorkoutSessionsTable createAlias(String alias) {
+    return $WorkoutSessionsTable(attachedDatabase, alias);
+  }
+}
+
+class WorkoutSession extends DataClass implements Insertable<WorkoutSession> {
+  final int id;
+  final DateTime startedAt;
+  final DateTime? endedAt;
+  final String? note;
+  const WorkoutSession({
+    required this.id,
+    required this.startedAt,
+    this.endedAt,
+    this.note,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['started_at'] = Variable<DateTime>(startedAt);
+    if (!nullToAbsent || endedAt != null) {
+      map['ended_at'] = Variable<DateTime>(endedAt);
+    }
+    if (!nullToAbsent || note != null) {
+      map['note'] = Variable<String>(note);
+    }
+    return map;
+  }
+
+  WorkoutSessionsCompanion toCompanion(bool nullToAbsent) {
+    return WorkoutSessionsCompanion(
+      id: Value(id),
+      startedAt: Value(startedAt),
+      endedAt: endedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(endedAt),
+      note: note == null && nullToAbsent ? const Value.absent() : Value(note),
+    );
+  }
+
+  factory WorkoutSession.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return WorkoutSession(
+      id: serializer.fromJson<int>(json['id']),
+      startedAt: serializer.fromJson<DateTime>(json['startedAt']),
+      endedAt: serializer.fromJson<DateTime?>(json['endedAt']),
+      note: serializer.fromJson<String?>(json['note']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'startedAt': serializer.toJson<DateTime>(startedAt),
+      'endedAt': serializer.toJson<DateTime?>(endedAt),
+      'note': serializer.toJson<String?>(note),
+    };
+  }
+
+  WorkoutSession copyWith({
+    int? id,
+    DateTime? startedAt,
+    Value<DateTime?> endedAt = const Value.absent(),
+    Value<String?> note = const Value.absent(),
+  }) => WorkoutSession(
+    id: id ?? this.id,
+    startedAt: startedAt ?? this.startedAt,
+    endedAt: endedAt.present ? endedAt.value : this.endedAt,
+    note: note.present ? note.value : this.note,
+  );
+  WorkoutSession copyWithCompanion(WorkoutSessionsCompanion data) {
+    return WorkoutSession(
+      id: data.id.present ? data.id.value : this.id,
+      startedAt: data.startedAt.present ? data.startedAt.value : this.startedAt,
+      endedAt: data.endedAt.present ? data.endedAt.value : this.endedAt,
+      note: data.note.present ? data.note.value : this.note,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('WorkoutSession(')
+          ..write('id: $id, ')
+          ..write('startedAt: $startedAt, ')
+          ..write('endedAt: $endedAt, ')
+          ..write('note: $note')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, startedAt, endedAt, note);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is WorkoutSession &&
+          other.id == this.id &&
+          other.startedAt == this.startedAt &&
+          other.endedAt == this.endedAt &&
+          other.note == this.note);
+}
+
+class WorkoutSessionsCompanion extends UpdateCompanion<WorkoutSession> {
+  final Value<int> id;
+  final Value<DateTime> startedAt;
+  final Value<DateTime?> endedAt;
+  final Value<String?> note;
+  const WorkoutSessionsCompanion({
+    this.id = const Value.absent(),
+    this.startedAt = const Value.absent(),
+    this.endedAt = const Value.absent(),
+    this.note = const Value.absent(),
+  });
+  WorkoutSessionsCompanion.insert({
+    this.id = const Value.absent(),
+    required DateTime startedAt,
+    this.endedAt = const Value.absent(),
+    this.note = const Value.absent(),
+  }) : startedAt = Value(startedAt);
+  static Insertable<WorkoutSession> custom({
+    Expression<int>? id,
+    Expression<DateTime>? startedAt,
+    Expression<DateTime>? endedAt,
+    Expression<String>? note,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (startedAt != null) 'started_at': startedAt,
+      if (endedAt != null) 'ended_at': endedAt,
+      if (note != null) 'note': note,
+    });
+  }
+
+  WorkoutSessionsCompanion copyWith({
+    Value<int>? id,
+    Value<DateTime>? startedAt,
+    Value<DateTime?>? endedAt,
+    Value<String?>? note,
+  }) {
+    return WorkoutSessionsCompanion(
+      id: id ?? this.id,
+      startedAt: startedAt ?? this.startedAt,
+      endedAt: endedAt ?? this.endedAt,
+      note: note ?? this.note,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (startedAt.present) {
+      map['started_at'] = Variable<DateTime>(startedAt.value);
+    }
+    if (endedAt.present) {
+      map['ended_at'] = Variable<DateTime>(endedAt.value);
+    }
+    if (note.present) {
+      map['note'] = Variable<String>(note.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('WorkoutSessionsCompanion(')
+          ..write('id: $id, ')
+          ..write('startedAt: $startedAt, ')
+          ..write('endedAt: $endedAt, ')
+          ..write('note: $note')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $ExerciseSetsTable extends ExerciseSets
+    with TableInfo<$ExerciseSetsTable, ExerciseSet> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $ExerciseSetsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _sessionIdMeta = const VerificationMeta(
+    'sessionId',
+  );
+  @override
+  late final GeneratedColumn<int> sessionId = GeneratedColumn<int>(
+    'session_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES workout_sessions (id) ON DELETE CASCADE',
+    ),
+  );
+  static const VerificationMeta _exerciseNameMeta = const VerificationMeta(
+    'exerciseName',
+  );
+  @override
+  late final GeneratedColumn<String> exerciseName = GeneratedColumn<String>(
+    'exercise_name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _repsMeta = const VerificationMeta('reps');
+  @override
+  late final GeneratedColumn<int> reps = GeneratedColumn<int>(
+    'reps',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _weightMeta = const VerificationMeta('weight');
+  @override
+  late final GeneratedColumn<double> weight = GeneratedColumn<double>(
+    'weight',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<WeightUnit, String> weightUnit =
+      GeneratedColumn<String>(
+        'weight_unit',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      ).withConverter<WeightUnit>($ExerciseSetsTable.$converterweightUnit);
+  @override
+  late final GeneratedColumnWithTypeConverter<WorkoutSetStatus, String> status =
+      GeneratedColumn<String>(
+        'status',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      ).withConverter<WorkoutSetStatus>($ExerciseSetsTable.$converterstatus);
+  static const VerificationMeta _orderIndexMeta = const VerificationMeta(
+    'orderIndex',
+  );
+  @override
+  late final GeneratedColumn<int> orderIndex = GeneratedColumn<int>(
+    'order_index',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    sessionId,
+    exerciseName,
+    reps,
+    weight,
+    weightUnit,
+    status,
+    orderIndex,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'exercise_sets';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<ExerciseSet> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('session_id')) {
+      context.handle(
+        _sessionIdMeta,
+        sessionId.isAcceptableOrUnknown(data['session_id']!, _sessionIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_sessionIdMeta);
+    }
+    if (data.containsKey('exercise_name')) {
+      context.handle(
+        _exerciseNameMeta,
+        exerciseName.isAcceptableOrUnknown(
+          data['exercise_name']!,
+          _exerciseNameMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_exerciseNameMeta);
+    }
+    if (data.containsKey('reps')) {
+      context.handle(
+        _repsMeta,
+        reps.isAcceptableOrUnknown(data['reps']!, _repsMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_repsMeta);
+    }
+    if (data.containsKey('weight')) {
+      context.handle(
+        _weightMeta,
+        weight.isAcceptableOrUnknown(data['weight']!, _weightMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_weightMeta);
+    }
+    if (data.containsKey('order_index')) {
+      context.handle(
+        _orderIndexMeta,
+        orderIndex.isAcceptableOrUnknown(data['order_index']!, _orderIndexMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_orderIndexMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  ExerciseSet map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return ExerciseSet(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      sessionId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}session_id'],
+      )!,
+      exerciseName: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}exercise_name'],
+      )!,
+      reps: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}reps'],
+      )!,
+      weight: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}weight'],
+      )!,
+      weightUnit: $ExerciseSetsTable.$converterweightUnit.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}weight_unit'],
+        )!,
+      ),
+      status: $ExerciseSetsTable.$converterstatus.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}status'],
+        )!,
+      ),
+      orderIndex: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}order_index'],
+      )!,
+    );
+  }
+
+  @override
+  $ExerciseSetsTable createAlias(String alias) {
+    return $ExerciseSetsTable(attachedDatabase, alias);
+  }
+
+  static JsonTypeConverter2<WeightUnit, String, String> $converterweightUnit =
+      const EnumNameConverter<WeightUnit>(WeightUnit.values);
+  static JsonTypeConverter2<WorkoutSetStatus, String, String> $converterstatus =
+      const EnumNameConverter<WorkoutSetStatus>(WorkoutSetStatus.values);
+}
+
+class ExerciseSet extends DataClass implements Insertable<ExerciseSet> {
+  final int id;
+  final int sessionId;
+  final String exerciseName;
+  final int reps;
+  final double weight;
+  final WeightUnit weightUnit;
+  final WorkoutSetStatus status;
+  final int orderIndex;
+  const ExerciseSet({
+    required this.id,
+    required this.sessionId,
+    required this.exerciseName,
+    required this.reps,
+    required this.weight,
+    required this.weightUnit,
+    required this.status,
+    required this.orderIndex,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['session_id'] = Variable<int>(sessionId);
+    map['exercise_name'] = Variable<String>(exerciseName);
+    map['reps'] = Variable<int>(reps);
+    map['weight'] = Variable<double>(weight);
+    {
+      map['weight_unit'] = Variable<String>(
+        $ExerciseSetsTable.$converterweightUnit.toSql(weightUnit),
+      );
+    }
+    {
+      map['status'] = Variable<String>(
+        $ExerciseSetsTable.$converterstatus.toSql(status),
+      );
+    }
+    map['order_index'] = Variable<int>(orderIndex);
+    return map;
+  }
+
+  ExerciseSetsCompanion toCompanion(bool nullToAbsent) {
+    return ExerciseSetsCompanion(
+      id: Value(id),
+      sessionId: Value(sessionId),
+      exerciseName: Value(exerciseName),
+      reps: Value(reps),
+      weight: Value(weight),
+      weightUnit: Value(weightUnit),
+      status: Value(status),
+      orderIndex: Value(orderIndex),
+    );
+  }
+
+  factory ExerciseSet.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return ExerciseSet(
+      id: serializer.fromJson<int>(json['id']),
+      sessionId: serializer.fromJson<int>(json['sessionId']),
+      exerciseName: serializer.fromJson<String>(json['exerciseName']),
+      reps: serializer.fromJson<int>(json['reps']),
+      weight: serializer.fromJson<double>(json['weight']),
+      weightUnit: $ExerciseSetsTable.$converterweightUnit.fromJson(
+        serializer.fromJson<String>(json['weightUnit']),
+      ),
+      status: $ExerciseSetsTable.$converterstatus.fromJson(
+        serializer.fromJson<String>(json['status']),
+      ),
+      orderIndex: serializer.fromJson<int>(json['orderIndex']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'sessionId': serializer.toJson<int>(sessionId),
+      'exerciseName': serializer.toJson<String>(exerciseName),
+      'reps': serializer.toJson<int>(reps),
+      'weight': serializer.toJson<double>(weight),
+      'weightUnit': serializer.toJson<String>(
+        $ExerciseSetsTable.$converterweightUnit.toJson(weightUnit),
+      ),
+      'status': serializer.toJson<String>(
+        $ExerciseSetsTable.$converterstatus.toJson(status),
+      ),
+      'orderIndex': serializer.toJson<int>(orderIndex),
+    };
+  }
+
+  ExerciseSet copyWith({
+    int? id,
+    int? sessionId,
+    String? exerciseName,
+    int? reps,
+    double? weight,
+    WeightUnit? weightUnit,
+    WorkoutSetStatus? status,
+    int? orderIndex,
+  }) => ExerciseSet(
+    id: id ?? this.id,
+    sessionId: sessionId ?? this.sessionId,
+    exerciseName: exerciseName ?? this.exerciseName,
+    reps: reps ?? this.reps,
+    weight: weight ?? this.weight,
+    weightUnit: weightUnit ?? this.weightUnit,
+    status: status ?? this.status,
+    orderIndex: orderIndex ?? this.orderIndex,
+  );
+  ExerciseSet copyWithCompanion(ExerciseSetsCompanion data) {
+    return ExerciseSet(
+      id: data.id.present ? data.id.value : this.id,
+      sessionId: data.sessionId.present ? data.sessionId.value : this.sessionId,
+      exerciseName: data.exerciseName.present
+          ? data.exerciseName.value
+          : this.exerciseName,
+      reps: data.reps.present ? data.reps.value : this.reps,
+      weight: data.weight.present ? data.weight.value : this.weight,
+      weightUnit: data.weightUnit.present
+          ? data.weightUnit.value
+          : this.weightUnit,
+      status: data.status.present ? data.status.value : this.status,
+      orderIndex: data.orderIndex.present
+          ? data.orderIndex.value
+          : this.orderIndex,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ExerciseSet(')
+          ..write('id: $id, ')
+          ..write('sessionId: $sessionId, ')
+          ..write('exerciseName: $exerciseName, ')
+          ..write('reps: $reps, ')
+          ..write('weight: $weight, ')
+          ..write('weightUnit: $weightUnit, ')
+          ..write('status: $status, ')
+          ..write('orderIndex: $orderIndex')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    sessionId,
+    exerciseName,
+    reps,
+    weight,
+    weightUnit,
+    status,
+    orderIndex,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is ExerciseSet &&
+          other.id == this.id &&
+          other.sessionId == this.sessionId &&
+          other.exerciseName == this.exerciseName &&
+          other.reps == this.reps &&
+          other.weight == this.weight &&
+          other.weightUnit == this.weightUnit &&
+          other.status == this.status &&
+          other.orderIndex == this.orderIndex);
+}
+
+class ExerciseSetsCompanion extends UpdateCompanion<ExerciseSet> {
+  final Value<int> id;
+  final Value<int> sessionId;
+  final Value<String> exerciseName;
+  final Value<int> reps;
+  final Value<double> weight;
+  final Value<WeightUnit> weightUnit;
+  final Value<WorkoutSetStatus> status;
+  final Value<int> orderIndex;
+  const ExerciseSetsCompanion({
+    this.id = const Value.absent(),
+    this.sessionId = const Value.absent(),
+    this.exerciseName = const Value.absent(),
+    this.reps = const Value.absent(),
+    this.weight = const Value.absent(),
+    this.weightUnit = const Value.absent(),
+    this.status = const Value.absent(),
+    this.orderIndex = const Value.absent(),
+  });
+  ExerciseSetsCompanion.insert({
+    this.id = const Value.absent(),
+    required int sessionId,
+    required String exerciseName,
+    required int reps,
+    required double weight,
+    required WeightUnit weightUnit,
+    required WorkoutSetStatus status,
+    required int orderIndex,
+  }) : sessionId = Value(sessionId),
+       exerciseName = Value(exerciseName),
+       reps = Value(reps),
+       weight = Value(weight),
+       weightUnit = Value(weightUnit),
+       status = Value(status),
+       orderIndex = Value(orderIndex);
+  static Insertable<ExerciseSet> custom({
+    Expression<int>? id,
+    Expression<int>? sessionId,
+    Expression<String>? exerciseName,
+    Expression<int>? reps,
+    Expression<double>? weight,
+    Expression<String>? weightUnit,
+    Expression<String>? status,
+    Expression<int>? orderIndex,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (sessionId != null) 'session_id': sessionId,
+      if (exerciseName != null) 'exercise_name': exerciseName,
+      if (reps != null) 'reps': reps,
+      if (weight != null) 'weight': weight,
+      if (weightUnit != null) 'weight_unit': weightUnit,
+      if (status != null) 'status': status,
+      if (orderIndex != null) 'order_index': orderIndex,
+    });
+  }
+
+  ExerciseSetsCompanion copyWith({
+    Value<int>? id,
+    Value<int>? sessionId,
+    Value<String>? exerciseName,
+    Value<int>? reps,
+    Value<double>? weight,
+    Value<WeightUnit>? weightUnit,
+    Value<WorkoutSetStatus>? status,
+    Value<int>? orderIndex,
+  }) {
+    return ExerciseSetsCompanion(
+      id: id ?? this.id,
+      sessionId: sessionId ?? this.sessionId,
+      exerciseName: exerciseName ?? this.exerciseName,
+      reps: reps ?? this.reps,
+      weight: weight ?? this.weight,
+      weightUnit: weightUnit ?? this.weightUnit,
+      status: status ?? this.status,
+      orderIndex: orderIndex ?? this.orderIndex,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (sessionId.present) {
+      map['session_id'] = Variable<int>(sessionId.value);
+    }
+    if (exerciseName.present) {
+      map['exercise_name'] = Variable<String>(exerciseName.value);
+    }
+    if (reps.present) {
+      map['reps'] = Variable<int>(reps.value);
+    }
+    if (weight.present) {
+      map['weight'] = Variable<double>(weight.value);
+    }
+    if (weightUnit.present) {
+      map['weight_unit'] = Variable<String>(
+        $ExerciseSetsTable.$converterweightUnit.toSql(weightUnit.value),
+      );
+    }
+    if (status.present) {
+      map['status'] = Variable<String>(
+        $ExerciseSetsTable.$converterstatus.toSql(status.value),
+      );
+    }
+    if (orderIndex.present) {
+      map['order_index'] = Variable<int>(orderIndex.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ExerciseSetsCompanion(')
+          ..write('id: $id, ')
+          ..write('sessionId: $sessionId, ')
+          ..write('exerciseName: $exerciseName, ')
+          ..write('reps: $reps, ')
+          ..write('weight: $weight, ')
+          ..write('weightUnit: $weightUnit, ')
+          ..write('status: $status, ')
+          ..write('orderIndex: $orderIndex')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $BodyWeightLogsTable extends BodyWeightLogs
+    with TableInfo<$BodyWeightLogsTable, BodyWeightLog> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $BodyWeightLogsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _timestampMeta = const VerificationMeta(
+    'timestamp',
+  );
+  @override
+  late final GeneratedColumn<DateTime> timestamp = GeneratedColumn<DateTime>(
+    'timestamp',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _valueMeta = const VerificationMeta('value');
+  @override
+  late final GeneratedColumn<double> value = GeneratedColumn<double>(
+    'value',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<WeightUnit, String> unit =
+      GeneratedColumn<String>(
+        'unit',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      ).withConverter<WeightUnit>($BodyWeightLogsTable.$converterunit);
+  @override
+  List<GeneratedColumn> get $columns => [id, timestamp, value, unit];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'body_weight_logs';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<BodyWeightLog> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('timestamp')) {
+      context.handle(
+        _timestampMeta,
+        timestamp.isAcceptableOrUnknown(data['timestamp']!, _timestampMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_timestampMeta);
+    }
+    if (data.containsKey('value')) {
+      context.handle(
+        _valueMeta,
+        value.isAcceptableOrUnknown(data['value']!, _valueMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_valueMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  BodyWeightLog map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return BodyWeightLog(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      timestamp: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}timestamp'],
+      )!,
+      value: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}value'],
+      )!,
+      unit: $BodyWeightLogsTable.$converterunit.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}unit'],
+        )!,
+      ),
+    );
+  }
+
+  @override
+  $BodyWeightLogsTable createAlias(String alias) {
+    return $BodyWeightLogsTable(attachedDatabase, alias);
+  }
+
+  static JsonTypeConverter2<WeightUnit, String, String> $converterunit =
+      const EnumNameConverter<WeightUnit>(WeightUnit.values);
+}
+
+class BodyWeightLog extends DataClass implements Insertable<BodyWeightLog> {
+  final int id;
+  final DateTime timestamp;
+  final double value;
+  final WeightUnit unit;
+  const BodyWeightLog({
+    required this.id,
+    required this.timestamp,
+    required this.value,
+    required this.unit,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['timestamp'] = Variable<DateTime>(timestamp);
+    map['value'] = Variable<double>(value);
+    {
+      map['unit'] = Variable<String>(
+        $BodyWeightLogsTable.$converterunit.toSql(unit),
+      );
+    }
+    return map;
+  }
+
+  BodyWeightLogsCompanion toCompanion(bool nullToAbsent) {
+    return BodyWeightLogsCompanion(
+      id: Value(id),
+      timestamp: Value(timestamp),
+      value: Value(value),
+      unit: Value(unit),
+    );
+  }
+
+  factory BodyWeightLog.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return BodyWeightLog(
+      id: serializer.fromJson<int>(json['id']),
+      timestamp: serializer.fromJson<DateTime>(json['timestamp']),
+      value: serializer.fromJson<double>(json['value']),
+      unit: $BodyWeightLogsTable.$converterunit.fromJson(
+        serializer.fromJson<String>(json['unit']),
+      ),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'timestamp': serializer.toJson<DateTime>(timestamp),
+      'value': serializer.toJson<double>(value),
+      'unit': serializer.toJson<String>(
+        $BodyWeightLogsTable.$converterunit.toJson(unit),
+      ),
+    };
+  }
+
+  BodyWeightLog copyWith({
+    int? id,
+    DateTime? timestamp,
+    double? value,
+    WeightUnit? unit,
+  }) => BodyWeightLog(
+    id: id ?? this.id,
+    timestamp: timestamp ?? this.timestamp,
+    value: value ?? this.value,
+    unit: unit ?? this.unit,
+  );
+  BodyWeightLog copyWithCompanion(BodyWeightLogsCompanion data) {
+    return BodyWeightLog(
+      id: data.id.present ? data.id.value : this.id,
+      timestamp: data.timestamp.present ? data.timestamp.value : this.timestamp,
+      value: data.value.present ? data.value.value : this.value,
+      unit: data.unit.present ? data.unit.value : this.unit,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('BodyWeightLog(')
+          ..write('id: $id, ')
+          ..write('timestamp: $timestamp, ')
+          ..write('value: $value, ')
+          ..write('unit: $unit')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, timestamp, value, unit);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is BodyWeightLog &&
+          other.id == this.id &&
+          other.timestamp == this.timestamp &&
+          other.value == this.value &&
+          other.unit == this.unit);
+}
+
+class BodyWeightLogsCompanion extends UpdateCompanion<BodyWeightLog> {
+  final Value<int> id;
+  final Value<DateTime> timestamp;
+  final Value<double> value;
+  final Value<WeightUnit> unit;
+  const BodyWeightLogsCompanion({
+    this.id = const Value.absent(),
+    this.timestamp = const Value.absent(),
+    this.value = const Value.absent(),
+    this.unit = const Value.absent(),
+  });
+  BodyWeightLogsCompanion.insert({
+    this.id = const Value.absent(),
+    required DateTime timestamp,
+    required double value,
+    required WeightUnit unit,
+  }) : timestamp = Value(timestamp),
+       value = Value(value),
+       unit = Value(unit);
+  static Insertable<BodyWeightLog> custom({
+    Expression<int>? id,
+    Expression<DateTime>? timestamp,
+    Expression<double>? value,
+    Expression<String>? unit,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (timestamp != null) 'timestamp': timestamp,
+      if (value != null) 'value': value,
+      if (unit != null) 'unit': unit,
+    });
+  }
+
+  BodyWeightLogsCompanion copyWith({
+    Value<int>? id,
+    Value<DateTime>? timestamp,
+    Value<double>? value,
+    Value<WeightUnit>? unit,
+  }) {
+    return BodyWeightLogsCompanion(
+      id: id ?? this.id,
+      timestamp: timestamp ?? this.timestamp,
+      value: value ?? this.value,
+      unit: unit ?? this.unit,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (timestamp.present) {
+      map['timestamp'] = Variable<DateTime>(timestamp.value);
+    }
+    if (value.present) {
+      map['value'] = Variable<double>(value.value);
+    }
+    if (unit.present) {
+      map['unit'] = Variable<String>(
+        $BodyWeightLogsTable.$converterunit.toSql(unit.value),
+      );
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('BodyWeightLogsCompanion(')
+          ..write('id: $id, ')
+          ..write('timestamp: $timestamp, ')
+          ..write('value: $value, ')
+          ..write('unit: $unit')
+          ..write(')'))
+        .toString();
+  }
+}
+
+abstract class _$AppDatabase extends GeneratedDatabase {
+  _$AppDatabase(QueryExecutor e) : super(e);
+  $AppDatabaseManager get managers => $AppDatabaseManager(this);
+  late final $FoodEntriesTable foodEntries = $FoodEntriesTable(this);
+  late final $WorkoutSessionsTable workoutSessions = $WorkoutSessionsTable(
+    this,
+  );
+  late final $ExerciseSetsTable exerciseSets = $ExerciseSetsTable(this);
+  late final $BodyWeightLogsTable bodyWeightLogs = $BodyWeightLogsTable(this);
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  @override
+  List<DatabaseSchemaEntity> get allSchemaEntities => [
+    foodEntries,
+    workoutSessions,
+    exerciseSets,
+    bodyWeightLogs,
+  ];
+  @override
+  StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'workout_sessions',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('exercise_sets', kind: UpdateKind.delete)],
+    ),
+  ]);
+}
+
+typedef $$FoodEntriesTableCreateCompanionBuilder =
+    FoodEntriesCompanion Function({
+      Value<int> id,
+      required DateTime timestamp,
+      required int kcal,
+      required double proteinG,
+      required MealType mealType,
+      required FoodEntryType entryType,
+      Value<String?> note,
+    });
+typedef $$FoodEntriesTableUpdateCompanionBuilder =
+    FoodEntriesCompanion Function({
+      Value<int> id,
+      Value<DateTime> timestamp,
+      Value<int> kcal,
+      Value<double> proteinG,
+      Value<MealType> mealType,
+      Value<FoodEntryType> entryType,
+      Value<String?> note,
+    });
+
+class $$FoodEntriesTableFilterComposer
+    extends Composer<_$AppDatabase, $FoodEntriesTable> {
+  $$FoodEntriesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get kcal => $composableBuilder(
+    column: $table.kcal,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get proteinG => $composableBuilder(
+    column: $table.proteinG,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<MealType, MealType, String> get mealType =>
+      $composableBuilder(
+        column: $table.mealType,
+        builder: (column) => ColumnWithTypeConverterFilters(column),
+      );
+
+  ColumnWithTypeConverterFilters<FoodEntryType, FoodEntryType, String>
+  get entryType => $composableBuilder(
+    column: $table.entryType,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnFilters<String> get note => $composableBuilder(
+    column: $table.note,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$FoodEntriesTableOrderingComposer
+    extends Composer<_$AppDatabase, $FoodEntriesTable> {
+  $$FoodEntriesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get kcal => $composableBuilder(
+    column: $table.kcal,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get proteinG => $composableBuilder(
+    column: $table.proteinG,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get mealType => $composableBuilder(
+    column: $table.mealType,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get entryType => $composableBuilder(
+    column: $table.entryType,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get note => $composableBuilder(
+    column: $table.note,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$FoodEntriesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $FoodEntriesTable> {
+  $$FoodEntriesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get timestamp =>
+      $composableBuilder(column: $table.timestamp, builder: (column) => column);
+
+  GeneratedColumn<int> get kcal =>
+      $composableBuilder(column: $table.kcal, builder: (column) => column);
+
+  GeneratedColumn<double> get proteinG =>
+      $composableBuilder(column: $table.proteinG, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<MealType, String> get mealType =>
+      $composableBuilder(column: $table.mealType, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<FoodEntryType, String> get entryType =>
+      $composableBuilder(column: $table.entryType, builder: (column) => column);
+
+  GeneratedColumn<String> get note =>
+      $composableBuilder(column: $table.note, builder: (column) => column);
+}
+
+class $$FoodEntriesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $FoodEntriesTable,
+          FoodEntry,
+          $$FoodEntriesTableFilterComposer,
+          $$FoodEntriesTableOrderingComposer,
+          $$FoodEntriesTableAnnotationComposer,
+          $$FoodEntriesTableCreateCompanionBuilder,
+          $$FoodEntriesTableUpdateCompanionBuilder,
+          (
+            FoodEntry,
+            BaseReferences<_$AppDatabase, $FoodEntriesTable, FoodEntry>,
+          ),
+          FoodEntry,
+          PrefetchHooks Function()
+        > {
+  $$FoodEntriesTableTableManager(_$AppDatabase db, $FoodEntriesTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$FoodEntriesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$FoodEntriesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$FoodEntriesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<DateTime> timestamp = const Value.absent(),
+                Value<int> kcal = const Value.absent(),
+                Value<double> proteinG = const Value.absent(),
+                Value<MealType> mealType = const Value.absent(),
+                Value<FoodEntryType> entryType = const Value.absent(),
+                Value<String?> note = const Value.absent(),
+              }) => FoodEntriesCompanion(
+                id: id,
+                timestamp: timestamp,
+                kcal: kcal,
+                proteinG: proteinG,
+                mealType: mealType,
+                entryType: entryType,
+                note: note,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required DateTime timestamp,
+                required int kcal,
+                required double proteinG,
+                required MealType mealType,
+                required FoodEntryType entryType,
+                Value<String?> note = const Value.absent(),
+              }) => FoodEntriesCompanion.insert(
+                id: id,
+                timestamp: timestamp,
+                kcal: kcal,
+                proteinG: proteinG,
+                mealType: mealType,
+                entryType: entryType,
+                note: note,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$FoodEntriesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $FoodEntriesTable,
+      FoodEntry,
+      $$FoodEntriesTableFilterComposer,
+      $$FoodEntriesTableOrderingComposer,
+      $$FoodEntriesTableAnnotationComposer,
+      $$FoodEntriesTableCreateCompanionBuilder,
+      $$FoodEntriesTableUpdateCompanionBuilder,
+      (FoodEntry, BaseReferences<_$AppDatabase, $FoodEntriesTable, FoodEntry>),
+      FoodEntry,
+      PrefetchHooks Function()
+    >;
+typedef $$WorkoutSessionsTableCreateCompanionBuilder =
+    WorkoutSessionsCompanion Function({
+      Value<int> id,
+      required DateTime startedAt,
+      Value<DateTime?> endedAt,
+      Value<String?> note,
+    });
+typedef $$WorkoutSessionsTableUpdateCompanionBuilder =
+    WorkoutSessionsCompanion Function({
+      Value<int> id,
+      Value<DateTime> startedAt,
+      Value<DateTime?> endedAt,
+      Value<String?> note,
+    });
+
+final class $$WorkoutSessionsTableReferences
+    extends
+        BaseReferences<_$AppDatabase, $WorkoutSessionsTable, WorkoutSession> {
+  $$WorkoutSessionsTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static MultiTypedResultKey<$ExerciseSetsTable, List<ExerciseSet>>
+  _exerciseSetsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+    db.exerciseSets,
+    aliasName: $_aliasNameGenerator(
+      db.workoutSessions.id,
+      db.exerciseSets.sessionId,
+    ),
+  );
+
+  $$ExerciseSetsTableProcessedTableManager get exerciseSetsRefs {
+    final manager = $$ExerciseSetsTableTableManager(
+      $_db,
+      $_db.exerciseSets,
+    ).filter((f) => f.sessionId.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_exerciseSetsRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
+
+class $$WorkoutSessionsTableFilterComposer
+    extends Composer<_$AppDatabase, $WorkoutSessionsTable> {
+  $$WorkoutSessionsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get startedAt => $composableBuilder(
+    column: $table.startedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get endedAt => $composableBuilder(
+    column: $table.endedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get note => $composableBuilder(
+    column: $table.note,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  Expression<bool> exerciseSetsRefs(
+    Expression<bool> Function($$ExerciseSetsTableFilterComposer f) f,
+  ) {
+    final $$ExerciseSetsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.exerciseSets,
+      getReferencedColumn: (t) => t.sessionId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ExerciseSetsTableFilterComposer(
+            $db: $db,
+            $table: $db.exerciseSets,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$WorkoutSessionsTableOrderingComposer
+    extends Composer<_$AppDatabase, $WorkoutSessionsTable> {
+  $$WorkoutSessionsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get startedAt => $composableBuilder(
+    column: $table.startedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get endedAt => $composableBuilder(
+    column: $table.endedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get note => $composableBuilder(
+    column: $table.note,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$WorkoutSessionsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $WorkoutSessionsTable> {
+  $$WorkoutSessionsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get startedAt =>
+      $composableBuilder(column: $table.startedAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get endedAt =>
+      $composableBuilder(column: $table.endedAt, builder: (column) => column);
+
+  GeneratedColumn<String> get note =>
+      $composableBuilder(column: $table.note, builder: (column) => column);
+
+  Expression<T> exerciseSetsRefs<T extends Object>(
+    Expression<T> Function($$ExerciseSetsTableAnnotationComposer a) f,
+  ) {
+    final $$ExerciseSetsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.exerciseSets,
+      getReferencedColumn: (t) => t.sessionId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ExerciseSetsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.exerciseSets,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$WorkoutSessionsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $WorkoutSessionsTable,
+          WorkoutSession,
+          $$WorkoutSessionsTableFilterComposer,
+          $$WorkoutSessionsTableOrderingComposer,
+          $$WorkoutSessionsTableAnnotationComposer,
+          $$WorkoutSessionsTableCreateCompanionBuilder,
+          $$WorkoutSessionsTableUpdateCompanionBuilder,
+          (WorkoutSession, $$WorkoutSessionsTableReferences),
+          WorkoutSession,
+          PrefetchHooks Function({bool exerciseSetsRefs})
+        > {
+  $$WorkoutSessionsTableTableManager(
+    _$AppDatabase db,
+    $WorkoutSessionsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$WorkoutSessionsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$WorkoutSessionsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$WorkoutSessionsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<DateTime> startedAt = const Value.absent(),
+                Value<DateTime?> endedAt = const Value.absent(),
+                Value<String?> note = const Value.absent(),
+              }) => WorkoutSessionsCompanion(
+                id: id,
+                startedAt: startedAt,
+                endedAt: endedAt,
+                note: note,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required DateTime startedAt,
+                Value<DateTime?> endedAt = const Value.absent(),
+                Value<String?> note = const Value.absent(),
+              }) => WorkoutSessionsCompanion.insert(
+                id: id,
+                startedAt: startedAt,
+                endedAt: endedAt,
+                note: note,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$WorkoutSessionsTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({exerciseSetsRefs = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [if (exerciseSetsRefs) db.exerciseSets],
+              addJoins: null,
+              getPrefetchedDataCallback: (items) async {
+                return [
+                  if (exerciseSetsRefs)
+                    await $_getPrefetchedData<
+                      WorkoutSession,
+                      $WorkoutSessionsTable,
+                      ExerciseSet
+                    >(
+                      currentTable: table,
+                      referencedTable: $$WorkoutSessionsTableReferences
+                          ._exerciseSetsRefsTable(db),
+                      managerFromTypedResult: (p0) =>
+                          $$WorkoutSessionsTableReferences(
+                            db,
+                            table,
+                            p0,
+                          ).exerciseSetsRefs,
+                      referencedItemsForCurrentItem: (item, referencedItems) =>
+                          referencedItems.where((e) => e.sessionId == item.id),
+                      typedResults: items,
+                    ),
+                ];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$WorkoutSessionsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $WorkoutSessionsTable,
+      WorkoutSession,
+      $$WorkoutSessionsTableFilterComposer,
+      $$WorkoutSessionsTableOrderingComposer,
+      $$WorkoutSessionsTableAnnotationComposer,
+      $$WorkoutSessionsTableCreateCompanionBuilder,
+      $$WorkoutSessionsTableUpdateCompanionBuilder,
+      (WorkoutSession, $$WorkoutSessionsTableReferences),
+      WorkoutSession,
+      PrefetchHooks Function({bool exerciseSetsRefs})
+    >;
+typedef $$ExerciseSetsTableCreateCompanionBuilder =
+    ExerciseSetsCompanion Function({
+      Value<int> id,
+      required int sessionId,
+      required String exerciseName,
+      required int reps,
+      required double weight,
+      required WeightUnit weightUnit,
+      required WorkoutSetStatus status,
+      required int orderIndex,
+    });
+typedef $$ExerciseSetsTableUpdateCompanionBuilder =
+    ExerciseSetsCompanion Function({
+      Value<int> id,
+      Value<int> sessionId,
+      Value<String> exerciseName,
+      Value<int> reps,
+      Value<double> weight,
+      Value<WeightUnit> weightUnit,
+      Value<WorkoutSetStatus> status,
+      Value<int> orderIndex,
+    });
+
+final class $$ExerciseSetsTableReferences
+    extends BaseReferences<_$AppDatabase, $ExerciseSetsTable, ExerciseSet> {
+  $$ExerciseSetsTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $WorkoutSessionsTable _sessionIdTable(_$AppDatabase db) =>
+      db.workoutSessions.createAlias(
+        $_aliasNameGenerator(db.exerciseSets.sessionId, db.workoutSessions.id),
+      );
+
+  $$WorkoutSessionsTableProcessedTableManager get sessionId {
+    final $_column = $_itemColumn<int>('session_id')!;
+
+    final manager = $$WorkoutSessionsTableTableManager(
+      $_db,
+      $_db.workoutSessions,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_sessionIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$ExerciseSetsTableFilterComposer
+    extends Composer<_$AppDatabase, $ExerciseSetsTable> {
+  $$ExerciseSetsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get exerciseName => $composableBuilder(
+    column: $table.exerciseName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get reps => $composableBuilder(
+    column: $table.reps,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get weight => $composableBuilder(
+    column: $table.weight,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<WeightUnit, WeightUnit, String>
+  get weightUnit => $composableBuilder(
+    column: $table.weightUnit,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<WorkoutSetStatus, WorkoutSetStatus, String>
+  get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnFilters<int> get orderIndex => $composableBuilder(
+    column: $table.orderIndex,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$WorkoutSessionsTableFilterComposer get sessionId {
+    final $$WorkoutSessionsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.sessionId,
+      referencedTable: $db.workoutSessions,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$WorkoutSessionsTableFilterComposer(
+            $db: $db,
+            $table: $db.workoutSessions,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$ExerciseSetsTableOrderingComposer
+    extends Composer<_$AppDatabase, $ExerciseSetsTable> {
+  $$ExerciseSetsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get exerciseName => $composableBuilder(
+    column: $table.exerciseName,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get reps => $composableBuilder(
+    column: $table.reps,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get weight => $composableBuilder(
+    column: $table.weight,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get weightUnit => $composableBuilder(
+    column: $table.weightUnit,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get status => $composableBuilder(
+    column: $table.status,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get orderIndex => $composableBuilder(
+    column: $table.orderIndex,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$WorkoutSessionsTableOrderingComposer get sessionId {
+    final $$WorkoutSessionsTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.sessionId,
+      referencedTable: $db.workoutSessions,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$WorkoutSessionsTableOrderingComposer(
+            $db: $db,
+            $table: $db.workoutSessions,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$ExerciseSetsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $ExerciseSetsTable> {
+  $$ExerciseSetsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get exerciseName => $composableBuilder(
+    column: $table.exerciseName,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get reps =>
+      $composableBuilder(column: $table.reps, builder: (column) => column);
+
+  GeneratedColumn<double> get weight =>
+      $composableBuilder(column: $table.weight, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<WeightUnit, String> get weightUnit =>
+      $composableBuilder(
+        column: $table.weightUnit,
+        builder: (column) => column,
+      );
+
+  GeneratedColumnWithTypeConverter<WorkoutSetStatus, String> get status =>
+      $composableBuilder(column: $table.status, builder: (column) => column);
+
+  GeneratedColumn<int> get orderIndex => $composableBuilder(
+    column: $table.orderIndex,
+    builder: (column) => column,
+  );
+
+  $$WorkoutSessionsTableAnnotationComposer get sessionId {
+    final $$WorkoutSessionsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.sessionId,
+      referencedTable: $db.workoutSessions,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$WorkoutSessionsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.workoutSessions,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$ExerciseSetsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $ExerciseSetsTable,
+          ExerciseSet,
+          $$ExerciseSetsTableFilterComposer,
+          $$ExerciseSetsTableOrderingComposer,
+          $$ExerciseSetsTableAnnotationComposer,
+          $$ExerciseSetsTableCreateCompanionBuilder,
+          $$ExerciseSetsTableUpdateCompanionBuilder,
+          (ExerciseSet, $$ExerciseSetsTableReferences),
+          ExerciseSet,
+          PrefetchHooks Function({bool sessionId})
+        > {
+  $$ExerciseSetsTableTableManager(_$AppDatabase db, $ExerciseSetsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$ExerciseSetsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$ExerciseSetsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$ExerciseSetsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<int> sessionId = const Value.absent(),
+                Value<String> exerciseName = const Value.absent(),
+                Value<int> reps = const Value.absent(),
+                Value<double> weight = const Value.absent(),
+                Value<WeightUnit> weightUnit = const Value.absent(),
+                Value<WorkoutSetStatus> status = const Value.absent(),
+                Value<int> orderIndex = const Value.absent(),
+              }) => ExerciseSetsCompanion(
+                id: id,
+                sessionId: sessionId,
+                exerciseName: exerciseName,
+                reps: reps,
+                weight: weight,
+                weightUnit: weightUnit,
+                status: status,
+                orderIndex: orderIndex,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required int sessionId,
+                required String exerciseName,
+                required int reps,
+                required double weight,
+                required WeightUnit weightUnit,
+                required WorkoutSetStatus status,
+                required int orderIndex,
+              }) => ExerciseSetsCompanion.insert(
+                id: id,
+                sessionId: sessionId,
+                exerciseName: exerciseName,
+                reps: reps,
+                weight: weight,
+                weightUnit: weightUnit,
+                status: status,
+                orderIndex: orderIndex,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$ExerciseSetsTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({sessionId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (sessionId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.sessionId,
+                                referencedTable: $$ExerciseSetsTableReferences
+                                    ._sessionIdTable(db),
+                                referencedColumn: $$ExerciseSetsTableReferences
+                                    ._sessionIdTable(db)
+                                    .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$ExerciseSetsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $ExerciseSetsTable,
+      ExerciseSet,
+      $$ExerciseSetsTableFilterComposer,
+      $$ExerciseSetsTableOrderingComposer,
+      $$ExerciseSetsTableAnnotationComposer,
+      $$ExerciseSetsTableCreateCompanionBuilder,
+      $$ExerciseSetsTableUpdateCompanionBuilder,
+      (ExerciseSet, $$ExerciseSetsTableReferences),
+      ExerciseSet,
+      PrefetchHooks Function({bool sessionId})
+    >;
+typedef $$BodyWeightLogsTableCreateCompanionBuilder =
+    BodyWeightLogsCompanion Function({
+      Value<int> id,
+      required DateTime timestamp,
+      required double value,
+      required WeightUnit unit,
+    });
+typedef $$BodyWeightLogsTableUpdateCompanionBuilder =
+    BodyWeightLogsCompanion Function({
+      Value<int> id,
+      Value<DateTime> timestamp,
+      Value<double> value,
+      Value<WeightUnit> unit,
+    });
+
+class $$BodyWeightLogsTableFilterComposer
+    extends Composer<_$AppDatabase, $BodyWeightLogsTable> {
+  $$BodyWeightLogsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get value => $composableBuilder(
+    column: $table.value,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<WeightUnit, WeightUnit, String> get unit =>
+      $composableBuilder(
+        column: $table.unit,
+        builder: (column) => ColumnWithTypeConverterFilters(column),
+      );
+}
+
+class $$BodyWeightLogsTableOrderingComposer
+    extends Composer<_$AppDatabase, $BodyWeightLogsTable> {
+  $$BodyWeightLogsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get timestamp => $composableBuilder(
+    column: $table.timestamp,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get value => $composableBuilder(
+    column: $table.value,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get unit => $composableBuilder(
+    column: $table.unit,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$BodyWeightLogsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $BodyWeightLogsTable> {
+  $$BodyWeightLogsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get timestamp =>
+      $composableBuilder(column: $table.timestamp, builder: (column) => column);
+
+  GeneratedColumn<double> get value =>
+      $composableBuilder(column: $table.value, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<WeightUnit, String> get unit =>
+      $composableBuilder(column: $table.unit, builder: (column) => column);
+}
+
+class $$BodyWeightLogsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $BodyWeightLogsTable,
+          BodyWeightLog,
+          $$BodyWeightLogsTableFilterComposer,
+          $$BodyWeightLogsTableOrderingComposer,
+          $$BodyWeightLogsTableAnnotationComposer,
+          $$BodyWeightLogsTableCreateCompanionBuilder,
+          $$BodyWeightLogsTableUpdateCompanionBuilder,
+          (
+            BodyWeightLog,
+            BaseReferences<_$AppDatabase, $BodyWeightLogsTable, BodyWeightLog>,
+          ),
+          BodyWeightLog,
+          PrefetchHooks Function()
+        > {
+  $$BodyWeightLogsTableTableManager(
+    _$AppDatabase db,
+    $BodyWeightLogsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$BodyWeightLogsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$BodyWeightLogsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$BodyWeightLogsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<DateTime> timestamp = const Value.absent(),
+                Value<double> value = const Value.absent(),
+                Value<WeightUnit> unit = const Value.absent(),
+              }) => BodyWeightLogsCompanion(
+                id: id,
+                timestamp: timestamp,
+                value: value,
+                unit: unit,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required DateTime timestamp,
+                required double value,
+                required WeightUnit unit,
+              }) => BodyWeightLogsCompanion.insert(
+                id: id,
+                timestamp: timestamp,
+                value: value,
+                unit: unit,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$BodyWeightLogsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $BodyWeightLogsTable,
+      BodyWeightLog,
+      $$BodyWeightLogsTableFilterComposer,
+      $$BodyWeightLogsTableOrderingComposer,
+      $$BodyWeightLogsTableAnnotationComposer,
+      $$BodyWeightLogsTableCreateCompanionBuilder,
+      $$BodyWeightLogsTableUpdateCompanionBuilder,
+      (
+        BodyWeightLog,
+        BaseReferences<_$AppDatabase, $BodyWeightLogsTable, BodyWeightLog>,
+      ),
+      BodyWeightLog,
+      PrefetchHooks Function()
+    >;
+
+class $AppDatabaseManager {
+  final _$AppDatabase _db;
+  $AppDatabaseManager(this._db);
+  $$FoodEntriesTableTableManager get foodEntries =>
+      $$FoodEntriesTableTableManager(_db, _db.foodEntries);
+  $$WorkoutSessionsTableTableManager get workoutSessions =>
+      $$WorkoutSessionsTableTableManager(_db, _db.workoutSessions);
+  $$ExerciseSetsTableTableManager get exerciseSets =>
+      $$ExerciseSetsTableTableManager(_db, _db.exerciseSets);
+  $$BodyWeightLogsTableTableManager get bodyWeightLogs =>
+      $$BodyWeightLogsTableTableManager(_db, _db.bodyWeightLogs);
+}

--- a/lib/data/day_range.dart
+++ b/lib/data/day_range.dart
@@ -1,0 +1,8 @@
+class DayRange {
+  DayRange(DateTime day)
+      : start = DateTime(day.year, day.month, day.day),
+        end = DateTime(day.year, day.month, day.day).add(const Duration(days: 1));
+
+  final DateTime start;
+  final DateTime end;
+}

--- a/lib/data/enums.dart
+++ b/lib/data/enums.dart
@@ -1,0 +1,7 @@
+enum MealType { breakfast, lunch, dinner, snack, other }
+
+enum FoodEntryType { manual, savedFood, barcode, estimate }
+
+enum WorkoutSetStatus { planned, completed, skipped }
+
+enum WeightUnit { kg, lb }

--- a/lib/data/repositories/body_weight_log_repository.dart
+++ b/lib/data/repositories/body_weight_log_repository.dart
@@ -1,0 +1,23 @@
+import 'package:drift/drift.dart';
+
+import '../database.dart';
+
+class BodyWeightLogRepository {
+  BodyWeightLogRepository(this._db);
+
+  final AppDatabase _db;
+
+  Future<int> add(BodyWeightLogsCompanion log) =>
+      _db.into(_db.bodyWeightLogs).insert(log);
+
+  Future<void> update(BodyWeightLog log) =>
+      (_db.update(_db.bodyWeightLogs)..whereSamePrimaryKey(log)).write(log);
+
+  Future<int> delete(int id) =>
+      (_db.delete(_db.bodyWeightLogs)..where((t) => t.id.equals(id))).go();
+
+  Stream<List<BodyWeightLog>> watchAll() =>
+      (_db.select(_db.bodyWeightLogs)
+            ..orderBy([(t) => OrderingTerm.desc(t.timestamp)]))
+          .watch();
+}

--- a/lib/data/repositories/exercise_set_repository.dart
+++ b/lib/data/repositories/exercise_set_repository.dart
@@ -1,0 +1,30 @@
+import 'package:drift/drift.dart';
+
+import '../database.dart';
+
+class ExerciseSetRepository {
+  ExerciseSetRepository(this._db);
+
+  final AppDatabase _db;
+
+  Future<int> add(ExerciseSetsCompanion set) =>
+      _db.into(_db.exerciseSets).insert(set);
+
+  Future<void> update(ExerciseSet set) =>
+      (_db.update(_db.exerciseSets)..whereSamePrimaryKey(set)).write(set);
+
+  Future<int> delete(int id) =>
+      (_db.delete(_db.exerciseSets)..where((t) => t.id.equals(id))).go();
+
+  Stream<List<ExerciseSet>> watchForSession(int sessionId) =>
+      (_db.select(_db.exerciseSets)
+            ..where((t) => t.sessionId.equals(sessionId))
+            ..orderBy([(t) => OrderingTerm.asc(t.orderIndex)]))
+          .watch();
+
+  Future<List<ExerciseSet>> listForSession(int sessionId) =>
+      (_db.select(_db.exerciseSets)
+            ..where((t) => t.sessionId.equals(sessionId))
+            ..orderBy([(t) => OrderingTerm.asc(t.orderIndex)]))
+          .get();
+}

--- a/lib/data/repositories/food_entry_repository.dart
+++ b/lib/data/repositories/food_entry_repository.dart
@@ -1,0 +1,50 @@
+import 'package:drift/drift.dart';
+
+import '../database.dart';
+import '../day_range.dart';
+
+class DailyTotals {
+  const DailyTotals({required this.kcal, required this.proteinG});
+  final int kcal;
+  final double proteinG;
+}
+
+class FoodEntryRepository {
+  FoodEntryRepository(this._db);
+
+  final AppDatabase _db;
+
+  Future<int> add(FoodEntriesCompanion entry) =>
+      _db.into(_db.foodEntries).insert(entry);
+
+  Future<void> update(FoodEntry entry) =>
+      (_db.update(_db.foodEntries)..whereSamePrimaryKey(entry)).write(entry);
+
+  Future<int> delete(int id) =>
+      (_db.delete(_db.foodEntries)..where((t) => t.id.equals(id))).go();
+
+  Stream<List<FoodEntry>> watchAll() =>
+      (_db.select(_db.foodEntries)
+            ..orderBy([(t) => OrderingTerm.desc(t.timestamp)]))
+          .watch();
+
+  Stream<List<FoodEntry>> watchByDate(DateTime day) {
+    final range = DayRange(day);
+    return (_db.select(_db.foodEntries)
+          ..where((t) => t.timestamp.isBetweenValues(range.start, range.end))
+          ..orderBy([(t) => OrderingTerm.desc(t.timestamp)]))
+        .watch();
+  }
+
+  Stream<DailyTotals> watchDailyTotals(DateTime day) {
+    return watchByDate(day).map((entries) {
+      var kcal = 0;
+      var protein = 0.0;
+      for (final e in entries) {
+        kcal += e.kcal;
+        protein += e.proteinG;
+      }
+      return DailyTotals(kcal: kcal, proteinG: protein);
+    });
+  }
+}

--- a/lib/data/repositories/workout_session_repository.dart
+++ b/lib/data/repositories/workout_session_repository.dart
@@ -1,0 +1,28 @@
+import 'package:drift/drift.dart';
+
+import '../database.dart';
+
+class WorkoutSessionRepository {
+  WorkoutSessionRepository(this._db);
+
+  final AppDatabase _db;
+
+  Future<int> add(WorkoutSessionsCompanion session) =>
+      _db.into(_db.workoutSessions).insert(session);
+
+  Future<void> update(WorkoutSession session) =>
+      (_db.update(_db.workoutSessions)..whereSamePrimaryKey(session))
+          .write(session);
+
+  Future<int> delete(int id) =>
+      (_db.delete(_db.workoutSessions)..where((t) => t.id.equals(id))).go();
+
+  Stream<List<WorkoutSession>> watchAll() =>
+      (_db.select(_db.workoutSessions)
+            ..orderBy([(t) => OrderingTerm.desc(t.startedAt)]))
+          .watch();
+
+  Future<WorkoutSession?> findById(int id) =>
+      (_db.select(_db.workoutSessions)..where((t) => t.id.equals(id)))
+          .getSingleOrNull();
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -420,7 +420,7 @@ packages:
     source: hosted
     version: "2.2.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   drift: ^2.20.3
   sqlite3_flutter_libs: ^0.5.24
   path_provider: ^2.1.5
+  path: ^1.9.0
 
 dev_dependencies:
   flutter_test:

--- a/test/data/body_weight_log_repository_test.dart
+++ b/test/data/body_weight_log_repository_test.dart
@@ -1,0 +1,73 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/data/repositories/body_weight_log_repository.dart';
+
+void main() {
+  late AppDatabase db;
+  late BodyWeightLogRepository repo;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = BodyWeightLogRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  test('add preserves unit exactly (no silent conversion)', () async {
+    await repo.add(BodyWeightLogsCompanion.insert(
+      timestamp: DateTime(2026, 4, 23),
+      value: 80.0,
+      unit: WeightUnit.kg,
+    ));
+    await repo.add(BodyWeightLogsCompanion.insert(
+      timestamp: DateTime(2026, 4, 22),
+      value: 176.0,
+      unit: WeightUnit.lb,
+    ));
+
+    final all = await repo.watchAll().first;
+    expect(all, hasLength(2));
+    final byUnit = {for (final log in all) log.unit: log.value};
+    expect(byUnit[WeightUnit.kg], 80.0);
+    expect(byUnit[WeightUnit.lb], 176.0);
+  });
+
+  test('update + delete', () async {
+    final id = await repo.add(BodyWeightLogsCompanion.insert(
+      timestamp: DateTime(2026, 4, 23),
+      value: 80.0,
+      unit: WeightUnit.kg,
+    ));
+
+    final original = (await repo.watchAll().first).single;
+    await repo.update(original.copyWith(value: 79.5));
+    expect((await repo.watchAll().first).single.value, 79.5);
+
+    expect(await repo.delete(id), 1);
+    expect(await repo.watchAll().first, isEmpty);
+  });
+
+  test('watchAll orders newest-first', () async {
+    await repo.add(BodyWeightLogsCompanion.insert(
+      timestamp: DateTime(2026, 4, 20),
+      value: 80.0,
+      unit: WeightUnit.kg,
+    ));
+    await repo.add(BodyWeightLogsCompanion.insert(
+      timestamp: DateTime(2026, 4, 23),
+      value: 79.5,
+      unit: WeightUnit.kg,
+    ));
+    await repo.add(BodyWeightLogsCompanion.insert(
+      timestamp: DateTime(2026, 4, 22),
+      value: 79.8,
+      unit: WeightUnit.kg,
+    ));
+
+    final values = (await repo.watchAll().first).map((l) => l.value).toList();
+    expect(values, [79.5, 79.8, 80.0]);
+  });
+}

--- a/test/data/food_entry_repository_test.dart
+++ b/test/data/food_entry_repository_test.dart
@@ -1,0 +1,105 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/data/repositories/food_entry_repository.dart';
+
+void main() {
+  late AppDatabase db;
+  late FoodEntryRepository repo;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = FoodEntryRepository(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  FoodEntriesCompanion sample({
+    DateTime? timestamp,
+    int kcal = 500,
+    double proteinG = 30.0,
+    MealType mealType = MealType.lunch,
+    FoodEntryType entryType = FoodEntryType.manual,
+  }) {
+    return FoodEntriesCompanion.insert(
+      timestamp: timestamp ?? DateTime(2026, 4, 23, 12, 30),
+      kcal: kcal,
+      proteinG: proteinG,
+      mealType: mealType,
+      entryType: entryType,
+    );
+  }
+
+  test('add + watchAll round-trips an entry with enum values as text', () async {
+    await repo.add(sample());
+
+    final entries = await repo.watchAll().first;
+    expect(entries, hasLength(1));
+    expect(entries.first.kcal, 500);
+    expect(entries.first.proteinG, 30.0);
+    expect(entries.first.mealType, MealType.lunch);
+    expect(entries.first.entryType, FoodEntryType.manual);
+
+    final raw = await db
+        .customSelect('SELECT meal_type, entry_type FROM food_entries')
+        .getSingle();
+    expect(raw.read<String>('meal_type'), 'lunch');
+    expect(raw.read<String>('entry_type'), 'manual');
+  });
+
+  test('update persists new field values', () async {
+    final id = await repo.add(sample());
+    final original = (await repo.watchAll().first).single;
+    final edited = original.copyWith(kcal: 600, proteinG: 40.0);
+
+    await repo.update(edited);
+
+    final after = (await repo.watchAll().first).single;
+    expect(after.id, id);
+    expect(after.kcal, 600);
+    expect(after.proteinG, 40.0);
+  });
+
+  test('delete removes the entry', () async {
+    final id = await repo.add(sample());
+    final removed = await repo.delete(id);
+    expect(removed, 1);
+    expect(await repo.watchAll().first, isEmpty);
+  });
+
+  test('watchByDate scopes to local calendar day', () async {
+    await repo.add(sample(timestamp: DateTime(2026, 4, 22, 23, 59)));
+    await repo.add(sample(timestamp: DateTime(2026, 4, 23, 0, 1), kcal: 200));
+    await repo.add(sample(timestamp: DateTime(2026, 4, 23, 23, 59), kcal: 300));
+    await repo.add(sample(timestamp: DateTime(2026, 4, 24, 0, 1)));
+
+    final onDay = await repo.watchByDate(DateTime(2026, 4, 23)).first;
+    expect(onDay.map((e) => e.kcal), unorderedEquals([200, 300]));
+  });
+
+  test('watchDailyTotals sums kcal and protein for the given day', () async {
+    await repo.add(sample(
+      timestamp: DateTime(2026, 4, 23, 8),
+      kcal: 400,
+      proteinG: 25.0,
+    ));
+    await repo.add(sample(
+      timestamp: DateTime(2026, 4, 23, 13),
+      kcal: 650,
+      proteinG: 42.5,
+    ));
+    await repo.add(sample(
+      timestamp: DateTime(2026, 4, 22, 20),
+      kcal: 999,
+      proteinG: 99.0,
+    ));
+
+    final totals = await repo.watchDailyTotals(DateTime(2026, 4, 23)).first;
+    expect(totals.kcal, 1050);
+    expect(totals.proteinG, closeTo(67.5, 1e-9));
+  });
+}

--- a/test/data/workout_repository_test.dart
+++ b/test/data/workout_repository_test.dart
@@ -1,0 +1,144 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/data/repositories/exercise_set_repository.dart';
+import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
+
+void main() {
+  late AppDatabase db;
+  late WorkoutSessionRepository sessions;
+  late ExerciseSetRepository sets;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    sessions = WorkoutSessionRepository(db);
+    sets = ExerciseSetRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  test('session lifecycle: add → end (update with endedAt) → delete cascades sets',
+      () async {
+    final sessionId = await sessions.add(WorkoutSessionsCompanion.insert(
+      startedAt: DateTime(2026, 4, 23, 18),
+    ));
+
+    for (var i = 0; i < 3; i++) {
+      await sets.add(ExerciseSetsCompanion.insert(
+        sessionId: sessionId,
+        exerciseName: 'Bench Press',
+        reps: 8,
+        weight: 80.0,
+        weightUnit: WeightUnit.kg,
+        status: WorkoutSetStatus.completed,
+        orderIndex: i,
+      ));
+    }
+
+    expect(await sets.listForSession(sessionId), hasLength(3));
+
+    final session = await sessions.findById(sessionId);
+    expect(session, isNotNull);
+    await sessions.update(session!.copyWith(
+      endedAt: Value(DateTime(2026, 4, 23, 19)),
+    ));
+    expect((await sessions.findById(sessionId))!.endedAt, isNotNull);
+
+    await sessions.delete(sessionId);
+    expect(await sessions.findById(sessionId), isNull);
+    expect(await sets.listForSession(sessionId), isEmpty,
+        reason: 'onDelete: cascade should remove child sets');
+  });
+
+  test('sets for a session are returned ordered by orderIndex ascending',
+      () async {
+    final id = await sessions.add(WorkoutSessionsCompanion.insert(
+      startedAt: DateTime(2026, 4, 23),
+    ));
+
+    await sets.add(ExerciseSetsCompanion.insert(
+      sessionId: id,
+      exerciseName: 'Squat',
+      reps: 5,
+      weight: 100,
+      weightUnit: WeightUnit.kg,
+      status: WorkoutSetStatus.completed,
+      orderIndex: 2,
+    ));
+    await sets.add(ExerciseSetsCompanion.insert(
+      sessionId: id,
+      exerciseName: 'Squat',
+      reps: 5,
+      weight: 100,
+      weightUnit: WeightUnit.kg,
+      status: WorkoutSetStatus.planned,
+      orderIndex: 0,
+    ));
+    await sets.add(ExerciseSetsCompanion.insert(
+      sessionId: id,
+      exerciseName: 'Squat',
+      reps: 5,
+      weight: 100,
+      weightUnit: WeightUnit.kg,
+      status: WorkoutSetStatus.skipped,
+      orderIndex: 1,
+    ));
+
+    final ordered = await sets.watchForSession(id).first;
+    expect(ordered.map((s) => s.status),
+        [WorkoutSetStatus.planned, WorkoutSetStatus.skipped, WorkoutSetStatus.completed]);
+  });
+
+  test('all three WorkoutSetStatus values round-trip', () async {
+    final id = await sessions.add(WorkoutSessionsCompanion.insert(
+      startedAt: DateTime(2026, 4, 23),
+    ));
+
+    for (final (i, status) in [
+      WorkoutSetStatus.planned,
+      WorkoutSetStatus.completed,
+      WorkoutSetStatus.skipped,
+    ].indexed) {
+      await sets.add(ExerciseSetsCompanion.insert(
+        sessionId: id,
+        exerciseName: 'Deadlift',
+        reps: 5,
+        weight: 140,
+        weightUnit: WeightUnit.kg,
+        status: status,
+        orderIndex: i,
+      ));
+    }
+
+    final rows = await db
+        .customSelect('SELECT status FROM exercise_sets ORDER BY order_index')
+        .get();
+    expect(rows.map((r) => r.read<String>('status')),
+        ['planned', 'completed', 'skipped']);
+  });
+
+  test('watchAll returns sessions newest-first by startedAt', () async {
+    await sessions.add(WorkoutSessionsCompanion.insert(
+      startedAt: DateTime(2026, 4, 20),
+    ));
+    await sessions.add(WorkoutSessionsCompanion.insert(
+      startedAt: DateTime(2026, 4, 23),
+    ));
+    await sessions.add(WorkoutSessionsCompanion.insert(
+      startedAt: DateTime(2026, 4, 22),
+    ));
+
+    final all = await sessions.watchAll().first;
+    expect(
+      all.map((s) => s.startedAt),
+      [
+        DateTime(2026, 4, 23),
+        DateTime(2026, 4, 22),
+        DateTime(2026, 4, 20),
+      ],
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Closes #2. Core data layer only — no UI, no product logic.

- 4 Drift tables: `food_entries`, `workout_sessions`, `exercise_sets`, `body_weight_logs`.
- 4 enums stored as TEXT (not ordinals): `MealType`, `FoodEntryType`, `WorkoutSetStatus`, `WeightUnit`.
- 1 repository per entity, each exposing `add` / `update` / `delete` + `watch*` streams.
- `schemaVersion = 1`; `onUpgrade` is a no-op with a reminder to document a manual backup path before advancing.
- Foreign keys enforced (`PRAGMA foreign_keys = ON` in `beforeOpen`); `ExerciseSet.sessionId` uses `ON DELETE CASCADE`.
- `FoodEntryRepository.watchDailyTotals()` derives today's kcal + protein from entries — no stored aggregate (supports issue #4).

## Scope — out
- UI (issues #3–#7).
- Persistence-across-process-restart integration test (issue #8).
- Cloud sync, auth, barcode, nutrition API, Apple Watch.

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — 13/13 passing (1 smoke + 12 repository tests)
- [x] Enum TEXT round-trip verified via `customSelect` reads
- [x] Cascade delete verified (session → sets)
- [x] Local-day scoping and ordering verified

## Architectural notes
- Repository boundary keeps Drift tables behind a thin interface — preserves the Apple Watch portability guardrail from `CLAUDE.md`.
- Pure Dart enums in `lib/data/enums.dart` are the canonical definition; Drift's `textEnum<T>()` maps them at the boundary.

## New env vars
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)