### PR TITLE
#4 — Daily dashboard: today's date + derived totals

### DIFF
--- a/lib/features/food/date_label.dart
+++ b/lib/features/food/date_label.dart
@@ -1,0 +1,6 @@
+const _monthNames = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+String shortDate(DateTime d) => '${_monthNames[d.month - 1]} ${d.day}';

--- a/lib/features/food/food_log_screen.dart
+++ b/lib/features/food/food_log_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/database.dart';
 import '../../data/repositories/food_entry_repository.dart';
+import 'date_label.dart';
 import 'food_entry_form_screen.dart';
 import 'food_providers.dart';
 import 'meal_type_label.dart';
@@ -69,30 +70,46 @@ class _TotalsHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final style = Theme.of(context).textTheme.titleMedium;
+    final theme = Theme.of(context);
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
-      child: totals.when(
-        data: (t) => Row(
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
-          children: [
-            Column(children: [
-              Text('${t.kcal}', style: Theme.of(context).textTheme.headlineMedium),
-              Text('kcal today', style: style),
-            ]),
-            Column(children: [
-              Text(
-                _formatProtein(t.proteinG),
-                style: Theme.of(context).textTheme.headlineMedium,
-              ),
-              Text('g protein', style: style),
-            ]),
-          ],
-        ),
-        loading: () => const SizedBox(height: 48),
-        error: (err, _) => Text('Totals unavailable: $err'),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'Today, ${shortDate(DateTime.now())}',
+            style: theme.textTheme.labelLarge,
+          ),
+          const SizedBox(height: 8),
+          totals.when(
+            data: (t) => Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                _Metric(value: '${t.kcal}', label: 'kcal'),
+                _Metric(value: _formatProtein(t.proteinG), label: 'g protein'),
+              ],
+            ),
+            loading: () => const SizedBox(height: 48),
+            error: (err, _) => Text('Totals unavailable: $err'),
+          ),
+        ],
       ),
     );
+  }
+}
+
+class _Metric extends StatelessWidget {
+  const _Metric({required this.value, required this.label});
+  final String value;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(children: [
+      Text(value, style: theme.textTheme.headlineMedium),
+      Text(label, style: theme.textTheme.titleMedium),
+    ]);
   }
 }
 

--- a/test/features/food/date_label_test.dart
+++ b/test/features/food/date_label_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/features/food/date_label.dart';
+
+void main() {
+  test('shortDate formats as "MMM d" for each month', () {
+    expect(shortDate(DateTime(2026, 1, 1)), 'Jan 1');
+    expect(shortDate(DateTime(2026, 4, 23)), 'Apr 23');
+    expect(shortDate(DateTime(2026, 12, 31)), 'Dec 31');
+  });
+}

--- a/test/smoke_test.dart
+++ b/test/smoke_test.dart
@@ -21,7 +21,8 @@ void main() {
 
     expect(find.byType(MaterialApp), findsOneWidget);
     expect(find.text('LiftLog'), findsOneWidget);
-    expect(find.text('kcal today'), findsOneWidget);
+    expect(find.textContaining('Today,'), findsOneWidget);
+    expect(find.text('kcal'), findsOneWidget);
     expect(find.text('g protein'), findsOneWidget);
     expect(find.textContaining('No entries yet'), findsOneWidget);
 


### PR DESCRIPTION
## Summary
Closes #4. The kcal + protein totals already live-updated on the home screen via #3. This PR adds the last missing piece from the #4 AC: today's date label in the totals header so the user knows the scope of the numbers.

- `Today, <Mon d>` row above the metrics.
- Minor refactor: extracted `_Metric` widget for the kcal / protein columns.

## AC status (from issue #4)
1. ✅ Totals equal sum of `FoodEntry` rows for the local calendar day (already satisfied by #3).
2. ✅ Add / edit / delete updates totals within a frame via Riverpod `StreamProvider` → Drift `watch` (already satisfied by #3).
3. ✅ No stored aggregate row — totals are derived via a query.
4. ✅ Query errors surface in UI via `totals.when(error: ...)`.
5. ✅ **NEW:** Today's date is displayed above the metrics.

## Scope — out
- Goals / targets / surplus indicators (out of v0.1).
- Charts, trends, history (→ #7).
- Editable date / multi-day navigation.

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — **21/21 passing** (new `shortDate` unit test; smoke test updated to assert the date header)

## New env vars
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)