### PR TITLE
#18 — Unify number + unit formatting

### DIFF
--- a/lib/features/body_weight/body_weight_form_screen.dart
+++ b/lib/features/body_weight/body_weight_form_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/database.dart';
 import '../../data/enums.dart';
 import '../../providers/app_providers.dart';
+import '../../ui/formatters.dart';
 import '../../ui/labels.dart';
 
 class BodyWeightFormScreen extends ConsumerStatefulWidget {
@@ -72,7 +73,7 @@ class _BodyWeightFormScreenState extends ConsumerState<BodyWeightFormScreen> {
       builder: (ctx) => AlertDialog(
         title: const Text('Delete weight log?'),
         content: Text(
-          'Delete ${widget.entry!.value} ${weightUnitLabel(widget.entry!.unit)}? '
+          'Delete ${formatWeight(widget.entry!.value, widget.entry!.unit)}? '
           'This cannot be undone.',
         ),
         actions: [

--- a/lib/features/body_weight/body_weight_screen.dart
+++ b/lib/features/body_weight/body_weight_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/database.dart';
-import '../../ui/labels.dart';
+import '../../ui/formatters.dart';
 import '../food/date_label.dart';
 import 'body_weight_form_screen.dart';
 import 'body_weight_providers.dart';
@@ -37,7 +37,7 @@ class BodyWeightScreen extends ConsumerWidget {
                 itemBuilder: (context, i) {
                   final e = list[i];
                   return ListTile(
-                    title: Text('${e.value} ${weightUnitLabel(e.unit)}'),
+                    title: Text(formatWeight(e.value, e.unit)),
                     subtitle: Text(shortDate(e.timestamp)),
                     onTap: () => _openForm(context, entry: e),
                   );

--- a/lib/features/food/food_entry_form_screen.dart
+++ b/lib/features/food/food_entry_form_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/database.dart';
 import '../../data/enums.dart';
 import '../../providers/app_providers.dart';
+import '../../ui/formatters.dart';
 import '../../ui/labels.dart';
 
 class FoodEntryFormScreen extends ConsumerStatefulWidget {
@@ -89,7 +90,7 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
       builder: (ctx) => AlertDialog(
         title: const Text('Delete entry?'),
         content: Text(
-          'Delete "${widget.entry!.name}" (${widget.entry!.kcal} kcal)? '
+          'Delete "${widget.entry!.name}" (${formatKcal(widget.entry!.kcal)} kcal)? '
           'This cannot be undone.',
         ),
         actions: [

--- a/lib/features/food/food_log_screen.dart
+++ b/lib/features/food/food_log_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/database.dart';
 import '../../data/repositories/food_entry_repository.dart';
+import '../../ui/formatters.dart';
 import '../../ui/labels.dart';
 import 'date_label.dart';
 import 'food_entry_form_screen.dart';
@@ -41,7 +42,7 @@ class FoodLogScreen extends ConsumerWidget {
                         return ListTile(
                           title: Text(e.name.isEmpty ? '(unnamed)' : e.name),
                           subtitle: Text(
-                            '${mealTypeLabel(e.mealType)} · ${e.kcal} kcal · ${_formatProtein(e.proteinG)}g protein',
+                            '${mealTypeLabel(e.mealType)} · ${formatKcal(e.kcal)} kcal · ${formatGrams(e.proteinG)} g protein',
                           ),
                           trailing: Text(_formatTime(e.timestamp)),
                           onTap: () => _openForm(context, entry: e),
@@ -85,8 +86,8 @@ class _TotalsHeader extends StatelessWidget {
             data: (t) => Row(
               mainAxisAlignment: MainAxisAlignment.spaceAround,
               children: [
-                _Metric(value: '${t.kcal}', label: 'kcal'),
-                _Metric(value: _formatProtein(t.proteinG), label: 'g protein'),
+                _Metric(value: formatKcal(t.kcal), label: 'kcal'),
+                _Metric(value: formatGrams(t.proteinG), label: 'g protein'),
               ],
             ),
             loading: () => const SizedBox(height: 48),
@@ -143,11 +144,6 @@ class _ErrorView extends StatelessWidget {
       ),
     );
   }
-}
-
-String _formatProtein(double g) {
-  if (g == g.roundToDouble()) return g.toStringAsFixed(0);
-  return g.toStringAsFixed(1);
 }
 
 String _formatTime(DateTime t) {

--- a/lib/features/history/history_screen.dart
+++ b/lib/features/history/history_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../ui/formatters.dart';
 import '../food/date_label.dart';
 import '../workouts/workout_session_screen.dart';
 import 'history_providers.dart';
@@ -28,7 +29,7 @@ class HistoryScreen extends ConsumerWidget {
                         ListTile(
                           title: Text(shortDate(d.day)),
                           subtitle: Text(
-                            '${d.kcal} kcal · ${_formatProtein(d.proteinG)}g protein',
+                            '${formatKcal(d.kcal)} kcal · ${formatGrams(d.proteinG)} g protein',
                           ),
                           onTap: () => Navigator.of(context).push(
                             MaterialPageRoute(
@@ -115,11 +116,6 @@ class _ErrorInline extends StatelessWidget {
       child: Text(text, style: Theme.of(context).textTheme.bodyMedium),
     );
   }
-}
-
-String _formatProtein(double g) {
-  if (g == g.roundToDouble()) return g.toStringAsFixed(0);
-  return g.toStringAsFixed(1);
 }
 
 String _workoutSubtitle(DateTime start, DateTime? end) {

--- a/lib/features/history/past_day_food_screen.dart
+++ b/lib/features/history/past_day_food_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../ui/formatters.dart';
 import '../../ui/labels.dart';
 import '../food/date_label.dart';
 import 'history_providers.dart';
@@ -35,7 +36,7 @@ class PastDayFoodScreen extends ConsumerWidget {
                   return ListTile(
                     title: Text(e.name.isEmpty ? '(unnamed)' : e.name),
                     subtitle: Text(
-                      '${mealTypeLabel(e.mealType)} · ${e.kcal} kcal · ${_formatProtein(e.proteinG)}g protein',
+                      '${mealTypeLabel(e.mealType)} · ${formatKcal(e.kcal)} kcal · ${formatGrams(e.proteinG)} g protein',
                     ),
                     trailing: Text(_formatTime(e.timestamp)),
                   );
@@ -46,11 +47,6 @@ class PastDayFoodScreen extends ConsumerWidget {
       ),
     );
   }
-}
-
-String _formatProtein(double g) {
-  if (g == g.roundToDouble()) return g.toStringAsFixed(0);
-  return g.toStringAsFixed(1);
 }
 
 String _formatTime(DateTime t) {

--- a/lib/features/workouts/workout_session_screen.dart
+++ b/lib/features/workouts/workout_session_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/database.dart';
 import '../../providers/app_providers.dart';
+import '../../ui/formatters.dart';
 import '../../ui/labels.dart';
 import '../food/date_label.dart';
 import 'exercise_set_form_screen.dart';
@@ -67,7 +68,7 @@ class WorkoutSessionScreen extends ConsumerWidget {
                         return ListTile(
                           title: Text(s.exerciseName),
                           subtitle: Text(
-                            '${s.reps} reps · ${s.weight} ${weightUnitLabel(s.weightUnit)} · ${workoutSetStatusLabel(s.status)}',
+                            '${s.reps} reps · ${formatWeight(s.weight, s.weightUnit)} · ${workoutSetStatusLabel(s.status)}',
                           ),
                           onTap: () =>
                               _editSet(context, s, sessionId, list.length),

--- a/lib/ui/formatters.dart
+++ b/lib/ui/formatters.dart
@@ -1,0 +1,20 @@
+import '../data/enums.dart';
+import 'labels.dart';
+
+/// Formats a calorie value (whole kcal only). Example: `1200`, `0`.
+String formatKcal(int kcal) => kcal.toString();
+
+/// Formats a gram value with at most one decimal place.
+/// - Integer values render without a decimal (`12`, `0`).
+/// - Decimal values render with one decimal, except trailing `.0` is trimmed
+///   (so `12.0` becomes `12`, while `12.5` stays `12.5`).
+String formatGrams(double g) {
+  if (g == g.roundToDouble()) return g.toStringAsFixed(0);
+  return g.toStringAsFixed(1);
+}
+
+/// Formats a weight value + unit label. Example: `80 kg`, `80.5 kg`, `176 lb`.
+/// Uses the same trim-trailing-.0 rule as [formatGrams] for the value, and
+/// routes the unit through [weightUnitLabel] so the suffix stays canonical.
+String formatWeight(double value, WeightUnit unit) =>
+    '${formatGrams(value)} ${weightUnitLabel(unit)}';

--- a/test/features/body_weight/body_weight_screen_test.dart
+++ b/test/features/body_weight/body_weight_screen_test.dart
@@ -48,8 +48,8 @@ void main() {
     await tester.pumpWidget(app());
     await tester.pumpAndSettle();
 
-    expect(find.text('176.0 lb'), findsOneWidget);
-    expect(find.text('80.0 kg'), findsOneWidget);
+    expect(find.text('176 lb'), findsOneWidget);
+    expect(find.text('80 kg'), findsOneWidget);
 
     await _drainDriftTimers(tester);
   });

--- a/test/ui/formatters_test.dart
+++ b/test/ui/formatters_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/ui/formatters.dart';
+
+void main() {
+  group('formatGrams', () {
+    test('integer double renders without decimals', () {
+      expect(formatGrams(80), '80');
+      expect(formatGrams(80.0), '80');
+    });
+
+    test('one-decimal value renders with one decimal', () {
+      expect(formatGrams(80.5), '80.5');
+      expect(formatGrams(12.5), '12.5');
+    });
+
+    test('zero renders as 0', () {
+      expect(formatGrams(0), '0');
+    });
+  });
+
+  group('formatKcal', () {
+    test('zero renders as 0', () {
+      expect(formatKcal(0), '0');
+    });
+
+    test('positive integer renders as-is', () {
+      expect(formatKcal(1200), '1200');
+    });
+  });
+
+  group('formatWeight', () {
+    test('integer value with kg', () {
+      expect(formatWeight(80, WeightUnit.kg), '80 kg');
+    });
+
+    test('integer-valued double with lb', () {
+      expect(formatWeight(176.0, WeightUnit.lb), '176 lb');
+    });
+
+    test('one-decimal value with kg', () {
+      expect(formatWeight(80.5, WeightUnit.kg), '80.5 kg');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds `lib/ui/formatters.dart` with three pure helpers — `formatKcal(int)`, `formatGrams(double)`, and `formatWeight(double, WeightUnit)` — and rolls them out to every screen that displays a number with a unit so calories, protein, and body weight all read the same way. Closes #18.

- `formatGrams` trims trailing `.0` (so `12.0` → `12`, `12.5` stays `12.5`, `0` → `0`).
- `formatWeight` routes the unit suffix through the existing `weightUnitLabel(unit)` switch — no hand-written kg/lb strings at callsites.
- Removes the two local `_formatProtein` helpers in `food_log_screen.dart` and `past_day_food_screen.dart`.

## Scope — in
- New: `lib/ui/formatters.dart`, `test/ui/formatters_test.dart`.
- Updated callsites: `food_log_screen.dart` (list subtitle + totals), `food_entry_form_screen.dart` (delete confirm), `body_weight_screen.dart` (list title), `body_weight_form_screen.dart` (delete confirm), `workout_session_screen.dart` (set row subtitle), `history_screen.dart` (day row subtitle), `past_day_food_screen.dart` (entry row subtitle).
- Updated widget test `body_weight_screen_test.dart` to match the new trimmed format (`176 lb` / `80 kg`) — the old assertions pinned the pre-unification rendering.

## Scope — out
- No locale / i18n, no kcal→kJ, no kg↔lb conversion.
- No `lib/data/**` changes, no enum changes, no schema migration.
- No pub dependencies added.
- `food_providers.dart` had no string formatting → not modified.
- `exercise_set_form_screen.dart` delete confirm is `'This cannot be undone.'` (no unit text) → no change needed.

## AC status
1. ✅ Formatter helpers exist with pure-Dart unit tests in `test/ui/formatters_test.dart` covering all cases from the brief (integer/decimal grams, zero, kcal zero + positive, kg + lb weights).
2. ✅ All listed adoption sites use the helpers. See grep outputs below — the remaining `kcal` hits are all field/column identifiers, canonical UI labels (`label: 'kcal'`, `'Calories (kcal)'`), the generated Drift code, or `${formatKcal(...)} kcal` compositions. No bare `'$<x> kcal'`, `'$<x> kg'`, or `'$<x> g'` number-interp remains outside `formatters.dart`.
3. ✅ No enum or schema change.
4. ✅ All existing business-logic tests pass unchanged. The one UI assertion that pinned the old format (body_weight_screen_test) was updated in lockstep with the new canonical output.

## Test plan
- `flutter analyze` → `No issues found! (ran in 2.1s)`
- `flutter test --reporter=expanded --timeout=30s` → `All tests passed!` (48 tests).
- Formatter unit tests cover: `formatGrams(80)`, `formatGrams(80.0)`, `formatGrams(80.5)`, `formatGrams(12.5)`, `formatGrams(0)`, `formatKcal(0)`, `formatKcal(1200)`, `formatWeight(80, kg)`, `formatWeight(176.0, lb)`, `formatWeight(80.5, kg)`.

## Grep outputs (AC #2)

`grep -rn "kg'" lib/ | grep -v formatters.dart`
```
lib/ui/labels.dart:21:      return 'kg';
```
Only the canonical `weightUnitLabel` switch returns it — no interpolation.

`grep -rn "g protein" lib/ | grep -v formatters.dart`
```
lib/features/food/food_log_screen.dart:45:                            '${mealTypeLabel(e.mealType)} · ${formatKcal(e.kcal)} kcal · ${formatGrams(e.proteinG)} g protein',
lib/features/food/food_log_screen.dart:90:                _Metric(value: formatGrams(t.proteinG), label: 'g protein'),
lib/features/history/history_screen.dart:32:                            '${formatKcal(d.kcal)} kcal · ${formatGrams(d.proteinG)} g protein',
lib/features/history/past_day_food_screen.dart:39:                      '${mealTypeLabel(e.mealType)} · ${formatKcal(e.kcal)} kcal · ${formatGrams(e.proteinG)} g protein',
```
Every hit composes via `formatGrams(...)` — no bare `'$<x>g protein'` interpolation left.

`grep -rn "kcal" lib/ | grep -v formatters.dart`
```
lib/features/food/food_log_screen.dart:45:                            '${mealTypeLabel(e.mealType)} · ${formatKcal(e.kcal)} kcal · ${formatGrams(e.proteinG)} g protein',
lib/features/food/food_log_screen.dart:89:                _Metric(value: formatKcal(t.kcal), label: 'kcal'),
lib/features/food/food_entry_form_screen.dart:24:  late final TextEditingController _kcalController;
lib/features/food/food_entry_form_screen.dart:36:    _kcalController = TextEditingController(text: e == null ? '' : '${e.kcal}');
lib/features/food/food_entry_form_screen.dart:45:    _kcalController.dispose();
lib/features/food/food_entry_form_screen.dart:55:    final kcal = int.parse(_kcalController.text.trim());
lib/features/food/food_entry_form_screen.dart:62:          kcal: kcal,
lib/features/food/food_entry_form_screen.dart:70:          kcal: kcal,
lib/features/food/food_entry_form_screen.dart:93:          'Delete "${widget.entry!.name}" (${formatKcal(widget.entry!.kcal)} kcal)? '
lib/features/food/food_entry_form_screen.dart:165:                controller: _kcalController,
lib/features/food/food_entry_form_screen.dart:166:                decoration: const InputDecoration(labelText: 'Calories (kcal)'),
lib/features/history/history_screen.dart:32:                            '${formatKcal(d.kcal)} kcal · ${formatGrams(d.proteinG)} g protein',
lib/features/history/past_day_food_screen.dart:39:                      '${mealTypeLabel(e.mealType)} · ${formatKcal(e.kcal)} kcal · ${formatGrams(e.proteinG)} g protein',
lib/data/repositories/food_entry_repository.dart: ... (column identifier / local variable / DailyTotals field — 9 hits)
lib/data/database.dart:16:  IntColumn get kcal => integer()();
lib/data/database.g.dart: ... (generated Drift code — many hits)
```
Outside formatters/labels, every remaining `kcal` is either a Drift column/struct field, a local variable named `kcal`, a canonical label (`label: 'kcal'`, `'Calories (kcal)'` field input), or a `${formatKcal(...)}` composition. No bare `'$<x> kcal'` number-interp remains.

## New env vars
None.