### PR TITLE
#19 — Surface estimate labeling

### DIFF
--- a/lib/features/food/estimate_badge.dart
+++ b/lib/features/food/estimate_badge.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import '../../data/enums.dart';
+
+/// Visible "Est." tag that surfaces when a food entry is an estimate.
+///
+/// Trust rule: estimated values must be visibly labeled in the UI. Never
+/// present an estimate as directly logged.
+///
+/// The renderer enumerates every [FoodEntryType] case explicitly — no
+/// fallthrough default. `savedFood` and `barcode` have no UI producers
+/// today, so they resolve to no badge until a real producer lands.
+class EstimateBadge extends StatelessWidget {
+  const EstimateBadge({super.key, required this.entryType});
+
+  final FoodEntryType entryType;
+
+  @override
+  Widget build(BuildContext context) {
+    switch (entryType) {
+      case FoodEntryType.estimate:
+        return const _EstBadge();
+      case FoodEntryType.manual:
+        return const SizedBox.shrink();
+      case FoodEntryType.savedFood:
+        // no UI producer today
+        return const SizedBox.shrink();
+      case FoodEntryType.barcode:
+        // no UI producer today
+        return const SizedBox.shrink();
+    }
+  }
+}
+
+class _EstBadge extends StatelessWidget {
+  const _EstBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        'Est.',
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSecondaryContainer,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/food/food_entry_form_screen.dart
+++ b/lib/features/food/food_entry_form_screen.dart
@@ -24,9 +24,15 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
   late final TextEditingController _kcalController;
   late final TextEditingController _proteinController;
   late MealType _mealType;
+  late bool _isEstimate;
   bool _saving = false;
 
   bool get _isEdit => widget.entry != null;
+
+  /// Toggle is visible when adding, or when editing an entry whose current
+  /// type is part of the flippable set (`manual` / `estimate`).
+  bool get _showEstimateToggle =>
+      !_isEdit || _canFlipType(widget.entry!.entryType);
 
   @override
   void initState() {
@@ -37,6 +43,7 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
     _proteinController =
         TextEditingController(text: e == null ? '' : e.proteinG.toString());
     _mealType = e?.mealType ?? MealType.other;
+    _isEstimate = e?.entryType == FoodEntryType.estimate;
   }
 
   @override
@@ -55,13 +62,21 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
     final kcal = int.parse(_kcalController.text.trim());
     final protein = double.parse(_proteinController.text.trim());
 
+    final newType = _isEstimate ? FoodEntryType.estimate : FoodEntryType.manual;
+
     try {
       if (_isEdit) {
+        // Only flip between manual <-> estimate. Never rewrite savedFood /
+        // barcode types from the UI (no producers exist yet; preserving the
+        // stored type is the safe default).
+        final current = widget.entry!.entryType;
+        final nextType = _canFlipType(current) ? newType : current;
         await repo.update(widget.entry!.copyWith(
           name: name,
           kcal: kcal,
           proteinG: protein,
           mealType: _mealType,
+          entryType: nextType,
         ));
       } else {
         await repo.add(FoodEntriesCompanion.insert(
@@ -70,7 +85,7 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
           kcal: kcal,
           proteinG: protein,
           mealType: _mealType,
-          entryType: FoodEntryType.manual,
+          entryType: newType,
         ));
       }
       if (!mounted) return;
@@ -81,6 +96,24 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Could not save entry: $e')),
       );
+    }
+  }
+
+  /// Enumerates every [FoodEntryType] case explicitly — no fallthrough.
+  /// The edit toggle only exposes a flip between `manual` and `estimate`;
+  /// `savedFood` / `barcode` are not UI-editable today (no producers).
+  bool _canFlipType(FoodEntryType t) {
+    switch (t) {
+      case FoodEntryType.manual:
+        return true;
+      case FoodEntryType.estimate:
+        return true;
+      case FoodEntryType.savedFood:
+        // no UI producer today
+        return false;
+      case FoodEntryType.barcode:
+        // no UI producer today
+        return false;
     }
   }
 
@@ -187,6 +220,20 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
                   return null;
                 },
               ),
+              if (_showEstimateToggle) ...[
+                const SizedBox(height: 4),
+                SwitchListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('This is an estimate'),
+                  subtitle: const Text(
+                    'Tag entries you eyeballed so totals stay honest.',
+                  ),
+                  value: _isEstimate,
+                  onChanged: _saving
+                      ? null
+                      : (v) => setState(() => _isEstimate = v),
+                ),
+              ],
               if (_isEdit) ...[
                 const SizedBox(height: 32),
                 TextButton.icon(

--- a/lib/features/food/food_log_screen.dart
+++ b/lib/features/food/food_log_screen.dart
@@ -6,6 +6,7 @@ import '../../data/repositories/food_entry_repository.dart';
 import '../../ui/formatters.dart';
 import '../../ui/labels.dart';
 import 'date_label.dart';
+import 'estimate_badge.dart';
 import 'food_entry_form_screen.dart';
 import 'food_providers.dart';
 
@@ -40,7 +41,18 @@ class FoodLogScreen extends ConsumerWidget {
                       itemBuilder: (context, i) {
                         final e = list[i];
                         return ListTile(
-                          title: Text(e.name.isEmpty ? '(unnamed)' : e.name),
+                          title: Row(
+                            children: [
+                              Flexible(
+                                child: Text(
+                                  e.name.isEmpty ? '(unnamed)' : e.name,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              EstimateBadge(entryType: e.entryType),
+                            ],
+                          ),
                           subtitle: Text(
                             '${mealTypeLabel(e.mealType)} · ${formatKcal(e.kcal)} kcal · ${formatGrams(e.proteinG)} g protein',
                           ),

--- a/lib/features/history/past_day_food_screen.dart
+++ b/lib/features/history/past_day_food_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../ui/formatters.dart';
 import '../../ui/labels.dart';
 import '../food/date_label.dart';
+import '../food/estimate_badge.dart';
 import 'history_providers.dart';
 
 class PastDayFoodScreen extends ConsumerWidget {
@@ -34,7 +35,18 @@ class PastDayFoodScreen extends ConsumerWidget {
                 itemBuilder: (context, i) {
                   final e = list[i];
                   return ListTile(
-                    title: Text(e.name.isEmpty ? '(unnamed)' : e.name),
+                    title: Row(
+                      children: [
+                        Flexible(
+                          child: Text(
+                            e.name.isEmpty ? '(unnamed)' : e.name,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        EstimateBadge(entryType: e.entryType),
+                      ],
+                    ),
                     subtitle: Text(
                       '${mealTypeLabel(e.mealType)} · ${formatKcal(e.kcal)} kcal · ${formatGrams(e.proteinG)} g protein',
                     ),

--- a/test/features/food/food_entry_form_screen_test.dart
+++ b/test/features/food/food_entry_form_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:liftlog_app/data/database.dart';
 import 'package:liftlog_app/data/enums.dart';
 import 'package:liftlog_app/data/repositories/food_entry_repository.dart';
 import 'package:liftlog_app/features/food/food_entry_form_screen.dart';
+import 'package:liftlog_app/features/food/food_log_screen.dart';
 import 'package:liftlog_app/providers/app_providers.dart';
 
 Widget _host(AppDatabase db, Widget child) {
@@ -130,4 +131,70 @@ void main() {
 
     expect(await repo.listAll(), isEmpty);
   });
+
+  testWidgets(
+      'add as estimate: toggle on → save → entry typed as estimate and '
+      'badge appears on the log', (tester) async {
+    await tester.pumpWidget(_host(db, const FoodEntryFormScreen()));
+
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Name'), 'Guess Bowl');
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Calories (kcal)'), '500');
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Protein (g)'), '25');
+
+    await tester.tap(find.text('This is an estimate'));
+    await tester.pump();
+
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final entries = await repo.listAll();
+    expect(entries, hasLength(1));
+    expect(entries.first.entryType, FoodEntryType.estimate);
+
+    // Unmount the form (whose Navigator is in an odd state after pop-to-empty)
+    // before mounting a fresh FoodLogScreen tree.
+    await tester.pumpWidget(const SizedBox());
+    await tester.pump(const Duration(milliseconds: 1));
+
+    await tester.pumpWidget(_host(db, const FoodLogScreen()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Guess Bowl'), findsOneWidget);
+    expect(find.text('Est.'), findsOneWidget);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('edit form: flipping estimate toggle off rewrites type to manual',
+      (tester) async {
+    await repo.add(FoodEntriesCompanion.insert(
+      timestamp: DateTime.now(),
+      name: const Value('Eyeballed soup'),
+      kcal: 250,
+      proteinG: 8.0,
+      mealType: MealType.dinner,
+      entryType: FoodEntryType.estimate,
+    ));
+    final entry = (await repo.listAll()).single;
+
+    await tester.pumpWidget(_host(db, FoodEntryFormScreen(entry: entry)));
+    await tester.pumpAndSettle();
+
+    // Toggle off — flips estimate -> manual.
+    await tester.tap(find.text('This is an estimate'));
+    await tester.pump();
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final after = (await repo.listAll()).single;
+    expect(after.entryType, FoodEntryType.manual);
+  });
+}
+
+Future<void> _drainDriftTimers(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox());
+  await tester.pump(const Duration(milliseconds: 1));
 }


### PR DESCRIPTION
## Summary
- Adds a "This is an estimate" toggle to the food add/edit form that writes `FoodEntryType.estimate` vs `.manual`. Edit flow lets the user flip only between those two; `savedFood`/`barcode` types are preserved untouched because no UI producers exist yet.
- Adds a centralized `EstimateBadge` widget and renders an "Est." badge next to entry names on the food log and past-day views when `entryType == FoodEntryType.estimate`.
- Totals remain derived strictly from logged entries — labeling is cosmetic, not mutative.

## Trust-rule compliance
- Estimated entries are **visibly labeled** ("Est." badge) — matches the CLAUDE.md trust rule "estimates must be visibly labeled in the UI."
- The badge renderer enumerates **all 4 `FoodEntryType` values** explicitly in its `switch` (no default fallthrough). `manual` → no badge, `estimate` → visible badge, `savedFood` / `barcode` → `SizedBox.shrink()` with an inline `// no UI producer today` comment. Same enumeration discipline applied in `_canFlipType` on the form.

## Scope
- In: toggle on form, badge on log + past-day rows, widget test covering the round-trip.
- Out (per issue): no UI surfacing of `savedFood` / `barcode`, no provenance column, no schema change.

## AC status
1. New entries default to `manual`; toggle writes `estimate`. ✓
2. Rows with `estimate` render "Est." badge on food log and past-day views. ✓
3. Enumerated switch on `FoodEntryType` in badge renderer — all 4 cases explicit. ✓
4. Widget test: add-as-estimate → reopen → badge present. ✓

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` green (50/50)
- [x] New widget tests:
  - "add as estimate: toggle on → save → entry typed as estimate and badge appears on the log"
  - "edit form: flipping estimate toggle off rewrites type to manual"
- [ ] On-device tap-through (founder QA; no device run per 2026-04-23 verification policy)

## Env vars / deps
None. No pub deps added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)