### PR TITLE
#20 — Editable timestamp on food + weight forms

### DIFF
--- a/lib/features/body_weight/body_weight_form_screen.dart
+++ b/lib/features/body_weight/body_weight_form_screen.dart
@@ -6,11 +6,16 @@ import '../../data/enums.dart';
 import '../../providers/app_providers.dart';
 import '../../ui/formatters.dart';
 import '../../ui/labels.dart';
+import '../../ui/timestamp_field.dart';
 
 class BodyWeightFormScreen extends ConsumerStatefulWidget {
-  const BodyWeightFormScreen({super.key, this.entry});
+  const BodyWeightFormScreen({super.key, this.entry, this.timestampPicker});
 
   final BodyWeightLog? entry;
+
+  /// Optional — only set by widget tests that want a deterministic timestamp
+  /// without driving the Material date+time dialogs. Null in production.
+  final TimestampPicker? timestampPicker;
 
   @override
   ConsumerState<BodyWeightFormScreen> createState() =>
@@ -21,6 +26,7 @@ class _BodyWeightFormScreenState extends ConsumerState<BodyWeightFormScreen> {
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _valueController;
   late WeightUnit _unit;
+  late DateTime _timestamp;
   bool _saving = false;
 
   bool get _isEdit => widget.entry != null;
@@ -29,9 +35,11 @@ class _BodyWeightFormScreenState extends ConsumerState<BodyWeightFormScreen> {
   void initState() {
     super.initState();
     final e = widget.entry;
-    _valueController =
-        TextEditingController(text: e == null ? '' : e.value.toString());
+    _valueController = TextEditingController(
+      text: e == null ? '' : e.value.toString(),
+    );
     _unit = e?.unit ?? WeightUnit.kg;
+    _timestamp = e?.timestamp ?? DateTime.now();
   }
 
   @override
@@ -48,22 +56,30 @@ class _BodyWeightFormScreenState extends ConsumerState<BodyWeightFormScreen> {
 
     try {
       if (_isEdit) {
-        await repo.update(widget.entry!.copyWith(value: value, unit: _unit));
+        await repo.update(
+          widget.entry!.copyWith(
+            timestamp: _timestamp,
+            value: value,
+            unit: _unit,
+          ),
+        );
       } else {
-        await repo.add(BodyWeightLogsCompanion.insert(
-          timestamp: DateTime.now(),
-          value: value,
-          unit: _unit,
-        ));
+        await repo.add(
+          BodyWeightLogsCompanion.insert(
+            timestamp: _timestamp,
+            value: value,
+            unit: _unit,
+          ),
+        );
       }
       if (!mounted) return;
       Navigator.of(context).pop();
     } catch (e) {
       if (!mounted) return;
       setState(() => _saving = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not save weight: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Could not save weight: $e')));
     }
   }
 
@@ -100,9 +116,9 @@ class _BodyWeightFormScreenState extends ConsumerState<BodyWeightFormScreen> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _saving = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not delete weight: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Could not delete weight: $e')));
     }
   }
 
@@ -127,8 +143,9 @@ class _BodyWeightFormScreenState extends ConsumerState<BodyWeightFormScreen> {
               TextFormField(
                 controller: _valueController,
                 decoration: const InputDecoration(labelText: 'Weight'),
-                keyboardType:
-                    const TextInputType.numberWithOptions(decimal: true),
+                keyboardType: const TextInputType.numberWithOptions(
+                  decimal: true,
+                ),
                 textInputAction: TextInputAction.done,
                 validator: (v) {
                   final n = double.tryParse((v ?? '').trim());
@@ -148,6 +165,14 @@ class _BodyWeightFormScreenState extends ConsumerState<BodyWeightFormScreen> {
                 onChanged: (u) {
                   if (u != null) setState(() => _unit = u);
                 },
+              ),
+              const SizedBox(height: 12),
+              TimestampField(
+                initialValue: _timestamp,
+                validator: futureGuardValidator,
+                enabled: !_saving,
+                picker: widget.timestampPicker,
+                onChanged: (t) => setState(() => _timestamp = t),
               ),
               if (_isEdit) ...[
                 const SizedBox(height: 32),

--- a/lib/features/food/food_entry_form_screen.dart
+++ b/lib/features/food/food_entry_form_screen.dart
@@ -7,11 +7,16 @@ import '../../data/enums.dart';
 import '../../providers/app_providers.dart';
 import '../../ui/formatters.dart';
 import '../../ui/labels.dart';
+import '../../ui/timestamp_field.dart';
 
 class FoodEntryFormScreen extends ConsumerStatefulWidget {
-  const FoodEntryFormScreen({super.key, this.entry});
+  const FoodEntryFormScreen({super.key, this.entry, this.timestampPicker});
 
   final FoodEntry? entry;
+
+  /// Optional — only set by widget tests that want a deterministic timestamp
+  /// without driving the Material date+time dialogs. Null in production.
+  final TimestampPicker? timestampPicker;
 
   @override
   ConsumerState<FoodEntryFormScreen> createState() =>
@@ -25,6 +30,7 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
   late final TextEditingController _proteinController;
   late MealType _mealType;
   late bool _isEstimate;
+  late DateTime _timestamp;
   bool _saving = false;
 
   bool get _isEdit => widget.entry != null;
@@ -40,10 +46,12 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
     final e = widget.entry;
     _nameController = TextEditingController(text: e?.name ?? '');
     _kcalController = TextEditingController(text: e == null ? '' : '${e.kcal}');
-    _proteinController =
-        TextEditingController(text: e == null ? '' : e.proteinG.toString());
+    _proteinController = TextEditingController(
+      text: e == null ? '' : e.proteinG.toString(),
+    );
     _mealType = e?.mealType ?? MealType.other;
     _isEstimate = e?.entryType == FoodEntryType.estimate;
+    _timestamp = e?.timestamp ?? DateTime.now();
   }
 
   @override
@@ -71,31 +79,36 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
         // stored type is the safe default).
         final current = widget.entry!.entryType;
         final nextType = _canFlipType(current) ? newType : current;
-        await repo.update(widget.entry!.copyWith(
-          name: name,
-          kcal: kcal,
-          proteinG: protein,
-          mealType: _mealType,
-          entryType: nextType,
-        ));
+        await repo.update(
+          widget.entry!.copyWith(
+            timestamp: _timestamp,
+            name: name,
+            kcal: kcal,
+            proteinG: protein,
+            mealType: _mealType,
+            entryType: nextType,
+          ),
+        );
       } else {
-        await repo.add(FoodEntriesCompanion.insert(
-          timestamp: DateTime.now(),
-          name: Value(name),
-          kcal: kcal,
-          proteinG: protein,
-          mealType: _mealType,
-          entryType: newType,
-        ));
+        await repo.add(
+          FoodEntriesCompanion.insert(
+            timestamp: _timestamp,
+            name: Value(name),
+            kcal: kcal,
+            proteinG: protein,
+            mealType: _mealType,
+            entryType: newType,
+          ),
+        );
       }
       if (!mounted) return;
       Navigator.of(context).pop();
     } catch (e) {
       if (!mounted) return;
       setState(() => _saving = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not save entry: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Could not save entry: $e')));
     }
   }
 
@@ -150,9 +163,9 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _saving = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not delete entry: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Could not delete entry: $e')));
     }
   }
 
@@ -194,6 +207,14 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
                 },
               ),
               const SizedBox(height: 12),
+              TimestampField(
+                initialValue: _timestamp,
+                validator: futureGuardValidator,
+                enabled: !_saving,
+                picker: widget.timestampPicker,
+                onChanged: (t) => setState(() => _timestamp = t),
+              ),
+              const SizedBox(height: 12),
               TextFormField(
                 controller: _kcalController,
                 decoration: const InputDecoration(labelText: 'Calories (kcal)'),
@@ -210,8 +231,9 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
               TextFormField(
                 controller: _proteinController,
                 decoration: const InputDecoration(labelText: 'Protein (g)'),
-                keyboardType:
-                    const TextInputType.numberWithOptions(decimal: true),
+                keyboardType: const TextInputType.numberWithOptions(
+                  decimal: true,
+                ),
                 textInputAction: TextInputAction.done,
                 validator: (v) {
                   final n = double.tryParse((v ?? '').trim());

--- a/lib/ui/timestamp_field.dart
+++ b/lib/ui/timestamp_field.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+
+/// Function signature for opening the date+time picker chain. Exposed so widget
+/// tests can bypass the Material dialog UI by injecting a deterministic picker;
+/// production callers use the default [showDatePicker]+[showTimePicker] combo.
+typedef TimestampPicker =
+    Future<DateTime?> Function(BuildContext context, DateTime current);
+
+/// Tappable form field that combines [showDatePicker] + [showTimePicker] into a
+/// single entry. Used by food and body-weight forms so logged-after-the-fact
+/// entries land on the correct day.
+///
+/// Uses [FormField] so [validator] errors surface beneath the field through the
+/// parent [Form] — no bespoke SnackBar wiring needed. Time changes are pushed
+/// out through [onChanged] so the parent remains the source of truth.
+class TimestampField extends StatelessWidget {
+  const TimestampField({
+    super.key,
+    required this.initialValue,
+    required this.onChanged,
+    this.label = 'When',
+    this.validator,
+    this.enabled = true,
+    this.picker,
+  });
+
+  final DateTime initialValue;
+  final ValueChanged<DateTime> onChanged;
+  final String label;
+  final FormFieldValidator<DateTime>? validator;
+  final bool enabled;
+
+  /// Override to inject a test-time picker. Defaults to the Material date+time
+  /// picker pair.
+  final TimestampPicker? picker;
+
+  @override
+  Widget build(BuildContext context) {
+    return FormField<DateTime>(
+      initialValue: initialValue,
+      validator: validator,
+      builder: (state) {
+        final value = state.value ?? initialValue;
+        return InputDecorator(
+          decoration: InputDecoration(
+            labelText: label,
+            errorText: state.errorText,
+            suffixIcon: const Icon(Icons.edit_calendar_outlined),
+          ),
+          child: InkWell(
+            onTap: enabled ? () => _pick(context, state) : null,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Text(_format(value)),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _pick(
+    BuildContext context,
+    FormFieldState<DateTime> state,
+  ) async {
+    final current = state.value ?? initialValue;
+    final open = picker ?? _defaultPicker;
+    final result = await open(context, current);
+    if (result == null) return;
+    state.didChange(result);
+    onChanged(result);
+  }
+}
+
+Future<DateTime?> _defaultPicker(BuildContext context, DateTime current) async {
+  final now = DateTime.now();
+  // Window generous enough for back-logging a missed meal or a future-dated
+  // weigh-in. 2y back / 1y forward keeps the picker bounded without being
+  // restrictive for realistic use.
+  final firstDate = DateTime(now.year - 2);
+  final lastDate = DateTime(now.year + 1, 12, 31);
+
+  final pickedDate = await showDatePicker(
+    context: context,
+    initialDate: current,
+    firstDate: firstDate,
+    lastDate: lastDate,
+  );
+  if (pickedDate == null) return null;
+  if (!context.mounted) return null;
+
+  final pickedTime = await showTimePicker(
+    context: context,
+    initialTime: TimeOfDay.fromDateTime(current),
+  );
+  if (pickedTime == null) return null;
+
+  return DateTime(
+    pickedDate.year,
+    pickedDate.month,
+    pickedDate.day,
+    pickedTime.hour,
+    pickedTime.minute,
+  );
+}
+
+String _format(DateTime t) {
+  final y = t.year.toString().padLeft(4, '0');
+  final mo = t.month.toString().padLeft(2, '0');
+  final d = t.day.toString().padLeft(2, '0');
+  final h = t.hour.toString().padLeft(2, '0');
+  final mi = t.minute.toString().padLeft(2, '0');
+  return '$y-$mo-$d $h:$mi';
+}
+
+/// Rejects timestamps more than 1 hour in the future. Centralised here so both
+/// food and body-weight forms share the same rule.
+String? futureGuardValidator(DateTime? value) {
+  if (value == null) return 'Pick a date & time';
+  final now = DateTime.now();
+  if (value.isAfter(now.add(const Duration(hours: 1)))) {
+    return 'Time cannot be more than 1 hour in the future';
+  }
+  return null;
+}

--- a/test/features/body_weight/body_weight_form_screen_test.dart
+++ b/test/features/body_weight/body_weight_form_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:liftlog_app/data/enums.dart';
 import 'package:liftlog_app/data/repositories/body_weight_log_repository.dart';
 import 'package:liftlog_app/features/body_weight/body_weight_form_screen.dart';
 import 'package:liftlog_app/providers/app_providers.dart';
+import 'package:liftlog_app/ui/timestamp_field.dart';
 
 Widget _host(AppDatabase db, Widget child) {
   return ProviderScope(
@@ -31,11 +32,13 @@ void main() {
     double value = 80.0,
     WeightUnit unit = WeightUnit.kg,
   }) async {
-    await repo.add(BodyWeightLogsCompanion.insert(
-      timestamp: DateTime.now(),
-      value: value,
-      unit: unit,
-    ));
+    await repo.add(
+      BodyWeightLogsCompanion.insert(
+        timestamp: DateTime.now(),
+        value: value,
+        unit: unit,
+      ),
+    );
     return (await repo.listAll()).single;
   }
 
@@ -55,7 +58,9 @@ void main() {
   testWidgets('saves with default unit kg', (tester) async {
     await tester.pumpWidget(_host(db, const BodyWeightFormScreen()));
     await tester.enterText(
-        find.widgetWithText(TextFormField, 'Weight'), '80.5');
+      find.widgetWithText(TextFormField, 'Weight'),
+      '80.5',
+    );
     await tester.tap(find.text('Save'));
     await tester.pumpAndSettle();
 
@@ -73,8 +78,11 @@ void main() {
 
     final after = (await repo.listAll()).single;
     expect(after.value, 176.0);
-    expect(after.unit, WeightUnit.lb,
-        reason: 'unit must not be silently converted on load');
+    expect(
+      after.unit,
+      WeightUnit.lb,
+      reason: 'unit must not be silently converted on load',
+    );
   });
 
   testWidgets('edit updates value and keeps unit', (tester) async {
@@ -84,7 +92,9 @@ void main() {
     await tester.pumpAndSettle();
 
     await tester.enterText(
-        find.widgetWithText(TextFormField, 'Weight'), '79.5');
+      find.widgetWithText(TextFormField, 'Weight'),
+      '79.5',
+    );
     await tester.tap(find.text('Save'));
     await tester.pumpAndSettle();
 
@@ -120,4 +130,79 @@ void main() {
 
     expect(await repo.listAll(), isEmpty);
   });
+
+  testWidgets('add form: picked past timestamp persists with that timestamp', (
+    tester,
+  ) async {
+    final twoDaysAgo = DateTime.now().subtract(const Duration(days: 2));
+    final picked = DateTime(
+      twoDaysAgo.year,
+      twoDaysAgo.month,
+      twoDaysAgo.day,
+      8,
+      15,
+    );
+
+    await tester.pumpWidget(
+      _host(
+        db,
+        BodyWeightFormScreen(timestampPicker: (ctx, current) async => picked),
+      ),
+    );
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Weight'),
+      '79.0',
+    );
+    await tester.tap(
+      find.descendant(
+        of: find.byType(TimestampField),
+        matching: find.byType(InkWell),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final logs = await repo.listAll();
+    expect(logs, hasLength(1));
+    expect(logs.first.timestamp, picked);
+    expect(logs.first.value, 79.0);
+  });
+
+  testWidgets(
+    'add form: timestamp >1h in the future blocks save (no new row)',
+    (tester) async {
+      final future = DateTime.now().add(const Duration(hours: 2));
+
+      await tester.pumpWidget(
+        _host(
+          db,
+          BodyWeightFormScreen(timestampPicker: (ctx, current) async => future),
+        ),
+      );
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Weight'),
+        '79.0',
+      );
+      await tester.tap(
+        find.descendant(
+          of: find.byType(TimestampField),
+          matching: find.byType(InkWell),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(await repo.listAll(), isEmpty);
+      expect(
+        find.text('Time cannot be more than 1 hour in the future'),
+        findsOneWidget,
+      );
+    },
+  );
 }

--- a/test/features/food/food_entry_form_screen_test.dart
+++ b/test/features/food/food_entry_form_screen_test.dart
@@ -9,7 +9,9 @@ import 'package:liftlog_app/data/enums.dart';
 import 'package:liftlog_app/data/repositories/food_entry_repository.dart';
 import 'package:liftlog_app/features/food/food_entry_form_screen.dart';
 import 'package:liftlog_app/features/food/food_log_screen.dart';
+import 'package:liftlog_app/features/history/past_day_food_screen.dart';
 import 'package:liftlog_app/providers/app_providers.dart';
+import 'package:liftlog_app/ui/timestamp_field.dart';
 
 Widget _host(AppDatabase db, Widget child) {
   return ProviderScope(
@@ -35,19 +37,22 @@ void main() {
     double proteinG = 10.0,
     MealType mealType = MealType.breakfast,
   }) async {
-    await repo.add(FoodEntriesCompanion.insert(
-      timestamp: DateTime.now(),
-      name: Value(name),
-      kcal: kcal,
-      proteinG: proteinG,
-      mealType: mealType,
-      entryType: FoodEntryType.manual,
-    ));
+    await repo.add(
+      FoodEntriesCompanion.insert(
+        timestamp: DateTime.now(),
+        name: Value(name),
+        kcal: kcal,
+        proteinG: proteinG,
+        mealType: mealType,
+        entryType: FoodEntryType.manual,
+      ),
+    );
     return (await repo.listAll()).single;
   }
 
-  testWidgets('add form: rejects empty name and non-numeric calories',
-      (tester) async {
+  testWidgets('add form: rejects empty name and non-numeric calories', (
+    tester,
+  ) async {
     await tester.pumpWidget(_host(db, const FoodEntryFormScreen()));
 
     await tester.tap(find.text('Save'));
@@ -58,15 +63,20 @@ void main() {
     expect(find.text('Enter a number'), findsOneWidget);
   });
 
-  testWidgets('add form: valid submission persists entry and pops',
-      (tester) async {
+  testWidgets('add form: valid submission persists entry and pops', (
+    tester,
+  ) async {
     await tester.pumpWidget(_host(db, const FoodEntryFormScreen()));
 
     await tester.enterText(find.widgetWithText(TextFormField, 'Name'), 'Eggs');
     await tester.enterText(
-        find.widgetWithText(TextFormField, 'Calories (kcal)'), '140');
+      find.widgetWithText(TextFormField, 'Calories (kcal)'),
+      '140',
+    );
     await tester.enterText(
-        find.widgetWithText(TextFormField, 'Protein (g)'), '12');
+      find.widgetWithText(TextFormField, 'Protein (g)'),
+      '12',
+    );
     await tester.tap(find.text('Save'));
     await tester.pumpAndSettle();
 
@@ -78,8 +88,9 @@ void main() {
     expect(entries.first.entryType, FoodEntryType.manual);
   });
 
-  testWidgets('edit form shows current values and updates on save',
-      (tester) async {
+  testWidgets('edit form shows current values and updates on save', (
+    tester,
+  ) async {
     final entry = await seed();
 
     await tester.pumpWidget(_host(db, FoodEntryFormScreen(entry: entry)));
@@ -87,9 +98,14 @@ void main() {
 
     expect(find.text('Oats'), findsOneWidget);
 
-    await tester.enterText(find.widgetWithText(TextFormField, 'Name'), 'Oatmeal');
     await tester.enterText(
-        find.widgetWithText(TextFormField, 'Calories (kcal)'), '320');
+      find.widgetWithText(TextFormField, 'Name'),
+      'Oatmeal',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Calories (kcal)'),
+      '320',
+    );
     await tester.tap(find.text('Save'));
     await tester.pumpAndSettle();
 
@@ -98,28 +114,38 @@ void main() {
     expect(after.kcal, 320);
   });
 
-  testWidgets('edit form: delete shows confirm dialog; cancel keeps the entry',
-      (tester) async {
-    final entry = await seed(name: 'Apple', kcal: 95, proteinG: 0.5,
-        mealType: MealType.snack);
+  testWidgets(
+    'edit form: delete shows confirm dialog; cancel keeps the entry',
+    (tester) async {
+      final entry = await seed(
+        name: 'Apple',
+        kcal: 95,
+        proteinG: 0.5,
+        mealType: MealType.snack,
+      );
 
-    await tester.pumpWidget(_host(db, FoodEntryFormScreen(entry: entry)));
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(_host(db, FoodEntryFormScreen(entry: entry)));
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Delete entry'));
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('Delete entry'));
+      await tester.pumpAndSettle();
 
-    expect(find.text('Delete entry?'), findsOneWidget);
+      expect(find.text('Delete entry?'), findsOneWidget);
 
-    await tester.tap(find.text('Cancel'));
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
 
-    expect(await repo.listAll(), hasLength(1));
-  });
+      expect(await repo.listAll(), hasLength(1));
+    },
+  );
 
   testWidgets('edit form: delete → confirm removes the entry', (tester) async {
-    final entry = await seed(name: 'Apple', kcal: 95, proteinG: 0.5,
-        mealType: MealType.snack);
+    final entry = await seed(
+      name: 'Apple',
+      kcal: 95,
+      proteinG: 0.5,
+      mealType: MealType.snack,
+    );
 
     await tester.pumpWidget(_host(db, FoodEntryFormScreen(entry: entry)));
     await tester.pumpAndSettle();
@@ -132,17 +158,22 @@ void main() {
     expect(await repo.listAll(), isEmpty);
   });
 
-  testWidgets(
-      'add as estimate: toggle on → save → entry typed as estimate and '
+  testWidgets('add as estimate: toggle on → save → entry typed as estimate and '
       'badge appears on the log', (tester) async {
     await tester.pumpWidget(_host(db, const FoodEntryFormScreen()));
 
     await tester.enterText(
-        find.widgetWithText(TextFormField, 'Name'), 'Guess Bowl');
+      find.widgetWithText(TextFormField, 'Name'),
+      'Guess Bowl',
+    );
     await tester.enterText(
-        find.widgetWithText(TextFormField, 'Calories (kcal)'), '500');
+      find.widgetWithText(TextFormField, 'Calories (kcal)'),
+      '500',
+    );
     await tester.enterText(
-        find.widgetWithText(TextFormField, 'Protein (g)'), '25');
+      find.widgetWithText(TextFormField, 'Protein (g)'),
+      '25',
+    );
 
     await tester.tap(find.text('This is an estimate'));
     await tester.pump();
@@ -168,30 +199,141 @@ void main() {
     await _drainDriftTimers(tester);
   });
 
-  testWidgets('edit form: flipping estimate toggle off rewrites type to manual',
-      (tester) async {
-    await repo.add(FoodEntriesCompanion.insert(
-      timestamp: DateTime.now(),
-      name: const Value('Eyeballed soup'),
-      kcal: 250,
-      proteinG: 8.0,
-      mealType: MealType.dinner,
-      entryType: FoodEntryType.estimate,
-    ));
-    final entry = (await repo.listAll()).single;
+  testWidgets(
+    'edit form: flipping estimate toggle off rewrites type to manual',
+    (tester) async {
+      await repo.add(
+        FoodEntriesCompanion.insert(
+          timestamp: DateTime.now(),
+          name: const Value('Eyeballed soup'),
+          kcal: 250,
+          proteinG: 8.0,
+          mealType: MealType.dinner,
+          entryType: FoodEntryType.estimate,
+        ),
+      );
+      final entry = (await repo.listAll()).single;
 
-    await tester.pumpWidget(_host(db, FoodEntryFormScreen(entry: entry)));
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(_host(db, FoodEntryFormScreen(entry: entry)));
+      await tester.pumpAndSettle();
 
-    // Toggle off — flips estimate -> manual.
-    await tester.tap(find.text('This is an estimate'));
-    await tester.pump();
-    await tester.tap(find.text('Save'));
-    await tester.pumpAndSettle();
+      // Toggle off — flips estimate -> manual.
+      await tester.tap(find.text('This is an estimate'));
+      await tester.pump();
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
 
-    final after = (await repo.listAll()).single;
-    expect(after.entryType, FoodEntryType.manual);
-  });
+      final after = (await repo.listAll()).single;
+      expect(after.entryType, FoodEntryType.manual);
+    },
+  );
+
+  testWidgets(
+    'add form: picked past timestamp persists and appears on past-day screen',
+    (tester) async {
+      final twoDaysAgo = DateTime.now().subtract(const Duration(days: 2));
+      final picked = DateTime(
+        twoDaysAgo.year,
+        twoDaysAgo.month,
+        twoDaysAgo.day,
+        9,
+        30,
+      );
+
+      await tester.pumpWidget(
+        _host(
+          db,
+          FoodEntryFormScreen(timestampPicker: (ctx, current) async => picked),
+        ),
+      );
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Name'),
+        'Porridge',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Calories (kcal)'),
+        '250',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Protein (g)'),
+        '8',
+      );
+
+      // Tap the timestamp field — opens (stubbed) picker, which returns `picked`.
+      await tester.tap(
+        find.descendant(
+          of: find.byType(TimestampField),
+          matching: find.byType(InkWell),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      final entries = await repo.listAll();
+      expect(entries, hasLength(1));
+      expect(entries.first.timestamp, picked);
+
+      // Unmount the form and mount the past-day screen for the picked day.
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump(const Duration(milliseconds: 1));
+
+      final day = DateTime(picked.year, picked.month, picked.day);
+      await tester.pumpWidget(_host(db, PastDayFoodScreen(day: day)));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Porridge'), findsOneWidget);
+
+      await _drainDriftTimers(tester);
+    },
+  );
+
+  testWidgets(
+    'add form: timestamp >1h in the future blocks save (no new row)',
+    (tester) async {
+      final future = DateTime.now().add(const Duration(hours: 2));
+
+      await tester.pumpWidget(
+        _host(
+          db,
+          FoodEntryFormScreen(timestampPicker: (ctx, current) async => future),
+        ),
+      );
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Name'),
+        'Ghost meal',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Calories (kcal)'),
+        '100',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Protein (g)'),
+        '5',
+      );
+
+      await tester.tap(
+        find.descendant(
+          of: find.byType(TimestampField),
+          matching: find.byType(InkWell),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      // Validator rejected — no row created.
+      expect(await repo.listAll(), isEmpty);
+      expect(
+        find.text('Time cannot be more than 1 hour in the future'),
+        findsOneWidget,
+      );
+    },
+  );
 }
 
 Future<void> _drainDriftTimers(WidgetTester tester) async {


### PR DESCRIPTION
## Summary
- Shared `lib/ui/timestamp_field.dart` renders a tappable date+time field; both the food and body-weight forms now use it
- Validator rejects timestamps >1h in the future (centralised in `futureGuardValidator`)
- Add defaults to `DateTime.now()`, edit shows the existing timestamp, both are user-editable before save

## Scope in
- `lib/ui/timestamp_field.dart` (new — single source of truth for picker chain + future guard)
- `lib/features/food/food_entry_form_screen.dart` — adopt it, persist `_timestamp` on both add and update
- `lib/features/body_weight/body_weight_form_screen.dart` — same
- Widget tests: add-as-past (food → `PastDayFoodScreen` round-trip; weight → `listAll()` check); future-block (both forms)

## Scope out
- Workout session / exercise set timestamps (separate issue)
- Timezones / multi-region

## AC status
1. New food/weight entry with picked past timestamp persists and appears under the correct past day — covered by the food form test mounting `PastDayFoodScreen(day: picked)` after save
2. Edit preserves existing timestamp by default — `initState` pulls `entry.timestamp`; picker only changes it on explicit pick
3. Save path rejects future-by-more-than-1h — `futureGuardValidator` returns an error string; `_formKey.validate()` returns false; save is blocked; inline error visible
4. Widget tests cover both the happy past-day round-trip and the future-block (no row) for food; symmetrical pair for body weight

## Notes
- `TimestampField` is a `StatelessWidget` wrapping a `FormField<DateTime>`. Parent owns the value through `onChanged`; the FormField handles validator wiring. Verdict: one file, both forms import it (per the shared-helper AC).
- To keep the widget tests deterministic without driving Material's date+time dialogs, the picker is injectable via an optional `TimestampPicker` typedef. Production callers leave it null and get the real `showDatePicker`+`showTimePicker` chain.

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — 54/54 (was 50/50; +4 new)
- [ ] Founder-run on-device QA once ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)