### PR TITLE
#21 — Food note + unified delete + error helper

### DIFF
--- a/lib/data/repositories/food_entry_repository.dart
+++ b/lib/data/repositories/food_entry_repository.dart
@@ -28,8 +28,15 @@ class FoodEntryRepository {
   Future<int> add(FoodEntriesCompanion entry) =>
       _db.into(_db.foodEntries).insert(entry);
 
-  Future<void> update(FoodEntry entry) =>
-      (_db.update(_db.foodEntries)..whereSamePrimaryKey(entry)).write(entry);
+  /// Writes every column of [entry], including nullable columns that are
+  /// being cleared (e.g. `note: null`). We use `replace` rather than `write`
+  /// because `write` serializes with `nullToAbsent: true` and would silently
+  /// skip a cleared `note` — see `lib/features/food/food_entry_form_screen.dart`
+  /// for the note-clear flow this enables. `replace` applies its own
+  /// `whereSamePrimaryKey` so the caller must not add one.
+  Future<void> update(FoodEntry entry) async {
+    await _db.update(_db.foodEntries).replace(entry);
+  }
 
   Future<int> delete(int id) =>
       (_db.delete(_db.foodEntries)..where((t) => t.id.equals(id))).go();

--- a/lib/features/body_weight/body_weight_form_screen.dart
+++ b/lib/features/body_weight/body_weight_form_screen.dart
@@ -4,8 +4,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/database.dart';
 import '../../data/enums.dart';
 import '../../providers/app_providers.dart';
+import '../../ui/delete_confirm.dart';
 import '../../ui/formatters.dart';
 import '../../ui/labels.dart';
+import '../../ui/show_save_error.dart';
 import '../../ui/timestamp_field.dart';
 
 class BodyWeightFormScreen extends ConsumerStatefulWidget {
@@ -77,35 +79,20 @@ class _BodyWeightFormScreenState extends ConsumerState<BodyWeightFormScreen> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _saving = false);
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Could not save weight: $e')));
+      showSaveError(context, 'save weight', e);
     }
   }
 
   Future<void> _delete() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Delete weight log?'),
-        content: Text(
+    final confirmed = await showDeleteConfirm(
+      context,
+      title: 'Delete weight log?',
+      message:
           'Delete ${formatWeight(widget.entry!.value, widget.entry!.unit)}? '
           'This cannot be undone.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            style: TextButton.styleFrom(foregroundColor: Colors.red),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
     );
-    if (confirmed != true) return;
+    if (!confirmed) return;
+    if (!mounted) return;
 
     setState(() => _saving = true);
     final repo = ref.read(bodyWeightLogRepositoryProvider);
@@ -116,9 +103,7 @@ class _BodyWeightFormScreenState extends ConsumerState<BodyWeightFormScreen> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _saving = false);
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Could not delete weight: $e')));
+      showSaveError(context, 'delete weight', e);
     }
   }
 

--- a/lib/features/food/food_entry_form_screen.dart
+++ b/lib/features/food/food_entry_form_screen.dart
@@ -5,9 +5,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/database.dart';
 import '../../data/enums.dart';
 import '../../providers/app_providers.dart';
+import '../../ui/delete_confirm.dart';
 import '../../ui/formatters.dart';
 import '../../ui/labels.dart';
+import '../../ui/show_save_error.dart';
 import '../../ui/timestamp_field.dart';
+
+/// Soft cap on the free-form note field. `maxLength` on [TextField] enforces
+/// this at the UI level; the DB column is unconstrained text.
+const int kFoodNoteMaxLength = 200;
 
 class FoodEntryFormScreen extends ConsumerStatefulWidget {
   const FoodEntryFormScreen({super.key, this.entry, this.timestampPicker});
@@ -28,6 +34,7 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
   late final TextEditingController _nameController;
   late final TextEditingController _kcalController;
   late final TextEditingController _proteinController;
+  late final TextEditingController _noteController;
   late MealType _mealType;
   late bool _isEstimate;
   late DateTime _timestamp;
@@ -49,6 +56,7 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
     _proteinController = TextEditingController(
       text: e == null ? '' : e.proteinG.toString(),
     );
+    _noteController = TextEditingController(text: e?.note ?? '');
     _mealType = e?.mealType ?? MealType.other;
     _isEstimate = e?.entryType == FoodEntryType.estimate;
     _timestamp = e?.timestamp ?? DateTime.now();
@@ -59,6 +67,7 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
     _nameController.dispose();
     _kcalController.dispose();
     _proteinController.dispose();
+    _noteController.dispose();
     super.dispose();
   }
 
@@ -71,6 +80,10 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
     final protein = double.parse(_proteinController.text.trim());
 
     final newType = _isEstimate ? FoodEntryType.estimate : FoodEntryType.manual;
+    // Empty trimmed text means "no note" — store null, not "". Distinguishes
+    // note-clear from note-unchanged at the DB level (note column is nullable).
+    final rawNote = _noteController.text.trim();
+    final noteValue = rawNote.isEmpty ? null : rawNote;
 
     try {
       if (_isEdit) {
@@ -87,6 +100,7 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
             proteinG: protein,
             mealType: _mealType,
             entryType: nextType,
+            note: Value(noteValue),
           ),
         );
       } else {
@@ -98,6 +112,7 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
             proteinG: protein,
             mealType: _mealType,
             entryType: newType,
+            note: Value(noteValue),
           ),
         );
       }
@@ -106,9 +121,7 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _saving = false);
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Could not save entry: $e')));
+      showSaveError(context, 'save entry', e);
     }
   }
 
@@ -131,28 +144,15 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
   }
 
   Future<void> _delete() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Delete entry?'),
-        content: Text(
+    final confirmed = await showDeleteConfirm(
+      context,
+      title: 'Delete entry?',
+      message:
           'Delete "${widget.entry!.name}" (${formatKcal(widget.entry!.kcal)} kcal)? '
           'This cannot be undone.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            style: TextButton.styleFrom(foregroundColor: Colors.red),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
     );
-    if (confirmed != true) return;
+    if (!confirmed) return;
+    if (!mounted) return;
 
     setState(() => _saving = true);
     final repo = ref.read(foodEntryRepositoryProvider);
@@ -163,9 +163,7 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _saving = false);
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Could not delete entry: $e')));
+      showSaveError(context, 'delete entry', e);
     }
   }
 
@@ -185,86 +183,123 @@ class _FoodEntryFormScreenState extends ConsumerState<FoodEntryFormScreen> {
         padding: const EdgeInsets.all(16),
         child: Form(
           key: _formKey,
-          child: ListView(
+          // The input fields scroll inside the Expanded; the destructive
+          // "Delete entry" action stays pinned at the bottom, always visible
+          // and always hit-testable (widget tests rely on this — the form
+          // can be taller than the viewport once the note field is present).
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              TextFormField(
-                controller: _nameController,
-                decoration: const InputDecoration(labelText: 'Name'),
-                textInputAction: TextInputAction.next,
-                validator: (v) =>
-                    (v == null || v.trim().isEmpty) ? 'Name is required' : null,
-              ),
-              const SizedBox(height: 12),
-              DropdownButtonFormField<MealType>(
-                initialValue: _mealType,
-                decoration: const InputDecoration(labelText: 'Meal'),
-                items: [
-                  for (final m in MealType.values)
-                    DropdownMenuItem(value: m, child: Text(mealTypeLabel(m))),
-                ],
-                onChanged: (m) {
-                  if (m != null) setState(() => _mealType = m);
-                },
-              ),
-              const SizedBox(height: 12),
-              TimestampField(
-                initialValue: _timestamp,
-                validator: futureGuardValidator,
-                enabled: !_saving,
-                picker: widget.timestampPicker,
-                onChanged: (t) => setState(() => _timestamp = t),
-              ),
-              const SizedBox(height: 12),
-              TextFormField(
-                controller: _kcalController,
-                decoration: const InputDecoration(labelText: 'Calories (kcal)'),
-                keyboardType: TextInputType.number,
-                textInputAction: TextInputAction.next,
-                validator: (v) {
-                  final n = int.tryParse((v ?? '').trim());
-                  if (n == null) return 'Enter a whole number';
-                  if (n < 0) return 'Must be zero or more';
-                  return null;
-                },
-              ),
-              const SizedBox(height: 12),
-              TextFormField(
-                controller: _proteinController,
-                decoration: const InputDecoration(labelText: 'Protein (g)'),
-                keyboardType: const TextInputType.numberWithOptions(
-                  decimal: true,
-                ),
-                textInputAction: TextInputAction.done,
-                validator: (v) {
-                  final n = double.tryParse((v ?? '').trim());
-                  if (n == null) return 'Enter a number';
-                  if (n < 0) return 'Must be zero or more';
-                  return null;
-                },
-              ),
-              if (_showEstimateToggle) ...[
-                const SizedBox(height: 4),
-                SwitchListTile(
-                  contentPadding: EdgeInsets.zero,
-                  title: const Text('This is an estimate'),
-                  subtitle: const Text(
-                    'Tag entries you eyeballed so totals stay honest.',
+              Expanded(
+                child: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      TextFormField(
+                        controller: _nameController,
+                        decoration: const InputDecoration(labelText: 'Name'),
+                        textInputAction: TextInputAction.next,
+                        validator: (v) => (v == null || v.trim().isEmpty)
+                            ? 'Name is required'
+                            : null,
+                      ),
+                      const SizedBox(height: 12),
+                      DropdownButtonFormField<MealType>(
+                        initialValue: _mealType,
+                        decoration: const InputDecoration(labelText: 'Meal'),
+                        items: [
+                          for (final m in MealType.values)
+                            DropdownMenuItem(
+                              value: m,
+                              child: Text(mealTypeLabel(m)),
+                            ),
+                        ],
+                        onChanged: (m) {
+                          if (m != null) setState(() => _mealType = m);
+                        },
+                      ),
+                      const SizedBox(height: 12),
+                      TimestampField(
+                        initialValue: _timestamp,
+                        validator: futureGuardValidator,
+                        enabled: !_saving,
+                        picker: widget.timestampPicker,
+                        onChanged: (t) => setState(() => _timestamp = t),
+                      ),
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: _kcalController,
+                        decoration: const InputDecoration(
+                          labelText: 'Calories (kcal)',
+                        ),
+                        keyboardType: TextInputType.number,
+                        textInputAction: TextInputAction.next,
+                        validator: (v) {
+                          final n = int.tryParse((v ?? '').trim());
+                          if (n == null) return 'Enter a whole number';
+                          if (n < 0) return 'Must be zero or more';
+                          return null;
+                        },
+                      ),
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: _proteinController,
+                        decoration: const InputDecoration(
+                          labelText: 'Protein (g)',
+                        ),
+                        keyboardType: const TextInputType.numberWithOptions(
+                          decimal: true,
+                        ),
+                        textInputAction: TextInputAction.done,
+                        validator: (v) {
+                          final n = double.tryParse((v ?? '').trim());
+                          if (n == null) return 'Enter a number';
+                          if (n < 0) return 'Must be zero or more';
+                          return null;
+                        },
+                      ),
+                      if (_showEstimateToggle) ...[
+                        const SizedBox(height: 4),
+                        SwitchListTile(
+                          contentPadding: EdgeInsets.zero,
+                          title: const Text('This is an estimate'),
+                          subtitle: const Text(
+                            'Tag entries you eyeballed so totals stay honest.',
+                          ),
+                          value: _isEstimate,
+                          onChanged: _saving
+                              ? null
+                              : (v) => setState(() => _isEstimate = v),
+                        ),
+                      ],
+                      const SizedBox(height: 8),
+                      TextField(
+                        controller: _noteController,
+                        decoration: const InputDecoration(
+                          labelText: 'Note (optional)',
+                          // Hide the default character counter — the limit is
+                          // a soft cap, not a hard UX signal worth a visible
+                          // number.
+                          counterText: '',
+                        ),
+                        enabled: !_saving,
+                        maxLength: kFoodNoteMaxLength,
+                        maxLines: 3,
+                        minLines: 1,
+                        textInputAction: TextInputAction.newline,
+                        keyboardType: TextInputType.multiline,
+                      ),
+                    ],
                   ),
-                  value: _isEstimate,
-                  onChanged: _saving
-                      ? null
-                      : (v) => setState(() => _isEstimate = v),
                 ),
-              ],
-              if (_isEdit) ...[
-                const SizedBox(height: 32),
+              ),
+              if (_isEdit)
                 TextButton.icon(
                   onPressed: _saving ? null : _delete,
                   icon: const Icon(Icons.delete_outline),
                   label: const Text('Delete entry'),
                   style: TextButton.styleFrom(foregroundColor: Colors.red),
                 ),
-              ],
             ],
           ),
         ),

--- a/lib/features/food/food_log_screen.dart
+++ b/lib/features/food/food_log_screen.dart
@@ -53,9 +53,7 @@ class FoodLogScreen extends ConsumerWidget {
                               EstimateBadge(entryType: e.entryType),
                             ],
                           ),
-                          subtitle: Text(
-                            '${mealTypeLabel(e.mealType)} · ${formatKcal(e.kcal)} kcal · ${formatGrams(e.proteinG)} g protein',
-                          ),
+                          subtitle: _EntrySubtitle(entry: e),
                           trailing: Text(_formatTime(e.timestamp)),
                           onTap: () => _openForm(context, entry: e),
                         );
@@ -123,6 +121,39 @@ class _Metric extends StatelessWidget {
       Text(value, style: theme.textTheme.headlineMedium),
       Text(label, style: theme.textTheme.titleMedium),
     ]);
+  }
+}
+
+/// Two-line subtitle for a food entry row: the meal/kcal/protein summary,
+/// and (when present) the user-provided note clipped to one line.
+class _EntrySubtitle extends StatelessWidget {
+  const _EntrySubtitle({required this.entry});
+
+  final FoodEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final summary =
+        '${mealTypeLabel(entry.mealType)} · ${formatKcal(entry.kcal)} kcal · ${formatGrams(entry.proteinG)} g protein';
+    final note = entry.note;
+    if (note == null || note.isEmpty) {
+      return Text(summary);
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(summary),
+        Text(
+          note,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.textTheme.bodySmall?.color?.withValues(alpha: 0.7),
+          ),
+        ),
+      ],
+    );
   }
 }
 

--- a/lib/features/history/past_day_food_screen.dart
+++ b/lib/features/history/past_day_food_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../data/database.dart';
 import '../../ui/formatters.dart';
 import '../../ui/labels.dart';
 import '../food/date_label.dart';
@@ -47,9 +48,7 @@ class PastDayFoodScreen extends ConsumerWidget {
                         EstimateBadge(entryType: e.entryType),
                       ],
                     ),
-                    subtitle: Text(
-                      '${mealTypeLabel(e.mealType)} · ${formatKcal(e.kcal)} kcal · ${formatGrams(e.proteinG)} g protein',
-                    ),
+                    subtitle: _EntrySubtitle(entry: e),
                     trailing: Text(_formatTime(e.timestamp)),
                   );
                 },
@@ -65,4 +64,40 @@ String _formatTime(DateTime t) {
   final h = t.hour.toString().padLeft(2, '0');
   final m = t.minute.toString().padLeft(2, '0');
   return '$h:$m';
+}
+
+/// Two-line subtitle for a food entry row: the meal/kcal/protein summary,
+/// and (when present) the user-provided note clipped to one line. Mirrors
+/// the same widget in `food_log_screen.dart` — kept as a per-screen private
+/// class to avoid leaking a UI type across feature folders for a 20-line
+/// widget.
+class _EntrySubtitle extends StatelessWidget {
+  const _EntrySubtitle({required this.entry});
+
+  final FoodEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final summary =
+        '${mealTypeLabel(entry.mealType)} · ${formatKcal(entry.kcal)} kcal · ${formatGrams(entry.proteinG)} g protein';
+    final note = entry.note;
+    if (note == null || note.isEmpty) {
+      return Text(summary);
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(summary),
+        Text(
+          note,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.textTheme.bodySmall?.color?.withValues(alpha: 0.7),
+          ),
+        ),
+      ],
+    );
+  }
 }

--- a/lib/features/workouts/exercise_set_form_screen.dart
+++ b/lib/features/workouts/exercise_set_form_screen.dart
@@ -4,7 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/database.dart';
 import '../../data/enums.dart';
 import '../../providers/app_providers.dart';
+import '../../ui/delete_confirm.dart';
 import '../../ui/labels.dart';
+import '../../ui/show_save_error.dart';
 
 class ExerciseSetFormScreen extends ConsumerStatefulWidget {
   const ExerciseSetFormScreen({
@@ -88,32 +90,18 @@ class _ExerciseSetFormScreenState extends ConsumerState<ExerciseSetFormScreen> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _saving = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not save set: $e')),
-      );
+      showSaveError(context, 'save set', e);
     }
   }
 
   Future<void> _delete() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Delete set?'),
-        content: const Text('This cannot be undone.'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            style: TextButton.styleFrom(foregroundColor: Colors.red),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
+    final confirmed = await showDeleteConfirm(
+      context,
+      title: 'Delete set?',
+      message: 'This cannot be undone.',
     );
-    if (confirmed != true) return;
+    if (!confirmed) return;
+    if (!mounted) return;
 
     setState(() => _saving = true);
     final repo = ref.read(exerciseSetRepositoryProvider);
@@ -124,9 +112,7 @@ class _ExerciseSetFormScreenState extends ConsumerState<ExerciseSetFormScreen> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _saving = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not delete set: $e')),
-      );
+      showSaveError(context, 'delete set', e);
     }
   }
 

--- a/lib/ui/delete_confirm.dart
+++ b/lib/ui/delete_confirm.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+/// Unified delete-confirm dialog.
+///
+/// Returns `true` if the user tapped "Delete", `false` if they tapped
+/// "Cancel", and `false` if they dismissed the dialog (barrier tap / back).
+///
+/// Trust rule: every delete of a logged entry must go through an explicit
+/// confirm step (see `CLAUDE.md` — "Delete flows must be explicit and
+/// confirmed"). This helper is that step — route every form-level delete
+/// through it.
+Future<bool> showDeleteConfirm(
+  BuildContext context, {
+  required String title,
+  required String message,
+}) async {
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: Text(title),
+      content: Text(message),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(false),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(true),
+          style: TextButton.styleFrom(foregroundColor: Colors.red),
+          child: const Text('Delete'),
+        ),
+      ],
+    ),
+  );
+  return result ?? false;
+}

--- a/lib/ui/show_save_error.dart
+++ b/lib/ui/show_save_error.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+/// Standardized save/delete error SnackBar.
+///
+/// Renders `Could not <operation>: <error>` as a SnackBar on the nearest
+/// [ScaffoldMessenger]. Use from every save/delete `catch` block in the
+/// form screens so the wording stays consistent.
+///
+/// Trust rule: persistence failures must surface to the UI — no silent
+/// fallbacks (see `CLAUDE.md`). This helper is the surfacing mechanism.
+void showSaveError(BuildContext context, String operation, Object error) {
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(content: Text('Could not $operation: $error')),
+  );
+}

--- a/test/features/food/food_entry_form_screen_test.dart
+++ b/test/features/food/food_entry_form_screen_test.dart
@@ -291,6 +291,60 @@ void main() {
   );
 
   testWidgets(
+    'note: add form saves note; edit form clears note back to null',
+    (tester) async {
+      // 1) Add with a note.
+      await tester.pumpWidget(_host(db, const FoodEntryFormScreen()));
+
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Name'),
+        'Curry',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Calories (kcal)'),
+        '600',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextFormField, 'Protein (g)'),
+        '30',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Note (optional)'),
+        'Extra rice tonight',
+      );
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      var stored = (await repo.listAll()).single;
+      expect(stored.note, 'Extra rice tonight');
+
+      // 2) Edit the entry and clear the note — unmount first so the new form
+      //    tree mounts cleanly (matches the pattern used above).
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump(const Duration(milliseconds: 1));
+
+      await tester.pumpWidget(_host(db, FoodEntryFormScreen(entry: stored)));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Extra rice tonight'), findsOneWidget);
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Note (optional)'),
+        '',
+      );
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      stored = (await repo.listAll()).single;
+      expect(
+        stored.note,
+        isNull,
+        reason: 'clearing the note must null the column, not store ""',
+      );
+    },
+  );
+
+  testWidgets(
     'add form: timestamp >1h in the future blocks save (no new row)',
     (tester) async {
       final future = DateTime.now().add(const Duration(hours: 2));


### PR DESCRIPTION
Closes #21.

## Summary
Bundles three small polish items on the food / body-weight / exercise-set form screens:

- **Food note field** — multiline `TextField` (soft-capped at 200 chars via `maxLength`, counter hidden) on `FoodEntryFormScreen`, wired to the existing nullable `FoodEntries.note` column. No schema change. Non-empty notes render as a muted second subtitle line (clipped to one line with ellipsis) on both `FoodLogScreen` and `PastDayFoodScreen`. An empty trimmed note saves as `NULL`, not `""`, so note-clear is distinguishable from note-unchanged at the DB level.
- **Unified delete-confirm helper** — new `lib/ui/delete_confirm.dart` exposing `Future<bool> showDeleteConfirm(context, {title, message})`. The three form screens now call it; three inline `showDialog` blocks removed.
- **Standardized save-error SnackBar** — new `lib/ui/show_save_error.dart` exposing `showSaveError(context, operation, error)`. Every save/delete `catch` in the three form screens now routes through it. Operation strings are the six listed in the brief.

## Behavior & trust notes
- `FoodEntryRepository.update` switched from `.write(entry)` to `.replace(entry)`. Drift's `write` serializes with `nullToAbsent: true` and silently drops a cleared nullable column — which would have violated the "no silent mutation" trust rule for note-clear. `replace` writes all columns including nullable nulls.
- Food form body restructured to `Column(Expanded(SingleChildScrollView(...fields)) + pinned Delete button)` so the destructive action stays findable and tappable in widget tests when the form is taller than the 800×600 default test viewport.
- No new pub deps. No schema changes. No Android/watchOS files. Canonical enum coverage unchanged.

## AC coverage
1. Food note persists, displays, edits, clears — covered by the new widget test `note: add form saves note; edit form clears note back to null` in `test/features/food/food_entry_form_screen_test.dart` (asserts `stored.note == null` after edit-to-clear).
2. Exactly one `showDeleteConfirm` helper; three forms call it; the four existing delete-confirm tests across the three form test files still pass.
3. Every form save/delete `catch` routes through `showSaveError`. `grep -rn "showSnackBar" lib/features/**/*_form_screen.dart` returns 0 hits (see closeout report).
4. No new pub deps.
5. No schema changes.

## Verification
- `flutter analyze` — clean (`No issues found!`).
- `flutter test` — 55 passed.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — all 55 tests green
- [x] `grep -rn "showSnackBar" lib/features/**/*_form_screen.dart` → 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)