### PR TITLE
#22 — Arch guardrail: list*() mirrors + replace() normalization + arch test

### DIFF
--- a/lib/data/repositories/body_weight_log_repository.dart
+++ b/lib/data/repositories/body_weight_log_repository.dart
@@ -10,8 +10,14 @@ class BodyWeightLogRepository {
   Future<int> add(BodyWeightLogsCompanion log) =>
       _db.into(_db.bodyWeightLogs).insert(log);
 
-  Future<void> update(BodyWeightLog log) =>
-      (_db.update(_db.bodyWeightLogs)..whereSamePrimaryKey(log)).write(log);
+  /// Writes every column of [log] including any nullable columns that are
+  /// being cleared. We use `replace` rather than `update(...).write(...)`
+  /// because `write` serializes with `nullToAbsent: true` and would silently
+  /// preserve cleared nullables — a trust-rule violation. `replace` applies
+  /// its own `whereSamePrimaryKey` so the caller must not add one.
+  Future<void> update(BodyWeightLog log) async {
+    await _db.update(_db.bodyWeightLogs).replace(log);
+  }
 
   Future<int> delete(int id) =>
       (_db.delete(_db.bodyWeightLogs)..where((t) => t.id.equals(id))).go();
@@ -23,6 +29,17 @@ class BodyWeightLogRepository {
 
   Future<List<BodyWeightLog>> listAll() =>
       (_db.select(_db.bodyWeightLogs)
+            ..orderBy([(t) => OrderingTerm.desc(t.timestamp)]))
+          .get();
+
+  /// Returns logs whose `timestamp` falls in `[from, to)` (from inclusive,
+  /// to exclusive), ordered by timestamp descending. Used by range-based
+  /// widget queries that would otherwise hang under Drift + fake_async.
+  Future<List<BodyWeightLog>> listRange(DateTime from, DateTime to) =>
+      (_db.select(_db.bodyWeightLogs)
+            ..where((t) =>
+                t.timestamp.isBiggerOrEqualValue(from) &
+                t.timestamp.isSmallerThanValue(to))
             ..orderBy([(t) => OrderingTerm.desc(t.timestamp)]))
           .get();
 }

--- a/lib/data/repositories/exercise_set_repository.dart
+++ b/lib/data/repositories/exercise_set_repository.dart
@@ -10,8 +10,16 @@ class ExerciseSetRepository {
   Future<int> add(ExerciseSetsCompanion set) =>
       _db.into(_db.exerciseSets).insert(set);
 
-  Future<void> update(ExerciseSet set) =>
-      (_db.update(_db.exerciseSets)..whereSamePrimaryKey(set)).write(set);
+  /// Writes every column of [set] including any nullable columns that are
+  /// being cleared. We use `replace` rather than `update(...).write(...)`
+  /// because `write` serializes with `nullToAbsent: true` and would silently
+  /// preserve cleared nullables — a trust-rule violation. Defensive: the
+  /// current `ExerciseSets` table has no nullables, but this keeps the
+  /// pattern consistent and future-proof. `replace` applies its own
+  /// `whereSamePrimaryKey` so the caller must not add one.
+  Future<void> update(ExerciseSet set) async {
+    await _db.update(_db.exerciseSets).replace(set);
+  }
 
   Future<int> delete(int id) =>
       (_db.delete(_db.exerciseSets)..where((t) => t.id.equals(id))).go();

--- a/lib/data/repositories/food_entry_repository.dart
+++ b/lib/data/repositories/food_entry_repository.dart
@@ -59,6 +59,24 @@ class FoodEntryRepository {
         .watch();
   }
 
+  Future<List<FoodEntry>> listByDate(DateTime day) {
+    final range = DayRange(day);
+    return (_db.select(_db.foodEntries)
+          ..where((t) => t.timestamp.isBetweenValues(range.start, range.end))
+          ..orderBy([(t) => OrderingTerm.desc(t.timestamp)]))
+        .get();
+  }
+
+  /// Returns entries whose `timestamp` falls in `[from, to)` (from inclusive,
+  /// to exclusive), ordered by timestamp descending.
+  Future<List<FoodEntry>> listRange(DateTime from, DateTime to) =>
+      (_db.select(_db.foodEntries)
+            ..where((t) =>
+                t.timestamp.isBiggerOrEqualValue(from) &
+                t.timestamp.isSmallerThanValue(to))
+            ..orderBy([(t) => OrderingTerm.desc(t.timestamp)]))
+          .get();
+
   Stream<DailyTotals> watchDailyTotals(DateTime day) {
     return watchByDate(day).map((entries) {
       var kcal = 0;
@@ -71,27 +89,47 @@ class FoodEntryRepository {
     });
   }
 
+  Future<DailyTotals> listDailyTotals(DateTime day) async {
+    final entries = await listByDate(day);
+    var kcal = 0;
+    var protein = 0.0;
+    for (final e in entries) {
+      kcal += e.kcal;
+      protein += e.proteinG;
+    }
+    return DailyTotals(kcal: kcal, proteinG: protein);
+  }
+
   Stream<List<DailySummary>> watchDailySummaries() {
     return (_db.select(_db.foodEntries)
           ..orderBy([(t) => OrderingTerm.desc(t.timestamp)]))
         .watch()
-        .map((entries) {
-      final buckets = <DateTime, List<FoodEntry>>{};
-      for (final e in entries) {
-        final day = DateTime(e.timestamp.year, e.timestamp.month, e.timestamp.day);
-        buckets.putIfAbsent(day, () => []).add(e);
+        .map(_summarize);
+  }
+
+  Future<List<DailySummary>> listDailySummaries() async {
+    final entries = await (_db.select(_db.foodEntries)
+          ..orderBy([(t) => OrderingTerm.desc(t.timestamp)]))
+        .get();
+    return _summarize(entries);
+  }
+
+  List<DailySummary> _summarize(List<FoodEntry> entries) {
+    final buckets = <DateTime, List<FoodEntry>>{};
+    for (final e in entries) {
+      final day = DateTime(e.timestamp.year, e.timestamp.month, e.timestamp.day);
+      buckets.putIfAbsent(day, () => []).add(e);
+    }
+    final summaries = buckets.entries.map((b) {
+      var kcal = 0;
+      var protein = 0.0;
+      for (final e in b.value) {
+        kcal += e.kcal;
+        protein += e.proteinG;
       }
-      final summaries = buckets.entries.map((b) {
-        var kcal = 0;
-        var protein = 0.0;
-        for (final e in b.value) {
-          kcal += e.kcal;
-          protein += e.proteinG;
-        }
-        return DailySummary(day: b.key, kcal: kcal, proteinG: protein);
-      }).toList()
-        ..sort((a, b) => b.day.compareTo(a.day));
-      return summaries;
-    });
+      return DailySummary(day: b.key, kcal: kcal, proteinG: protein);
+    }).toList()
+      ..sort((a, b) => b.day.compareTo(a.day));
+    return summaries;
   }
 }

--- a/lib/data/repositories/workout_session_repository.dart
+++ b/lib/data/repositories/workout_session_repository.dart
@@ -10,9 +10,15 @@ class WorkoutSessionRepository {
   Future<int> add(WorkoutSessionsCompanion session) =>
       _db.into(_db.workoutSessions).insert(session);
 
-  Future<void> update(WorkoutSession session) =>
-      (_db.update(_db.workoutSessions)..whereSamePrimaryKey(session))
-          .write(session);
+  /// Writes every column of [session] including nullable columns that are
+  /// being cleared (e.g. `endedAt: null`, `note: null`). We use `replace`
+  /// rather than `update(...).write(...)` because `write` serializes with
+  /// `nullToAbsent: true` and would silently preserve cleared nullables —
+  /// a trust-rule violation. `replace` applies its own `whereSamePrimaryKey`
+  /// so the caller must not add one.
+  Future<void> update(WorkoutSession session) async {
+    await _db.update(_db.workoutSessions).replace(session);
+  }
 
   Future<int> delete(int id) =>
       (_db.delete(_db.workoutSessions)..where((t) => t.id.equals(id))).go();

--- a/test/arch/data_access_boundary_test.dart
+++ b/test/arch/data_access_boundary_test.dart
@@ -1,0 +1,159 @@
+// Arch guardrail: protects the data-access boundary.
+//
+// Rule 1 — Feature code does not reach into Drift directly.
+//   Under `lib/features/**`, the only permitted `package:drift` import is
+//   the narrow companion-value form:
+//       import 'package:drift/drift.dart' show Value;
+//   Any broader drift import fails the test. Feature code must also never
+//   call `.select(` or construct `AppDatabase()` — both are repository-only.
+//
+// Rule 2 — Repository `update()` methods use `replace()`, not `write()`.
+//   Drift's `write()` serializes with `nullToAbsent: true`, silently
+//   preserving cleared nullables. That's a trust-rule violation
+//   ("no silent mutation"). Scan `lib/data/repositories/**` for any
+//   `.write(` occurrence and fail if found. A line containing the literal
+//   comment `// drift-write-ok:` opts out — used only when we need `write`
+//   for a legitimate reason (justified in a PR).
+//
+// Implementation is deliberately plain: File.readAsStringSync + regex +
+// manual Directory walks. No build_runner reflection, no glob packages.
+// Keep regexes narrow; brittleness is the known risk.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // Resolve the project root from the test file's location so the test
+  // works whether run from the repo root, IDE, or CI working directory.
+  final projectRoot = _findProjectRoot();
+  final featuresDir = Directory(p.join(projectRoot, 'lib', 'features'));
+  final reposDir = Directory(p.join(projectRoot, 'lib', 'data', 'repositories'));
+
+  group('data access boundary', () {
+    test('feature code does not reach into Drift directly', () {
+      expect(featuresDir.existsSync(), isTrue,
+          reason: 'expected lib/features at ${featuresDir.path}');
+
+      // Matches any `import 'package:drift/...';` — we'll then inspect the
+      // matched line to decide if it's the allowed `show Value;` form.
+      final driftImport = RegExp(r'''import\s+['"]package:drift/[^'"]+['"][^;]*;''');
+      // Narrow allow-list: exactly the companion-Value import, with optional
+      // whitespace. We intentionally allow no other `show` lists to keep the
+      // boundary tight.
+      final allowedDriftImport = RegExp(
+        r'''^\s*import\s+['"]package:drift/drift\.dart['"]\s+show\s+Value\s*;\s*$''',
+      );
+      // `.select(` — the Drift query entry point. Feature code must go
+      // through repositories, not the DB directly.
+      final selectCall = RegExp(r'\.select\(');
+      // `AppDatabase()` — constructing the DB directly bypasses providers.
+      final appDbCtor = RegExp(r'AppDatabase\(\)');
+
+      final violations = <String>[];
+      for (final file in _dartFilesIn(featuresDir)) {
+        final relPath = p.relative(file.path, from: projectRoot);
+        final lines = file.readAsStringSync().split('\n');
+        for (var i = 0; i < lines.length; i++) {
+          final rawLine = lines[i];
+          // Skip opt-out lines anywhere we might grow exemptions; for now
+          // drift-write-ok is a repo-layer concept but honoring it here is
+          // cheap and keeps escape-hatch semantics consistent.
+          if (rawLine.contains('// drift-write-ok:')) continue;
+          // Strip single-line comments before scanning so doc mentions of
+          // `.select(`, `AppDatabase()`, or a drift import in prose don't
+          // trigger false positives. Import directives are never inside
+          // comments, so this is safe for the drift-import rule too.
+          final commentIdx = rawLine.indexOf('//');
+          final codePart = commentIdx >= 0 ? rawLine.substring(0, commentIdx) : rawLine;
+
+          if (driftImport.hasMatch(codePart) && !allowedDriftImport.hasMatch(codePart)) {
+            violations.add('$relPath:${i + 1}: disallowed drift import: ${rawLine.trim()}');
+          }
+          if (selectCall.hasMatch(codePart)) {
+            violations.add('$relPath:${i + 1}: feature code must not call .select(: ${rawLine.trim()}');
+          }
+          if (appDbCtor.hasMatch(codePart)) {
+            violations.add('$relPath:${i + 1}: feature code must not construct AppDatabase(): ${rawLine.trim()}');
+          }
+        }
+      }
+
+      expect(
+        violations,
+        isEmpty,
+        reason: 'Feature code must go through repositories. Violations:\n'
+            '${violations.join('\n')}',
+      );
+    });
+
+    test('repository update() methods use replace(), not write()', () {
+      expect(reposDir.existsSync(), isTrue,
+          reason: 'expected lib/data/repositories at ${reposDir.path}');
+
+      // `.write(` — the offending serializer. Allow opt-out only via an
+      // explicit `// drift-write-ok:` marker on the same line. We also
+      // strip single-line comments (`//` and `///`) before scanning so
+      // docstring mentions of `write(` don't trigger false positives.
+      final writeCall = RegExp(r'\.write\(');
+
+      final violations = <String>[];
+      for (final file in _dartFilesIn(reposDir)) {
+        final relPath = p.relative(file.path, from: projectRoot);
+        final lines = file.readAsStringSync().split('\n');
+        for (var i = 0; i < lines.length; i++) {
+          final rawLine = lines[i];
+          // Minimal opt-out: raw substring check, as specified.
+          if (rawLine.contains('// drift-write-ok:')) continue;
+          // Strip anything from the first `//` onward — ignores both `//`
+          // and `///` comments. Not perfect (misses URLs in strings and
+          // `//` inside string literals), but good enough for repo files
+          // which don't contain those patterns.
+          final commentIdx = rawLine.indexOf('//');
+          final codePart = commentIdx >= 0 ? rawLine.substring(0, commentIdx) : rawLine;
+          if (!writeCall.hasMatch(codePart)) continue;
+          violations.add('$relPath:${i + 1}: repository must use replace(), not write(): ${rawLine.trim()}');
+        }
+      }
+
+      expect(
+        violations,
+        isEmpty,
+        reason: 'Drift write() silently preserves cleared nullables. '
+            'Use replace() instead. Violations:\n'
+            '${violations.join('\n')}',
+      );
+    });
+  });
+}
+
+/// Walks up from this test file until it finds a directory containing
+/// `pubspec.yaml`. That's the project root. Falls back to cwd if not found
+/// (e.g. when tests run from a restructured layout).
+String _findProjectRoot() {
+  // Script.toFilePath() is the running test's compiled source path; climb
+  // from there to locate pubspec.yaml.
+  var dir = Directory.fromUri(Platform.script).parent;
+  for (var i = 0; i < 10; i++) {
+    if (File(p.join(dir.path, 'pubspec.yaml')).existsSync()) {
+      return dir.path;
+    }
+    if (dir.parent.path == dir.path) break;
+    dir = dir.parent;
+  }
+  // Fallback: Directory.current, which is the repo root when running
+  // `flutter test` from the repo.
+  return Directory.current.path;
+}
+
+/// Yields every `.dart` file under [root], recursively. Plain File/Directory
+/// walk — no glob dependency.
+Iterable<File> _dartFilesIn(Directory root) sync* {
+  if (!root.existsSync()) return;
+  for (final entity in root.listSync(recursive: true, followLinks: false)) {
+    if (entity is File && entity.path.endsWith('.dart')) {
+      yield entity;
+    }
+  }
+}


### PR DESCRIPTION
Closes #22.

## Summary

Apple Watch groundwork — three changes, one PR:

1. **`list*()` mirror audit.** Every `watch*()` on a repo now has a one-shot sibling. Added `listRange(from, to)` to `BodyWeightLogRepository` and `FoodEntryRepository` (`[from, to)`, desc by timestamp); added `listByDate`, `listDailyTotals`, `listDailySummaries` to `FoodEntryRepository`. `WorkoutSessionRepository.watchById` already has `findById` as its one-shot single-row sibling — kept as-is since it's used by existing tests and screens.
2. **`update()` → `replace()` normalization.** Three repos were using `update(table)..whereSamePrimaryKey(x).write(x)`. `write()` serializes with `nullToAbsent: true`, silently preserving cleared nullables — a "no silent mutation" trust-rule violation. Converted `BodyWeightLogRepository.update`, `WorkoutSessionRepository.update` (nullable `endedAt` + `note`), and `ExerciseSetRepository.update` (defensive; no nullables today) to `replace(entity)`. Removed the `..whereSamePrimaryKey` chain — `replace()` applies one internally; chaining trips an assertion. `FoodEntryRepository.update` was already `replace()` after #21 — untouched.
3. **Arch test: `test/arch/data_access_boundary_test.dart`.** Two rules:
   - Feature code under `lib/features/**` may not `import 'package:drift/...'` except the narrow `show Value;` form, and may not call `.select(` or construct `AppDatabase()`.
   - Repository files may not contain `.write(` (outside `//` comments). Escape hatch: a line containing the literal `// drift-write-ok:` marker is skipped.
   Plain `File.readAsStringSync` + regex + `Directory` walks. No new deps (`path` was already present).

## AC coverage

- [x] Every `watch*()` on a repo has a matching `list*()` sibling; `listRange` exists on food + weight repos. (`watchById` → `findById` retained as the canonical single-row sibling.)
- [x] All three `update()` methods use `replace()`; no `write()` usage remains in `lib/data/repositories/**`.
- [x] Arch test passes today. Verified negative case twice (see below); reverted both.
- [x] `vault/05 Architecture/Skills.md` updated with the arch-test bullet.
- [x] `flutter analyze` clean; `flutter test` green (57 passed, includes 2 new arch tests).

## Negative-case verification (false-positive confirmation)

1. Added a bare `import 'package:drift/drift.dart';` at the top of `lib/features/food/food_providers.dart`. Arch test failed with: `lib/features/food/food_providers.dart:1: disallowed drift import: import 'package:drift/drift.dart';`. Reverted.
2. Temporarily reintroduced `(_db.update(_db.bodyWeightLogs)..whereSamePrimaryKey(log)).write(log)` in `BodyWeightLogRepository.update`. Arch test failed with: `lib/data/repositories/body_weight_log_repository.dart:19: repository must use replace(), not write(): await ...write(log);`. Reverted.

## Scope hygiene

- No new pub deps.
- No schema changes.
- No `lib/features/**` behavior changes (only data-layer plumbing).
- No WatchConnectivity / HealthKit / watchOS targets.
- `vault/05 Architecture/Skills.md` edit: documented per the issue's explicit AC exception. Vault is gitignored so it's not in the commit.

## Test plan

- [x] `flutter analyze` — clean.
- [x] `flutter test` — 57 passed including the new 2 arch tests.
- [ ] Founder does on-device tap-through smoke (no user-visible changes expected; this PR is data-layer only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)