### PR TITLE
#23 — Progress tab v1

### DIFF
--- a/lib/features/progress/kcal_bars.dart
+++ b/lib/features/progress/kcal_bars.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+import 'progress_data.dart';
+
+/// Daily kcal bar chart. One bar per day in the current window, including
+/// 0-value bars for days with no logged entries (visible gap, not a
+/// misleading inferred value). Ruthlessly simple — no axes or tooltips.
+class KcalBars extends StatelessWidget {
+  const KcalBars({super.key, required this.days});
+
+  final List<DailyKcal> days;
+
+  static const double height = 140;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.primary;
+    return SizedBox(
+      height: height,
+      width: double.infinity,
+      child: CustomPaint(
+        painter: KcalBarsPainter(days: days, color: color),
+      ),
+    );
+  }
+}
+
+class KcalBarsPainter extends CustomPainter {
+  KcalBarsPainter({required this.days, required this.color});
+
+  final List<DailyKcal> days;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (days.isEmpty) return;
+
+    // Pick the y-scale from the max of the window. If every day is 0 we
+    // simply render no bars (empty-state copy handles the user-facing case).
+    var maxKcal = 0;
+    for (final d in days) {
+      if (d.kcal > maxKcal) maxKcal = d.kcal;
+    }
+    if (maxKcal == 0) return;
+
+    const paddingX = 4.0;
+    const paddingY = 4.0;
+    final plotW = size.width - paddingX * 2;
+    final plotH = size.height - paddingY * 2;
+
+    // Bar width: divide available width into N equal slots, then draw each
+    // bar filling ~80% of its slot. 2px minimum so 30d windows stay visible
+    // on a 393pt-wide iPhone viewport.
+    final slot = plotW / days.length;
+    final barW = (slot * 0.8).clamp(2.0, slot);
+    final barOffset = (slot - barW) / 2;
+
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill;
+
+    for (var i = 0; i < days.length; i++) {
+      final d = days[i];
+      if (d.kcal <= 0) continue;
+      final h = (d.kcal / maxKcal) * plotH;
+      final x = paddingX + i * slot + barOffset;
+      final y = paddingY + (plotH - h);
+      canvas.drawRect(Rect.fromLTWH(x, y, barW, h), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant KcalBarsPainter old) =>
+      old.days != days || old.color != color;
+}

--- a/lib/features/progress/progress_data.dart
+++ b/lib/features/progress/progress_data.dart
@@ -1,0 +1,171 @@
+import '../../data/database.dart';
+import '../../data/enums.dart';
+
+/// Time-window selector for the Progress tab. Enumerated exhaustively; never
+/// fall through to a default case.
+enum ProgressWindow { sevenDays, thirtyDays, all }
+
+/// A single point on the weight sparkline. Kept portable (no UI types) so the
+/// aggregator can stay a pure-Dart function that's trivial to unit test.
+class WeightPoint {
+  const WeightPoint({required this.timestamp, required this.value});
+  final DateTime timestamp;
+  final double value;
+}
+
+/// Output of the weight aggregator. `dominantUnit` is the unit the sparkline
+/// should draw in, picked to match the most recent log in the window. When the
+/// window contains logs in more than one unit, [mixedUnits] is true — the UI
+/// layer uses that to render the "mixed units" banner. We deliberately never
+/// convert between kg and lb (trust rule: no silent unit conversion).
+class WeightSeries {
+  const WeightSeries({
+    required this.points,
+    required this.dominantUnit,
+    required this.mixedUnits,
+  });
+
+  final List<WeightPoint> points;
+  final WeightUnit? dominantUnit;
+  final bool mixedUnits;
+
+  bool get isEmpty => points.isEmpty;
+  bool get hasEnoughForSparkline => points.length >= 2;
+}
+
+/// One daily kcal bucket. `day` is the local-calendar midnight of that day.
+class DailyKcal {
+  const DailyKcal({required this.day, required this.kcal});
+  final DateTime day;
+  final int kcal;
+}
+
+/// Output of the kcal aggregator. `days` has one entry per day in the window
+/// (inclusive from → exclusive to), in chronological order. A day with no
+/// food entries contributes a 0, so the bar chart can show a visible gap.
+class KcalSeries {
+  const KcalSeries({required this.days});
+  final List<DailyKcal> days;
+
+  bool get isEmpty => days.every((d) => d.kcal == 0);
+  int get loggedDayCount => days.where((d) => d.kcal > 0).length;
+  int get maxKcal =>
+      days.isEmpty ? 0 : days.map((d) => d.kcal).reduce((a, b) => a > b ? a : b);
+}
+
+/// Resolves a [ProgressWindow] to a `[from, to)` instant range. `to` is
+/// exclusive and anchored to midnight-after-`now` so "today" always shows up
+/// as the final day bucket.
+///
+/// For `all`, `from` is `DateTime.fromMillisecondsSinceEpoch(0)` — the
+/// repository range queries treat everything newer as in-window. Good enough
+/// for a single-user local tracker.
+({DateTime from, DateTime to}) resolveWindow(
+  ProgressWindow window, {
+  required DateTime now,
+}) {
+  // Use calendar-day arithmetic (via DateTime constructor) rather than
+  // `Duration` so DST transitions can't slip the window into the wrong day.
+  final todayStart = DateTime(now.year, now.month, now.day);
+  final to = DateTime(now.year, now.month, now.day + 1);
+  switch (window) {
+    case ProgressWindow.sevenDays:
+      // 7 days total including today: today + 6 prior days.
+      return (from: DateTime(now.year, now.month, now.day - 6), to: to);
+    case ProgressWindow.thirtyDays:
+      return (from: DateTime(now.year, now.month, now.day - 29), to: to);
+    case ProgressWindow.all:
+      return (from: DateTime.fromMillisecondsSinceEpoch(0), to: to);
+  }
+}
+
+/// Returns the local-midnight day that [t] falls within. Pure function so day
+/// bucketing stays testable without touching [DateTime.now].
+DateTime _dayOf(DateTime t) => DateTime(t.year, t.month, t.day);
+
+/// Builds a [WeightSeries] from raw logs. Responsibilities:
+///
+/// 1. Pick a dominant unit. If logs are in more than one unit, the most recent
+///    log wins — this is what the "Mixed units — showing kg only" banner
+///    reflects. Never silently convert (trust rule).
+/// 2. Filter to only that unit's points.
+/// 3. Sort chronologically so the painter can walk left-to-right.
+///
+/// Keeping this in the aggregator (not the widget) means:
+/// - The "mixed unit" behavior is unit-testable without pumping widgets.
+/// - The sparkline painter receives a single-unit list and doesn't need to
+///   know about [WeightUnit] at all.
+WeightSeries buildWeightSeries(List<BodyWeightLog> logs) {
+  if (logs.isEmpty) {
+    return const WeightSeries(points: [], dominantUnit: null, mixedUnits: false);
+  }
+
+  // Find the most-recent-log unit — that's the one we show.
+  final sortedDesc = [...logs]..sort((a, b) => b.timestamp.compareTo(a.timestamp));
+  final dominant = sortedDesc.first.unit;
+
+  final hasKg = logs.any((l) => l.unit == WeightUnit.kg);
+  final hasLb = logs.any((l) => l.unit == WeightUnit.lb);
+  final mixed = hasKg && hasLb;
+
+  final filtered = logs.where((l) => l.unit == dominant).toList()
+    ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+  final points = filtered
+      .map((l) => WeightPoint(timestamp: l.timestamp, value: l.value))
+      .toList();
+
+  return WeightSeries(
+    points: points,
+    dominantUnit: dominant,
+    mixedUnits: mixed,
+  );
+}
+
+/// Builds a [KcalSeries] from raw food entries. Entries are bucketed by
+/// local-calendar day; each day in `[from, to)` gets one bucket, including
+/// days with no entries (kcal = 0) so the bar chart renders a consistent
+/// day-count.
+///
+/// Assumes `from` is already at local midnight. Walks forward by 24-hour
+/// increments rather than arithmetic day math so DST transitions don't shift
+/// buckets; for a single-user iPhone tracker that's fine.
+KcalSeries buildKcalSeries(
+  List<FoodEntry> entries, {
+  required DateTime from,
+  required DateTime to,
+}) {
+  // Short-circuit: `all`-window resolves `from` to epoch-0. We instead derive
+  // the first bucket from the oldest entry's day — empty-day padding back to
+  // 1970 would produce tens of thousands of zero bars.
+  final DateTime effectiveFrom;
+  if (from.millisecondsSinceEpoch <= 0) {
+    if (entries.isEmpty) {
+      effectiveFrom = DateTime(to.year, to.month, to.day).subtract(const Duration(days: 1));
+    } else {
+      final oldest =
+          entries.map((e) => e.timestamp).reduce((a, b) => a.isBefore(b) ? a : b);
+      effectiveFrom = _dayOf(oldest);
+    }
+  } else {
+    effectiveFrom = _dayOf(from);
+  }
+
+  // Bucket entries by day.
+  final buckets = <DateTime, int>{};
+  for (final e in entries) {
+    final day = _dayOf(e.timestamp);
+    buckets[day] = (buckets[day] ?? 0) + e.kcal;
+  }
+
+  // Emit one row per day in the range. Include 0-rows for visible gaps.
+  // Advance by calendar day (not `Duration(days: 1)`) so DST transitions
+  // don't skip or duplicate a day in the series.
+  final days = <DailyKcal>[];
+  var cursor = effectiveFrom;
+  final end = DateTime(to.year, to.month, to.day);
+  while (cursor.isBefore(end)) {
+    days.add(DailyKcal(day: cursor, kcal: buckets[cursor] ?? 0));
+    cursor = DateTime(cursor.year, cursor.month, cursor.day + 1);
+  }
+  return KcalSeries(days: days);
+}

--- a/lib/features/progress/progress_providers.dart
+++ b/lib/features/progress/progress_providers.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/app_providers.dart';
+import 'progress_data.dart';
+
+/// Currently selected time window for the Progress tab. Widget state lives in
+/// a [StateProvider] so changing it from `SegmentedButton` is a single
+/// `ref.read(...).state = ...` assignment.
+final progressWindowProvider =
+    StateProvider<ProgressWindow>((ref) => ProgressWindow.sevenDays);
+
+/// A wall-clock provider — overridable in tests to make window resolution
+/// deterministic. Prod callers get the real time.
+final progressNowProvider = Provider<DateTime>((ref) => DateTime.now());
+
+/// Weight series for the currently-selected window. Uses the one-shot
+/// `listRange` repository method (not `watch*`) so widget tests don't hang
+/// under Drift + fake_async.
+final weightSeriesProvider = FutureProvider<WeightSeries>((ref) async {
+  final window = ref.watch(progressWindowProvider);
+  final now = ref.watch(progressNowProvider);
+  final range = resolveWindow(window, now: now);
+  final repo = ref.watch(bodyWeightLogRepositoryProvider);
+  final logs = await repo.listRange(range.from, range.to);
+  return buildWeightSeries(logs);
+});
+
+/// Daily kcal series for the currently-selected window.
+final kcalSeriesProvider = FutureProvider<KcalSeries>((ref) async {
+  final window = ref.watch(progressWindowProvider);
+  final now = ref.watch(progressNowProvider);
+  final range = resolveWindow(window, now: now);
+  final repo = ref.watch(foodEntryRepositoryProvider);
+  final entries = await repo.listRange(range.from, range.to);
+  return buildKcalSeries(entries, from: range.from, to: range.to);
+});

--- a/lib/features/progress/progress_screen.dart
+++ b/lib/features/progress/progress_screen.dart
@@ -1,0 +1,228 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../ui/labels.dart';
+import 'kcal_bars.dart';
+import 'progress_data.dart';
+import 'progress_providers.dart';
+import 'weight_sparkline.dart';
+
+/// Progress tab v1. Top: 7 / 30 / all segmented selector. Below: body-weight
+/// sparkline + daily kcal bars. No tooltips, no axes, no zoom — explicitly
+/// scoped out (see issue #23).
+class ProgressScreen extends ConsumerWidget {
+  const ProgressScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final window = ref.watch(progressWindowProvider);
+    final weight = ref.watch(weightSeriesProvider);
+    final kcal = ref.watch(kcalSeriesProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Progress')),
+      body: ListView(
+        padding: const EdgeInsets.only(bottom: 24),
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: SizedBox(
+              width: double.infinity,
+              child: SegmentedButton<ProgressWindow>(
+                segments: const [
+                  ButtonSegment(
+                    value: ProgressWindow.sevenDays,
+                    label: Text('7d'),
+                  ),
+                  ButtonSegment(
+                    value: ProgressWindow.thirtyDays,
+                    label: Text('30d'),
+                  ),
+                  ButtonSegment(
+                    value: ProgressWindow.all,
+                    label: Text('All'),
+                  ),
+                ],
+                selected: {window},
+                onSelectionChanged: (sel) {
+                  ref.read(progressWindowProvider.notifier).state = sel.first;
+                },
+              ),
+            ),
+          ),
+          _CombinedOrSections(weight: weight, kcal: kcal),
+        ],
+      ),
+    );
+  }
+}
+
+/// When both series are empty, issue #23 asks for a single combined message
+/// rather than two separate empty cards. This widget makes that decision
+/// once we have data from both providers.
+class _CombinedOrSections extends StatelessWidget {
+  const _CombinedOrSections({required this.weight, required this.kcal});
+
+  final AsyncValue<WeightSeries> weight;
+  final AsyncValue<KcalSeries> kcal;
+
+  @override
+  Widget build(BuildContext context) {
+    final wData = weight.asData?.value;
+    final kData = kcal.asData?.value;
+
+    if (wData != null && kData != null) {
+      final weightEmpty = !wData.hasEnoughForSparkline;
+      final kcalEmpty = kData.loggedDayCount == 0;
+      if (weightEmpty && kcalEmpty) {
+        return const Padding(
+          padding: EdgeInsets.fromLTRB(16, 32, 16, 16),
+          child: Center(child: Text('Not enough data yet.')),
+        );
+      }
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _WeightSection(weight: weight),
+        const SizedBox(height: 16),
+        _KcalSection(kcal: kcal),
+      ],
+    );
+  }
+}
+
+class _WeightSection extends StatelessWidget {
+  const _WeightSection({required this.weight});
+
+  final AsyncValue<WeightSeries> weight;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const _SectionHeader(label: 'Body weight'),
+        weight.when(
+          data: (s) => _weightBody(context, s),
+          loading: () => const SizedBox(height: WeightSparkline.height),
+          error: (err, _) => _ErrorInline(text: 'Weight data: $err'),
+        ),
+      ],
+    );
+  }
+
+  Widget _weightBody(BuildContext context, WeightSeries s) {
+    if (!s.hasEnoughForSparkline) {
+      return const _EmptyInline(
+        text: 'Not enough weight data yet — log at least 2 entries.',
+      );
+    }
+    final dominant = s.dominantUnit;
+    final children = <Widget>[];
+    if (s.mixedUnits && dominant != null) {
+      children.add(_MixedUnitsBanner(
+        text: 'Mixed units — showing ${weightUnitLabel(dominant)} only',
+      ));
+    }
+    children.add(Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      child: WeightSparkline(points: s.points),
+    ));
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: children,
+    );
+  }
+}
+
+class _KcalSection extends StatelessWidget {
+  const _KcalSection({required this.kcal});
+
+  final AsyncValue<KcalSeries> kcal;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const _SectionHeader(label: 'Daily kcal'),
+        kcal.when(
+          data: (s) => s.loggedDayCount == 0
+              ? const _EmptyInline(text: 'No calorie data for this window.')
+              : Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+                  child: KcalBars(days: s.days),
+                ),
+          loading: () => const SizedBox(height: KcalBars.height),
+          error: (err, _) => _ErrorInline(text: 'Kcal data: $err'),
+        ),
+      ],
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.label});
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.titleMedium,
+      ),
+    );
+  }
+}
+
+class _MixedUnitsBanner extends StatelessWidget {
+  const _MixedUnitsBanner({required this.text});
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 4, 16, 4),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        text,
+        style: theme.textTheme.bodySmall,
+      ),
+    );
+  }
+}
+
+class _EmptyInline extends StatelessWidget {
+  const _EmptyInline({required this.text});
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: Text(text, style: Theme.of(context).textTheme.bodyMedium),
+    );
+  }
+}
+
+class _ErrorInline extends StatelessWidget {
+  const _ErrorInline({required this.text});
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: Text(text, style: Theme.of(context).textTheme.bodyMedium),
+    );
+  }
+}

--- a/lib/features/progress/weight_sparkline.dart
+++ b/lib/features/progress/weight_sparkline.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+import 'progress_data.dart';
+
+/// A deliberately-bare weight sparkline. No axes, no labels, no grid — just a
+/// polyline auto-fit to the min/max of whatever points it receives. Points
+/// are already filtered to a single unit by the aggregator; this widget never
+/// converts or relabels anything.
+class WeightSparkline extends StatelessWidget {
+  const WeightSparkline({super.key, required this.points});
+
+  final List<WeightPoint> points;
+
+  static const double height = 140;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.primary;
+    return SizedBox(
+      height: height,
+      width: double.infinity,
+      child: CustomPaint(
+        painter: WeightSparklinePainter(points: points, color: color),
+      ),
+    );
+  }
+}
+
+class WeightSparklinePainter extends CustomPainter {
+  WeightSparklinePainter({required this.points, required this.color});
+
+  final List<WeightPoint> points;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (points.length < 2) return;
+
+    // X scale: linear by timestamp. Using ms-since-epoch keeps the arithmetic
+    // simple; no risk of overflow for realistic body-weight log ranges.
+    final tMin = points.first.timestamp.millisecondsSinceEpoch.toDouble();
+    final tMax = points.last.timestamp.millisecondsSinceEpoch.toDouble();
+    final tSpan = (tMax - tMin).abs() < 1 ? 1.0 : tMax - tMin;
+
+    // Y scale: auto-fit to actual min/max with a small vertical padding so
+    // the line never grazes the edge. If all values are identical, draw a
+    // horizontal line in the middle.
+    var yMin = points.first.value;
+    var yMax = points.first.value;
+    for (final p in points) {
+      if (p.value < yMin) yMin = p.value;
+      if (p.value > yMax) yMax = p.value;
+    }
+    final yRange = yMax - yMin;
+    final paddedMin = yRange == 0 ? yMin - 1 : yMin - yRange * 0.1;
+    final paddedMax = yRange == 0 ? yMax + 1 : yMax + yRange * 0.1;
+    final ySpan = paddedMax - paddedMin;
+
+    const paddingX = 4.0;
+    const paddingY = 4.0;
+    final plotW = size.width - paddingX * 2;
+    final plotH = size.height - paddingY * 2;
+
+    Offset project(WeightPoint p) {
+      final tx = (p.timestamp.millisecondsSinceEpoch - tMin) / tSpan;
+      // Flip Y so larger values render higher on the canvas.
+      final ty = 1 - ((p.value - paddedMin) / ySpan);
+      return Offset(paddingX + tx * plotW, paddingY + ty * plotH);
+    }
+
+    final path = Path()..moveTo(project(points.first).dx, project(points.first).dy);
+    for (var i = 1; i < points.length; i++) {
+      final o = project(points[i]);
+      path.lineTo(o.dx, o.dy);
+    }
+
+    final linePaint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2.0
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+    canvas.drawPath(path, linePaint);
+
+    // Dot at each data point so sparse series remain visible.
+    final dotPaint = Paint()..color = color;
+    for (final p in points) {
+      canvas.drawCircle(project(p), 2.5, dotPaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant WeightSparklinePainter old) =>
+      old.points != points || old.color != color;
+}

--- a/lib/shell/root_shell.dart
+++ b/lib/shell/root_shell.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../features/body_weight/body_weight_screen.dart';
 import '../features/food/food_log_screen.dart';
 import '../features/history/history_screen.dart';
+import '../features/progress/progress_screen.dart';
 import '../features/workouts/workout_list_screen.dart';
 
 class RootShell extends StatefulWidget {
@@ -20,6 +21,7 @@ class _RootShellState extends State<RootShell> {
     BodyWeightScreen(),
     WorkoutListScreen(),
     HistoryScreen(),
+    ProgressScreen(),
   ];
 
   @override
@@ -49,6 +51,11 @@ class _RootShellState extends State<RootShell> {
             icon: Icon(Icons.history_outlined),
             selectedIcon: Icon(Icons.history),
             label: 'History',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.show_chart_outlined),
+            selectedIcon: Icon(Icons.show_chart),
+            label: 'Progress',
           ),
         ],
       ),

--- a/test/features/progress/kcal_bars_test.dart
+++ b/test/features/progress/kcal_bars_test.dart
@@ -1,0 +1,67 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/features/progress/kcal_bars.dart';
+import 'package:liftlog_app/features/progress/progress_data.dart';
+
+void main() {
+  group('KcalBarsPainter', () {
+    test('paint() handles empty, all-zero, and mixed-value days without throwing', () {
+      final recorder = PictureRecorder();
+      final canvas = Canvas(recorder);
+      const size = Size(300, 140);
+
+      KcalBarsPainter(days: const [], color: Colors.blue).paint(canvas, size);
+
+      KcalBarsPainter(
+        days: [
+          DailyKcal(day: DateTime(2026, 4, 20), kcal: 0),
+          DailyKcal(day: DateTime(2026, 4, 21), kcal: 0),
+        ],
+        color: Colors.blue,
+      ).paint(canvas, size);
+
+      KcalBarsPainter(
+        days: [
+          DailyKcal(day: DateTime(2026, 4, 20), kcal: 400),
+          DailyKcal(day: DateTime(2026, 4, 21), kcal: 0),
+          DailyKcal(day: DateTime(2026, 4, 22), kcal: 2200),
+          DailyKcal(day: DateTime(2026, 4, 23), kcal: 1500),
+        ],
+        color: Colors.blue,
+      ).paint(canvas, size);
+
+      // 30-day window stresses the min-bar-width clamp.
+      KcalBarsPainter(
+        days: List.generate(
+          30,
+          (i) => DailyKcal(day: DateTime(2026, 4, 1).add(Duration(days: i)), kcal: i * 80),
+        ),
+        color: Colors.blue,
+      ).paint(canvas, size);
+
+      recorder.endRecording();
+    });
+
+    test('shouldRepaint reflects days / color changes', () {
+      final days = [
+        DailyKcal(day: DateTime(2026, 4, 22), kcal: 1500),
+        DailyKcal(day: DateTime(2026, 4, 23), kcal: 1800),
+      ];
+      final a = KcalBarsPainter(days: days, color: Colors.blue);
+      final sameRef = KcalBarsPainter(days: days, color: Colors.blue);
+      expect(a.shouldRepaint(sameRef), isFalse);
+
+      final otherDays = KcalBarsPainter(
+        days: [DailyKcal(day: DateTime(2026, 4, 22), kcal: 100)],
+        color: Colors.blue,
+      );
+      expect(a.shouldRepaint(otherDays), isTrue);
+
+      final otherColor = KcalBarsPainter(days: days, color: Colors.red);
+      expect(a.shouldRepaint(otherColor), isTrue);
+    });
+  });
+}

--- a/test/features/progress/progress_data_test.dart
+++ b/test/features/progress/progress_data_test.dart
@@ -1,0 +1,168 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/features/progress/progress_data.dart';
+
+BodyWeightLog _weight(DateTime t, double v, WeightUnit u) =>
+    BodyWeightLog(id: 1, timestamp: t, value: v, unit: u);
+
+FoodEntry _food(DateTime t, int kcal) => FoodEntry(
+      id: 1,
+      timestamp: t,
+      name: '',
+      kcal: kcal,
+      proteinG: 0.0,
+      mealType: MealType.other,
+      entryType: FoodEntryType.manual,
+      note: null,
+    );
+
+void main() {
+  group('resolveWindow', () {
+    final now = DateTime(2026, 4, 23, 15, 30); // mid-day
+
+    test('sevenDays spans today + 6 prior days', () {
+      final r = resolveWindow(ProgressWindow.sevenDays, now: now);
+      expect(r.from, DateTime(2026, 4, 17));
+      expect(r.to, DateTime(2026, 4, 24));
+    });
+
+    test('thirtyDays spans today + 29 prior days', () {
+      final r = resolveWindow(ProgressWindow.thirtyDays, now: now);
+      expect(r.from, DateTime(2026, 3, 25));
+      expect(r.to, DateTime(2026, 4, 24));
+    });
+
+    test('all uses epoch-0 as from', () {
+      final r = resolveWindow(ProgressWindow.all, now: now);
+      expect(r.from.millisecondsSinceEpoch, 0);
+      expect(r.to, DateTime(2026, 4, 24));
+    });
+  });
+
+  group('buildWeightSeries', () {
+    test('empty logs yields empty series with no dominant unit', () {
+      final s = buildWeightSeries(const []);
+      expect(s.isEmpty, isTrue);
+      expect(s.dominantUnit, isNull);
+      expect(s.mixedUnits, isFalse);
+      expect(s.hasEnoughForSparkline, isFalse);
+    });
+
+    test('single-unit logs: no mixed flag, dominant = that unit', () {
+      final s = buildWeightSeries([
+        _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
+        _weight(DateTime(2026, 4, 22), 80.5, WeightUnit.kg),
+      ]);
+      expect(s.dominantUnit, WeightUnit.kg);
+      expect(s.mixedUnits, isFalse);
+      expect(s.points.length, 2);
+      expect(s.hasEnoughForSparkline, isTrue);
+    });
+
+    test('sorts points chronologically regardless of input order', () {
+      final s = buildWeightSeries([
+        _weight(DateTime(2026, 4, 22), 80.5, WeightUnit.kg),
+        _weight(DateTime(2026, 4, 18), 79.0, WeightUnit.kg),
+        _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
+      ]);
+      expect(
+        s.points.map((p) => p.timestamp).toList(),
+        [
+          DateTime(2026, 4, 18),
+          DateTime(2026, 4, 20),
+          DateTime(2026, 4, 22),
+        ],
+      );
+    });
+
+    test('mixed units: dominant = most recent unit, others dropped', () {
+      // Most recent is kg → dominant kg, the lb point is dropped.
+      final s = buildWeightSeries([
+        _weight(DateTime(2026, 4, 18), 176.0, WeightUnit.lb),
+        _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
+        _weight(DateTime(2026, 4, 22), 80.5, WeightUnit.kg),
+      ]);
+      expect(s.dominantUnit, WeightUnit.kg);
+      expect(s.mixedUnits, isTrue);
+      expect(s.points.length, 2);
+      expect(s.points.every((p) => p.value < 100), isTrue,
+          reason: 'lb value 176 must be dropped; never silently converted');
+    });
+
+    test('mixed units, most recent is lb: drops kg points', () {
+      final s = buildWeightSeries([
+        _weight(DateTime(2026, 4, 18), 80.0, WeightUnit.kg),
+        _weight(DateTime(2026, 4, 22), 176.0, WeightUnit.lb),
+      ]);
+      expect(s.dominantUnit, WeightUnit.lb);
+      expect(s.mixedUnits, isTrue);
+      expect(s.points.length, 1);
+      expect(s.points.single.value, 176.0);
+    });
+  });
+
+  group('buildKcalSeries', () {
+    test('bounded window: emits one bucket per day, 0 for empty days', () {
+      final from = DateTime(2026, 4, 20);
+      final to = DateTime(2026, 4, 24); // exclusive → 4 days
+      final entries = [
+        _food(DateTime(2026, 4, 20, 8), 300),
+        _food(DateTime(2026, 4, 20, 13), 500),
+        // 4/21, 4/22 empty
+        _food(DateTime(2026, 4, 23, 9), 600),
+      ];
+      final s = buildKcalSeries(entries, from: from, to: to);
+      expect(s.days.length, 4);
+      expect(s.days[0].day, DateTime(2026, 4, 20));
+      expect(s.days[0].kcal, 800);
+      expect(s.days[1].kcal, 0);
+      expect(s.days[2].kcal, 0);
+      expect(s.days[3].kcal, 600);
+      expect(s.loggedDayCount, 2);
+      expect(s.maxKcal, 800);
+    });
+
+    test('local-day bucketing: entries early and late in the day aggregate', () {
+      final from = DateTime(2026, 4, 22);
+      final to = DateTime(2026, 4, 23);
+      final s = buildKcalSeries(
+        [
+          _food(DateTime(2026, 4, 22, 0, 5), 100),
+          _food(DateTime(2026, 4, 22, 23, 55), 900),
+        ],
+        from: from,
+        to: to,
+      );
+      expect(s.days.length, 1);
+      expect(s.days.single.kcal, 1000);
+    });
+
+    test('all-window with entries derives first bucket from oldest entry', () {
+      final s = buildKcalSeries(
+        [
+          _food(DateTime(2026, 4, 20, 12), 500),
+          _food(DateTime(2026, 4, 22, 12), 700),
+        ],
+        from: DateTime.fromMillisecondsSinceEpoch(0),
+        to: DateTime(2026, 4, 24),
+      );
+      expect(s.days.first.day, DateTime(2026, 4, 20));
+      expect(s.days.length, 4); // 4/20, 4/21, 4/22, 4/23
+      expect(s.days.last.day, DateTime(2026, 4, 23));
+    });
+
+    test('all-window with no entries degrades to a single zero-bucket', () {
+      final s = buildKcalSeries(
+        const [],
+        from: DateTime.fromMillisecondsSinceEpoch(0),
+        to: DateTime(2026, 4, 24),
+      );
+      expect(s.days.length, 1);
+      expect(s.days.single.kcal, 0);
+      expect(s.isEmpty, isTrue);
+      expect(s.loggedDayCount, 0);
+    });
+  });
+}

--- a/test/features/progress/progress_screen_test.dart
+++ b/test/features/progress/progress_screen_test.dart
@@ -1,0 +1,255 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/data/repositories/body_weight_log_repository.dart';
+import 'package:liftlog_app/data/repositories/food_entry_repository.dart';
+import 'package:liftlog_app/features/progress/progress_data.dart';
+import 'package:liftlog_app/features/progress/progress_providers.dart';
+import 'package:liftlog_app/features/progress/progress_screen.dart';
+import 'package:liftlog_app/providers/app_providers.dart';
+import 'package:liftlog_app/shell/root_shell.dart';
+
+void main() {
+  late AppDatabase db;
+
+  // Frozen "now" anchoring all windows to 2026-04-23 so the test data lands
+  // inside 7d / 30d / all deterministically.
+  final fakeNow = DateTime(2026, 4, 23, 12);
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async => db.close());
+
+  Widget app({List<Override> extra = const []}) => ProviderScope(
+        overrides: [
+          appDatabaseProvider.overrideWithValue(db),
+          progressNowProvider.overrideWithValue(fakeNow),
+          ...extra,
+        ],
+        child: const MaterialApp(home: ProgressScreen()),
+      );
+
+  testWidgets('tab appears as 5th icon in root shell and tapping renders Progress',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appDatabaseProvider.overrideWithValue(db),
+          progressNowProvider.overrideWithValue(fakeNow),
+        ],
+        child: const MaterialApp(home: RootShell()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 5 destinations total.
+    expect(find.byType(NavigationDestination), findsNWidgets(5));
+    expect(find.text('Progress'), findsOneWidget);
+
+    // Tap the Progress tab — screen should render its AppBar title.
+    await tester.tap(find.text('Progress'));
+    await tester.pumpAndSettle();
+
+    // AppBar title "Progress" + the NavigationDestination label "Progress"
+    // both exist — so we expect at least 2 occurrences.
+    expect(find.text('Progress'), findsAtLeastNWidgets(2));
+    // Empty DB → combined empty-state copy renders (per AC #4).
+    expect(find.text('Not enough data yet.'), findsOneWidget);
+    // Segmented selector is always visible.
+    expect(find.text('7d'), findsOneWidget);
+    expect(find.text('30d'), findsOneWidget);
+    expect(find.text('All'), findsOneWidget);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('window toggle swaps the kcal series length', (tester) async {
+    // Fixture: an entry 10 days ago (inside 30d, outside 7d) + an entry today.
+    final foodRepo = FoodEntryRepository(db);
+    await foodRepo.add(FoodEntriesCompanion.insert(
+      timestamp: fakeNow.subtract(const Duration(days: 10)),
+      name: const Value('Old meal'),
+      kcal: 400,
+      proteinG: 20.0,
+      mealType: MealType.lunch,
+      entryType: FoodEntryType.manual,
+    ));
+    await foodRepo.add(FoodEntriesCompanion.insert(
+      timestamp: fakeNow,
+      name: const Value('Today meal'),
+      kcal: 600,
+      proteinG: 30.0,
+      mealType: MealType.lunch,
+      entryType: FoodEntryType.manual,
+    ));
+    // Two weight logs so the sparkline shows up; both in-window for all three.
+    final wRepo = BodyWeightLogRepository(db);
+    await wRepo.add(BodyWeightLogsCompanion.insert(
+      timestamp: fakeNow.subtract(const Duration(days: 2)),
+      value: 80.0,
+      unit: WeightUnit.kg,
+    ));
+    await wRepo.add(BodyWeightLogsCompanion.insert(
+      timestamp: fakeNow,
+      value: 80.5,
+      unit: WeightUnit.kg,
+    ));
+
+    // Start at 7d — only the "today" food entry is inside.
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    // Grab the KcalSeries exposed via the provider to assert day-count.
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ProgressScreen)),
+    );
+    KcalSeries kcal = await container.read(kcalSeriesProvider.future);
+    expect(kcal.days.length, 7, reason: '7d window → 7 buckets');
+    expect(kcal.loggedDayCount, 1, reason: 'only today is logged inside 7d');
+
+    // Flip to 30d via provider-override style tap on the segmented button.
+    await tester.tap(find.text('30d'));
+    await tester.pumpAndSettle();
+
+    kcal = await container.read(kcalSeriesProvider.future);
+    expect(kcal.days.length, 30, reason: '30d window → 30 buckets');
+    expect(kcal.loggedDayCount, 2,
+        reason: 'both the 10-day-old entry and today are inside 30d');
+
+    // Flip to All — in this fixture the oldest entry is 10 days back, so the
+    // aggregator emits ~11 buckets (today inclusive).
+    await tester.tap(find.text('All'));
+    await tester.pumpAndSettle();
+
+    kcal = await container.read(kcalSeriesProvider.future);
+    expect(kcal.days.length, 11);
+    expect(kcal.loggedDayCount, 2);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('mixed-unit window shows banner and renders single-unit sparkline',
+      (tester) async {
+    final wRepo = BodyWeightLogRepository(db);
+    // Older entry in lb, newer entry in kg — dominant should be kg.
+    await wRepo.add(BodyWeightLogsCompanion.insert(
+      timestamp: fakeNow.subtract(const Duration(days: 2)),
+      value: 176.0,
+      unit: WeightUnit.lb,
+    ));
+    await wRepo.add(BodyWeightLogsCompanion.insert(
+      timestamp: fakeNow.subtract(const Duration(days: 1)),
+      value: 80.0,
+      unit: WeightUnit.kg,
+    ));
+    await wRepo.add(BodyWeightLogsCompanion.insert(
+      timestamp: fakeNow,
+      value: 80.5,
+      unit: WeightUnit.kg,
+    ));
+
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Mixed units — showing kg only'), findsOneWidget);
+
+    // Painter receives the series via the provider; assert it's kg-only.
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ProgressScreen)),
+    );
+    final w = await container.read(weightSeriesProvider.future);
+    expect(w.dominantUnit, WeightUnit.kg);
+    expect(w.mixedUnits, isTrue);
+    expect(w.points.length, 2);
+    expect(w.points.every((p) => p.value < 100), isTrue,
+        reason: 'lb value 176 must be dropped, never silently converted');
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('weight-only-empty: kcal renders, weight shows empty copy',
+      (tester) async {
+    final foodRepo = FoodEntryRepository(db);
+    await foodRepo.add(FoodEntriesCompanion.insert(
+      timestamp: fakeNow,
+      name: const Value('Lunch'),
+      kcal: 500,
+      proteinG: 30.0,
+      mealType: MealType.lunch,
+      entryType: FoodEntryType.manual,
+    ));
+    // No weight logs at all.
+
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Not enough weight data yet — log at least 2 entries.'),
+      findsOneWidget,
+    );
+    expect(find.text('No calorie data for this window.'), findsNothing);
+    expect(find.text('Not enough data yet.'), findsNothing);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('kcal-only-empty: weight renders, kcal shows empty copy',
+      (tester) async {
+    final wRepo = BodyWeightLogRepository(db);
+    await wRepo.add(BodyWeightLogsCompanion.insert(
+      timestamp: fakeNow.subtract(const Duration(days: 2)),
+      value: 80.0,
+      unit: WeightUnit.kg,
+    ));
+    await wRepo.add(BodyWeightLogsCompanion.insert(
+      timestamp: fakeNow,
+      value: 80.5,
+      unit: WeightUnit.kg,
+    ));
+    // No food entries.
+
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    expect(find.text('No calorie data for this window.'), findsOneWidget);
+    expect(
+      find.text('Not enough weight data yet — log at least 2 entries.'),
+      findsNothing,
+    );
+    expect(find.text('Not enough data yet.'), findsNothing);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('both-empty: shows single combined message, no per-section empty',
+      (tester) async {
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Not enough data yet.'), findsOneWidget);
+    // The per-section empty copy must NOT appear when the combined message
+    // is shown — otherwise the user sees three empty messages stacked.
+    expect(
+      find.text('Not enough weight data yet — log at least 2 entries.'),
+      findsNothing,
+    );
+    expect(find.text('No calorie data for this window.'), findsNothing);
+
+    await _drainDriftTimers(tester);
+  });
+}
+
+/// Drift schedules a zero-duration Timer when its stream is cancelled on
+/// dispose. Advance fake_async's clock so the Timer fires before the
+/// framework's post-test !timersPending invariant check runs.
+Future<void> _drainDriftTimers(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox());
+  await tester.pump(const Duration(milliseconds: 1));
+}

--- a/test/features/progress/weight_sparkline_test.dart
+++ b/test/features/progress/weight_sparkline_test.dart
@@ -1,0 +1,65 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/features/progress/progress_data.dart';
+import 'package:liftlog_app/features/progress/weight_sparkline.dart';
+
+void main() {
+  group('WeightSparklinePainter', () {
+    test('paint() does not throw for empty, single, and multi-point inputs', () {
+      final recorder = PictureRecorder();
+      final canvas = Canvas(recorder);
+      const size = Size(300, 140);
+
+      WeightSparklinePainter(points: const [], color: Colors.blue)
+          .paint(canvas, size);
+      WeightSparklinePainter(
+        points: [WeightPoint(timestamp: DateTime(2026, 4, 20), value: 80.0)],
+        color: Colors.blue,
+      ).paint(canvas, size);
+      WeightSparklinePainter(
+        points: [
+          WeightPoint(timestamp: DateTime(2026, 4, 20), value: 80.0),
+          WeightPoint(timestamp: DateTime(2026, 4, 22), value: 80.5),
+          WeightPoint(timestamp: DateTime(2026, 4, 23), value: 79.8),
+        ],
+        color: Colors.blue,
+      ).paint(canvas, size);
+
+      // Also survives identical-y values (yRange == 0 branch).
+      WeightSparklinePainter(
+        points: [
+          WeightPoint(timestamp: DateTime(2026, 4, 20), value: 80.0),
+          WeightPoint(timestamp: DateTime(2026, 4, 21), value: 80.0),
+        ],
+        color: Colors.blue,
+      ).paint(canvas, size);
+
+      recorder.endRecording();
+    });
+
+    test('shouldRepaint returns true when points or color change, false otherwise', () {
+      final points = [
+        WeightPoint(timestamp: DateTime(2026, 4, 20), value: 80.0),
+        WeightPoint(timestamp: DateTime(2026, 4, 22), value: 80.5),
+      ];
+      final a = WeightSparklinePainter(points: points, color: Colors.blue);
+      final sameRef = WeightSparklinePainter(points: points, color: Colors.blue);
+      expect(a.shouldRepaint(sameRef), isFalse);
+
+      final differentPoints = WeightSparklinePainter(
+        points: [
+          WeightPoint(timestamp: DateTime(2026, 4, 20), value: 81.0),
+        ],
+        color: Colors.blue,
+      );
+      expect(a.shouldRepaint(differentPoints), isTrue);
+
+      final differentColor =
+          WeightSparklinePainter(points: points, color: Colors.red);
+      expect(a.shouldRepaint(differentColor), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Closes #23.

## Summary
- Adds a 5th **Progress** tab to the bottom navigation with a 7d / 30d / all `SegmentedButton` selector, a body-weight sparkline, and a daily kcal bar chart.
- All chart rendering is done with `CustomPainter`. **No new pub dependencies.**
- Data layer: new `FutureProvider`s read `listRange` from the existing `BodyWeightLogRepository` / `FoodEntryRepository` (shipped in #22). No `.select(` and no Drift imports in feature code.
- Window state is a `StateProvider<ProgressWindow>`; `progressNowProvider` injects the clock so widget tests can freeze "now".

## Trust rules
- **No silent unit conversion.** When a window contains both kg and lb logs, the most-recent-log unit wins, the other unit's points are dropped from the sparkline, and the UI renders a visible `Mixed units — showing kg only` (or `lb only`) banner.
- **No misleading zero.** The kcal aggregator emits one bucket per local-calendar day in the window — days with no entries render as a visible gap (0), not a hidden "some value."
- **DST-safe day arithmetic.** Window resolution and the per-day walk use `DateTime(y, m, d ± n)` rather than `Duration(days: 1)` so spring-forward / fall-back can't slip the series.

## Empty states (per AC #4)
- Weight sparkline < 2 points → `Not enough weight data yet — log at least 2 entries.`
- Kcal bars with 0 logged days → `No calorie data for this window.`
- Both empty → a single combined `Not enough data yet.` at screen level (no stacked duplicates).

## Design notes
- **Bar width / y-scale.** Each bar gets a slot of `plotWidth / dayCount` and fills ~80% of its slot, clamped to a 2px minimum so 30-day windows stay visible on iPhone 15's 393pt-wide viewport. Y-scale is auto-fit to the window max; all-zero windows draw nothing (empty-state copy covers the user-facing case).
- **Sparkline.** Linear X by timestamp (ms-since-epoch), Y auto-fit to min/max with 10% vertical padding so the line never grazes the edge. If all values are identical, the line sits in the middle. Dots at each data point so sparse series stay visible.
- **`SegmentedButton` layout.** Wrapped in a full-width `SizedBox` inside padded `ListView` children — `SegmentedButton` has no intrinsic width hint and would otherwise collapse to hug content.
- **Mixed-unit banner belongs in the aggregator, not the widget.** The issue spec leaves this open. The aggregator owns unit selection and filtering, returns `WeightSeries.mixedUnits` + `dominantUnit`, and the widget just reads those flags to decide whether to render the banner. This keeps the "drop non-dominant-unit points" behavior unit-testable without pumping widgets, and the painter never needs to know about `WeightUnit`.

## Test plan
- [x] `flutter analyze` → `No issues found!`
- [x] `flutter test` → **79 passed** (was 56; +23 new: 11 aggregator unit tests, 6 widget tests, 4 painter tests, 2 arch tests unchanged)
- [x] `test/arch/data_access_boundary_test.dart` still green — no feature-code Drift imports, no `.select(`
- [x] Widget test confirms the 5th tab appears and the Progress screen renders
- [x] Widget test for the 7d / 30d / all toggle confirms the kcal series length changes (7, 30, and 11-from-oldest-entry for `all`)
- [x] Widget tests cover weight-only-empty, kcal-only-empty, and both-empty empty states
- [x] Widget test for mixed units: one lb + two kg entries in the same window → banner renders, sparkline receives only the kg points (lb's 176 value is **not** silently converted)
- [x] Painter tests (`paint()` doesn't throw, `shouldRepaint` returns the sensible value) — no golden files

## Scope — out (explicit)
- Workout volume chart (that's #24)
- Goal / target lines
- Zoom / pan / tooltips
- `fl_chart` or any charting dep
- Landscape layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)