### PR TITLE
#24 — Weekly workout volume on Progress tab

### DIFF
--- a/lib/data/repositories/workout_session_repository.dart
+++ b/lib/data/repositories/workout_session_repository.dart
@@ -40,4 +40,44 @@ class WorkoutSessionRepository {
   Stream<WorkoutSession?> watchById(int id) =>
       (_db.select(_db.workoutSessions)..where((t) => t.id.equals(id)))
           .watchSingleOrNull();
+
+  /// Returns every session whose `startedAt` falls in `[from, to)`, paired
+  /// with the sets belonging to that session (ordered by `orderIndex` asc).
+  ///
+  /// Implementation is two queries rather than a SQL join: fetch sessions in
+  /// range, then fetch sets whose `sessionId` is in that id set. For a
+  /// single-user local tracker this is simpler than assembling a drift join
+  /// and keeps the return shape trivially typed. Sessions with no sets yield
+  /// a record with `sets: const []`.
+  ///
+  /// Callers (the Progress tab) further filter sets by
+  /// [WorkoutSetStatus.completed]; we deliberately don't pre-filter here so
+  /// future consumers can reuse the same method for planned / skipped
+  /// buckets without another query path.
+  Future<List<({WorkoutSession session, List<ExerciseSet> sets})>>
+      listRangeWithSets(DateTime from, DateTime to) async {
+    final sessions = await (_db.select(_db.workoutSessions)
+          ..where((t) =>
+              t.startedAt.isBiggerOrEqualValue(from) &
+              t.startedAt.isSmallerThanValue(to))
+          ..orderBy([(t) => OrderingTerm.asc(t.startedAt)]))
+        .get();
+    if (sessions.isEmpty) return const [];
+
+    final ids = sessions.map((s) => s.id).toList();
+    final sets = await (_db.select(_db.exerciseSets)
+          ..where((t) => t.sessionId.isIn(ids))
+          ..orderBy([(t) => OrderingTerm.asc(t.orderIndex)]))
+        .get();
+
+    // Bucket sets by sessionId so each session gets its own ordered list.
+    final bySession = <int, List<ExerciseSet>>{};
+    for (final s in sets) {
+      bySession.putIfAbsent(s.sessionId, () => []).add(s);
+    }
+    return [
+      for (final s in sessions)
+        (session: s, sets: bySession[s.id] ?? const <ExerciseSet>[]),
+    ];
+  }
 }

--- a/lib/features/progress/progress_data.dart
+++ b/lib/features/progress/progress_data.dart
@@ -83,6 +83,15 @@ class KcalSeries {
 /// bucketing stays testable without touching [DateTime.now].
 DateTime _dayOf(DateTime t) => DateTime(t.year, t.month, t.day);
 
+/// Returns the local-midnight Monday of the ISO week that [t] falls in.
+/// [DateTime.weekday] is `1` for Monday through `7` for Sunday, so subtracting
+/// `(weekday - 1)` civil days always lands on that week's Monday. Calendar
+/// arithmetic (not `Duration`) so DST-day weeks don't drift by an hour.
+DateTime _mondayOf(DateTime t) {
+  final day = _dayOf(t);
+  return DateTime(day.year, day.month, day.day - (day.weekday - 1));
+}
+
 /// Builds a [WeightSeries] from raw logs. Responsibilities:
 ///
 /// 1. Pick a dominant unit. If logs are in more than one unit, the most recent
@@ -168,4 +177,102 @@ KcalSeries buildKcalSeries(
     cursor = DateTime(cursor.year, cursor.month, cursor.day + 1);
   }
   return KcalSeries(days: days);
+}
+
+/// Output of the weekly-volume aggregator. `weekStarts[i]` is the local
+/// midnight of the Monday that starts week `i`; `completedSets[i]` is the
+/// count of sets with `WorkoutSetStatus.completed` whose parent session's
+/// `startedAt` falls inside `[weekStarts[i], weekStarts[i] + 7 days)`.
+///
+/// Both lists have identical length (the fixed 8-week window). `isEmpty`
+/// is true iff every bucket is zero — the UI uses that for the dedicated
+/// empty-state copy rather than rendering eight blank bars.
+class WeeklyVolumeSeries {
+  const WeeklyVolumeSeries({
+    required this.weekStarts,
+    required this.completedSets,
+  });
+
+  final List<DateTime> weekStarts;
+  final List<int> completedSets;
+
+  bool get isEmpty => completedSets.every((c) => c == 0);
+  int get maxCompletedSets => completedSets.isEmpty
+      ? 0
+      : completedSets.reduce((a, b) => a > b ? a : b);
+}
+
+/// Builds a [WeeklyVolumeSeries] covering the 8 most recent ISO weeks ending
+/// at the week of `now`. Sets are bucketed by their parent session's
+/// `startedAt` (not by the set's own create time — sets don't carry one in
+/// this schema). Only `WorkoutSetStatus.completed` sets count toward volume.
+///
+/// ISO week: Monday-to-Sunday. `weekStarts[0]` is the oldest Monday in the
+/// window, `weekStarts[7]` is the Monday of `now`'s week.
+WeeklyVolumeSeries buildWeeklyVolumeSeries(
+  List<ExerciseSet> sets,
+  List<WorkoutSession> sessions,
+  DateTime now,
+) {
+  // Build the 8 Mondays, oldest first. Calendar arithmetic via DateTime()
+  // — never Duration — so DST-week boundaries are always exactly 7 civil
+  // days apart.
+  final currentMonday = _mondayOf(now);
+  final weekStarts = <DateTime>[
+    for (var i = 7; i >= 0; i--)
+      DateTime(currentMonday.year, currentMonday.month, currentMonday.day - 7 * i),
+  ];
+  final windowStart = weekStarts.first;
+  final windowEnd = DateTime(
+    currentMonday.year,
+    currentMonday.month,
+    currentMonday.day + 7,
+  );
+
+  // Index Monday → bucket position (0..7). Cheaper and DST-safe than
+  // re-deriving bucket index from a civil-day difference — we hit a DST
+  // week in testing where `Duration.inDays` rounded to 6 instead of 7.
+  final mondayIndex = <DateTime, int>{
+    for (var i = 0; i < weekStarts.length; i++) weekStarts[i]: i,
+  };
+
+  // sessionId → startedAt for O(1) lookup when iterating sets. Sessions
+  // outside the 8-week window never contribute, so their sets are skipped.
+  final sessionStart = <int, DateTime>{};
+  for (final s in sessions) {
+    if (s.startedAt.isBefore(windowStart)) continue;
+    if (!s.startedAt.isBefore(windowEnd)) continue;
+    sessionStart[s.id] = s.startedAt;
+  }
+
+  final counts = List<int>.filled(8, 0);
+  for (final set in sets) {
+    final sessionStartedAt = sessionStart[set.sessionId];
+    if (sessionStartedAt == null) continue; // session not in 8-week window
+
+    // Exhaustive switch over WorkoutSetStatus: planned & skipped are
+    // deliberately excluded because "weekly volume" in this app means
+    // work actually performed. A planned set is an intent that may never
+    // happen; a skipped set is explicit non-completion — neither
+    // represents volume a user should feel credit for.
+    bool countThis;
+    switch (set.status) {
+      case WorkoutSetStatus.planned:
+        countThis = false;
+      case WorkoutSetStatus.completed:
+        countThis = true;
+      case WorkoutSetStatus.skipped:
+        countThis = false;
+    }
+    if (!countThis) continue;
+
+    // Bucket by Monday-of-week. Look the set's Monday up in the pre-built
+    // index — safer than computing a civil-day difference here.
+    final weekMonday = _mondayOf(sessionStartedAt);
+    final index = mondayIndex[weekMonday];
+    if (index == null) continue; // defensive: outside window
+    counts[index] += 1;
+  }
+
+  return WeeklyVolumeSeries(weekStarts: weekStarts, completedSets: counts);
 }

--- a/lib/features/progress/progress_providers.dart
+++ b/lib/features/progress/progress_providers.dart
@@ -34,3 +34,36 @@ final kcalSeriesProvider = FutureProvider<KcalSeries>((ref) async {
   final entries = await repo.listRange(range.from, range.to);
   return buildKcalSeries(entries, from: range.from, to: range.to);
 });
+
+/// Weekly completed-set volume for the trailing 8 ISO weeks. Independent of
+/// the 7d / 30d / all selector — the brief fixes this section at 8 weeks.
+/// Uses the one-shot `listRangeWithSets` repository method (not `watch*`) so
+/// widget tests don't hang under Drift + fake_async.
+final weeklyVolumeProvider = FutureProvider<WeeklyVolumeSeries>((ref) async {
+  final now = ref.watch(progressNowProvider);
+  // Range = Monday-of(now) - 7 weeks through Monday-of(now) + 7 days.
+  // Compute here so the repo call only fetches sessions that matter — the
+  // aggregator does an identical bucketing pass, but it's cheaper to let
+  // SQLite filter at the data layer first.
+  final today = DateTime(now.year, now.month, now.day);
+  final currentMonday =
+      DateTime(today.year, today.month, today.day - (today.weekday - 1));
+  final from = DateTime(
+    currentMonday.year,
+    currentMonday.month,
+    currentMonday.day - 7 * 7,
+  );
+  final to = DateTime(
+    currentMonday.year,
+    currentMonday.month,
+    currentMonday.day + 7,
+  );
+  final repo = ref.watch(workoutSessionRepositoryProvider);
+  final grouped = await repo.listRangeWithSets(from, to);
+
+  // Flatten to the shape buildWeeklyVolumeSeries expects. We hold onto both
+  // the session objects (for startedAt) and their sets.
+  final sessions = [for (final g in grouped) g.session];
+  final sets = [for (final g in grouped) ...g.sets];
+  return buildWeeklyVolumeSeries(sets, sessions, now);
+});

--- a/lib/features/progress/progress_screen.dart
+++ b/lib/features/progress/progress_screen.dart
@@ -5,6 +5,7 @@ import '../../ui/labels.dart';
 import 'kcal_bars.dart';
 import 'progress_data.dart';
 import 'progress_providers.dart';
+import 'weekly_volume_bars.dart';
 import 'weight_sparkline.dart';
 
 /// Progress tab v1. Top: 7 / 30 / all segmented selector. Below: body-weight
@@ -18,6 +19,7 @@ class ProgressScreen extends ConsumerWidget {
     final window = ref.watch(progressWindowProvider);
     final weight = ref.watch(weightSeriesProvider);
     final kcal = ref.watch(kcalSeriesProvider);
+    final weeklyVolume = ref.watch(weeklyVolumeProvider);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Progress')),
@@ -51,6 +53,8 @@ class ProgressScreen extends ConsumerWidget {
             ),
           ),
           _CombinedOrSections(weight: weight, kcal: kcal),
+          const SizedBox(height: 16),
+          _WeeklyVolumeSection(series: weeklyVolume),
         ],
       ),
     );
@@ -157,6 +161,37 @@ class _KcalSection extends StatelessWidget {
                 ),
           loading: () => const SizedBox(height: KcalBars.height),
           error: (err, _) => _ErrorInline(text: 'Kcal data: $err'),
+        ),
+      ],
+    );
+  }
+}
+
+class _WeeklyVolumeSection extends StatelessWidget {
+  const _WeeklyVolumeSection({required this.series});
+
+  final AsyncValue<WeeklyVolumeSeries> series;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const _SectionHeader(
+          label: 'Workouts — completed sets/week (last 8 weeks)',
+        ),
+        series.when(
+          // Distinct empty copy — we don't render 8 blank bars when isEmpty.
+          data: (s) => s.isEmpty
+              ? const _EmptyInline(
+                  text: 'No completed sets in the last 8 weeks.',
+                )
+              : Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+                  child: WeeklyVolumeBars(series: s),
+                ),
+          loading: () => const SizedBox(height: WeeklyVolumeBars.height),
+          error: (err, _) => _ErrorInline(text: 'Volume data: $err'),
         ),
       ],
     );

--- a/lib/features/progress/weekly_volume_bars.dart
+++ b/lib/features/progress/weekly_volume_bars.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+import 'progress_data.dart';
+
+/// Weekly completed-sets bar chart. One bar per ISO week in the trailing
+/// 8-week window; 0-weeks render as a gap (no bar) rather than a zero-height
+/// bar, matching the kcal chart's style. Ruthlessly simple — no axes, no
+/// tooltips, no labels (see issue #24).
+class WeeklyVolumeBars extends StatelessWidget {
+  const WeeklyVolumeBars({super.key, required this.series});
+
+  final WeeklyVolumeSeries series;
+
+  static const double height = 140;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.primary;
+    return SizedBox(
+      height: height,
+      width: double.infinity,
+      child: CustomPaint(
+        painter: WeeklyVolumeBarsPainter(series: series, color: color),
+      ),
+    );
+  }
+}
+
+class WeeklyVolumeBarsPainter extends CustomPainter {
+  WeeklyVolumeBarsPainter({required this.series, required this.color});
+
+  final WeeklyVolumeSeries series;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final counts = series.completedSets;
+    if (counts.isEmpty) return;
+
+    // Y scale from the window's max. If everything is zero we draw nothing —
+    // the screen already renders the dedicated empty-state copy in that case.
+    var maxCount = 0;
+    for (final c in counts) {
+      if (c > maxCount) maxCount = c;
+    }
+    if (maxCount == 0) return;
+
+    const paddingX = 4.0;
+    const paddingY = 4.0;
+    final plotW = size.width - paddingX * 2;
+    final plotH = size.height - paddingY * 2;
+
+    // Bar width: equal slot per week (8 weeks fixed), bar ~80% of slot.
+    // Min 2px so narrow iPhone viewports still render something.
+    final slot = plotW / counts.length;
+    final barW = (slot * 0.8).clamp(2.0, slot);
+    final barOffset = (slot - barW) / 2;
+
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill;
+
+    for (var i = 0; i < counts.length; i++) {
+      final c = counts[i];
+      if (c <= 0) continue;
+      final h = (c / maxCount) * plotH;
+      final x = paddingX + i * slot + barOffset;
+      final y = paddingY + (plotH - h);
+      canvas.drawRect(Rect.fromLTWH(x, y, barW, h), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant WeeklyVolumeBarsPainter old) =>
+      old.series != series || old.color != color;
+}

--- a/test/data/workout_repository_test.dart
+++ b/test/data/workout_repository_test.dart
@@ -141,4 +141,109 @@ void main() {
       ],
     );
   });
+
+  group('listRangeWithSets', () {
+    test('returns only sessions in [from, to) with their sets, '
+        'ordered by orderIndex', () async {
+      // Before window.
+      final oldId = await sessions.add(WorkoutSessionsCompanion.insert(
+        startedAt: DateTime(2026, 3, 1),
+      ));
+      await sets.add(ExerciseSetsCompanion.insert(
+        sessionId: oldId,
+        exerciseName: 'Old lift',
+        reps: 5,
+        weight: 80,
+        weightUnit: WeightUnit.kg,
+        status: WorkoutSetStatus.completed,
+        orderIndex: 0,
+      ));
+
+      // Inside window — two sessions, 2 + 1 sets.
+      final aId = await sessions.add(WorkoutSessionsCompanion.insert(
+        startedAt: DateTime(2026, 4, 20, 12),
+      ));
+      await sets.add(ExerciseSetsCompanion.insert(
+        sessionId: aId,
+        exerciseName: 'Squat',
+        reps: 5,
+        weight: 100,
+        weightUnit: WeightUnit.kg,
+        status: WorkoutSetStatus.completed,
+        orderIndex: 1,
+      ));
+      await sets.add(ExerciseSetsCompanion.insert(
+        sessionId: aId,
+        exerciseName: 'Squat',
+        reps: 5,
+        weight: 100,
+        weightUnit: WeightUnit.kg,
+        status: WorkoutSetStatus.planned,
+        orderIndex: 0,
+      ));
+
+      final bId = await sessions.add(WorkoutSessionsCompanion.insert(
+        startedAt: DateTime(2026, 4, 22, 18),
+      ));
+      await sets.add(ExerciseSetsCompanion.insert(
+        sessionId: bId,
+        exerciseName: 'Bench',
+        reps: 8,
+        weight: 80,
+        weightUnit: WeightUnit.kg,
+        status: WorkoutSetStatus.completed,
+        orderIndex: 0,
+      ));
+
+      // Outside window (after `to`).
+      final laterId = await sessions.add(WorkoutSessionsCompanion.insert(
+        startedAt: DateTime(2026, 5, 1),
+      ));
+      await sets.add(ExerciseSetsCompanion.insert(
+        sessionId: laterId,
+        exerciseName: 'Future lift',
+        reps: 5,
+        weight: 80,
+        weightUnit: WeightUnit.kg,
+        status: WorkoutSetStatus.completed,
+        orderIndex: 0,
+      ));
+
+      final result = await sessions.listRangeWithSets(
+        DateTime(2026, 4, 20),
+        DateTime(2026, 4, 27),
+      );
+
+      expect(result.length, 2,
+          reason: 'only sessions in [from, to) — oldId and laterId excluded');
+      expect(result.map((r) => r.session.id), [aId, bId]);
+      // Session A sets: orderIndex ascending (planned first, completed second).
+      expect(result[0].sets.map((s) => s.orderIndex), [0, 1]);
+      expect(result[0].sets.map((s) => s.status),
+          [WorkoutSetStatus.planned, WorkoutSetStatus.completed]);
+      expect(result[1].sets.length, 1);
+    });
+
+    test('returns sessions with no sets as an empty sets list', () async {
+      final id = await sessions.add(WorkoutSessionsCompanion.insert(
+        startedAt: DateTime(2026, 4, 21),
+      ));
+
+      final result = await sessions.listRangeWithSets(
+        DateTime(2026, 4, 20),
+        DateTime(2026, 4, 27),
+      );
+      expect(result.length, 1);
+      expect(result.single.session.id, id);
+      expect(result.single.sets, isEmpty);
+    });
+
+    test('empty window returns empty list', () async {
+      final result = await sessions.listRangeWithSets(
+        DateTime(2026, 4, 20),
+        DateTime(2026, 4, 27),
+      );
+      expect(result, isEmpty);
+    });
+  });
 }

--- a/test/features/progress/progress_data_test.dart
+++ b/test/features/progress/progress_data_test.dart
@@ -18,6 +18,25 @@ FoodEntry _food(DateTime t, int kcal) => FoodEntry(
       note: null,
     );
 
+WorkoutSession _session(int id, DateTime startedAt) => WorkoutSession(
+      id: id,
+      startedAt: startedAt,
+      endedAt: null,
+      note: null,
+    );
+
+ExerciseSet _set(int sessionId, WorkoutSetStatus status, {int order = 0}) =>
+    ExerciseSet(
+      id: sessionId * 100 + order,
+      sessionId: sessionId,
+      exerciseName: 'Bench Press',
+      reps: 8,
+      weight: 80.0,
+      weightUnit: WeightUnit.kg,
+      status: status,
+      orderIndex: order,
+    );
+
 void main() {
   group('resolveWindow', () {
     final now = DateTime(2026, 4, 23, 15, 30); // mid-day
@@ -163,6 +182,143 @@ void main() {
       expect(s.days.single.kcal, 0);
       expect(s.isEmpty, isTrue);
       expect(s.loggedDayCount, 0);
+    });
+  });
+
+  group('buildWeeklyVolumeSeries', () {
+    // Anchor "now" on Thursday 2026-04-23 so the current ISO week starts
+    // Monday 2026-04-20. That makes bucket math easy to eyeball.
+    final now = DateTime(2026, 4, 23, 15, 30);
+
+    test('emits 8 buckets with Monday anchors, oldest first', () {
+      final s = buildWeeklyVolumeSeries(const [], const [], now);
+      expect(s.weekStarts.length, 8);
+      expect(s.completedSets.length, 8);
+      // Current week's Monday is the last bucket.
+      expect(s.weekStarts.last, DateTime(2026, 4, 20));
+      // 7 weeks before that is the first bucket.
+      expect(s.weekStarts.first, DateTime(2026, 3, 2));
+      // Every bucket is a local-midnight Monday. Compare by calendar components
+      // rather than `Duration.inDays` — on DST weeks two consecutive civil
+      // Mondays are only 23 or 25 wall-clock hours apart, so `.inDays` rounds
+      // to 6, not 7. Calendar-day arithmetic is what we care about.
+      for (var i = 0; i < s.weekStarts.length; i++) {
+        final monday = s.weekStarts[i];
+        expect(monday.weekday, DateTime.monday,
+            reason: 'bucket $i must start on a Monday');
+        expect(monday.hour, 0);
+        expect(monday.minute, 0);
+        final expected = DateTime(2026, 4, 20 - 7 * (7 - i));
+        expect(monday, expected, reason: 'bucket $i mismatch');
+      }
+    });
+
+    test('empty input: all weeks zero, isEmpty true', () {
+      final s = buildWeeklyVolumeSeries(const [], const [], now);
+      expect(s.completedSets, everyElement(0));
+      expect(s.isEmpty, isTrue);
+    });
+
+    test('completed sets count, planned and skipped do not — current week', () {
+      // Wednesday 2026-04-22 → inside current week (Monday 4/20).
+      final session = _session(1, DateTime(2026, 4, 22, 18));
+      final sets = [
+        _set(1, WorkoutSetStatus.completed, order: 0),
+        _set(1, WorkoutSetStatus.completed, order: 1),
+        _set(1, WorkoutSetStatus.completed, order: 2),
+        _set(1, WorkoutSetStatus.planned, order: 3),
+        _set(1, WorkoutSetStatus.planned, order: 4),
+        _set(1, WorkoutSetStatus.skipped, order: 5),
+      ];
+      final s = buildWeeklyVolumeSeries(sets, [session], now);
+      expect(s.completedSets.last, 3,
+          reason: 'only 3 completed sets count; planned and skipped excluded');
+      for (var i = 0; i < 7; i++) {
+        expect(s.completedSets[i], 0);
+      }
+      expect(s.isEmpty, isFalse);
+    });
+
+    test('sets across two different weeks bucket into their own weeks', () {
+      // Week of 4/20: 2 completed sets (current week, index 7).
+      final sessionA = _session(1, DateTime(2026, 4, 21, 18));
+      // Week of 4/13: 4 completed sets (prior week, index 6).
+      final sessionB = _session(2, DateTime(2026, 4, 15, 12));
+      final sets = [
+        _set(1, WorkoutSetStatus.completed, order: 0),
+        _set(1, WorkoutSetStatus.completed, order: 1),
+        _set(2, WorkoutSetStatus.completed, order: 0),
+        _set(2, WorkoutSetStatus.completed, order: 1),
+        _set(2, WorkoutSetStatus.completed, order: 2),
+        _set(2, WorkoutSetStatus.completed, order: 3),
+      ];
+      final s = buildWeeklyVolumeSeries(sets, [sessionA, sessionB], now);
+      expect(s.completedSets[7], 2, reason: 'current week');
+      expect(s.completedSets[6], 4, reason: 'prior week');
+      for (var i = 0; i < 6; i++) {
+        expect(s.completedSets[i], 0);
+      }
+    });
+
+    test('all-skipped 8-week window: isEmpty true', () {
+      // One session per week for all 8 weeks, each with only skipped sets.
+      final sessions = <WorkoutSession>[];
+      final sets = <ExerciseSet>[];
+      for (var i = 0; i < 8; i++) {
+        final monday = DateTime(2026, 3, 2 + 7 * i);
+        final session =
+            _session(i + 1, DateTime(monday.year, monday.month, monday.day, 12));
+        sessions.add(session);
+        sets.add(_set(i + 1, WorkoutSetStatus.skipped, order: 0));
+        sets.add(_set(i + 1, WorkoutSetStatus.skipped, order: 1));
+      }
+      final s = buildWeeklyVolumeSeries(sets, sessions, now);
+      expect(s.completedSets, everyElement(0));
+      expect(s.isEmpty, isTrue);
+    });
+
+    test('sessions outside the 8-week window are ignored', () {
+      // 9 weeks back — before windowStart.
+      final oldSession = _session(1, DateTime(2026, 2, 20, 12));
+      final sets = [
+        _set(1, WorkoutSetStatus.completed, order: 0),
+        _set(1, WorkoutSetStatus.completed, order: 1),
+      ];
+      final s = buildWeeklyVolumeSeries(sets, [oldSession], now);
+      expect(s.isEmpty, isTrue,
+          reason: 'sets attached to out-of-window sessions must be ignored');
+    });
+
+    test('orphan sets (session not in list) are ignored', () {
+      final s = buildWeeklyVolumeSeries(
+        [_set(99, WorkoutSetStatus.completed)],
+        const [],
+        now,
+      );
+      expect(s.isEmpty, isTrue);
+    });
+
+    test('session on Monday midnight buckets to that Monday, not previous week',
+        () {
+      final session = _session(1, DateTime(2026, 4, 20));
+      final s = buildWeeklyVolumeSeries(
+        [_set(1, WorkoutSetStatus.completed)],
+        [session],
+        now,
+      );
+      expect(s.completedSets[7], 1);
+      expect(s.completedSets[6], 0);
+    });
+
+    test('session on Sunday 23:59 buckets to the Monday before it', () {
+      final session = _session(1, DateTime(2026, 4, 19, 23, 59));
+      final s = buildWeeklyVolumeSeries(
+        [_set(1, WorkoutSetStatus.completed)],
+        [session],
+        now,
+      );
+      expect(s.completedSets[6], 1, reason: 'prior week (Mon 4/13)');
+      expect(s.completedSets[7], 0);
     });
   });
 }

--- a/test/features/progress/progress_screen_test.dart
+++ b/test/features/progress/progress_screen_test.dart
@@ -7,10 +7,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:liftlog_app/data/database.dart';
 import 'package:liftlog_app/data/enums.dart';
 import 'package:liftlog_app/data/repositories/body_weight_log_repository.dart';
+import 'package:liftlog_app/data/repositories/exercise_set_repository.dart';
 import 'package:liftlog_app/data/repositories/food_entry_repository.dart';
+import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
 import 'package:liftlog_app/features/progress/progress_data.dart';
 import 'package:liftlog_app/features/progress/progress_providers.dart';
 import 'package:liftlog_app/features/progress/progress_screen.dart';
+import 'package:liftlog_app/features/progress/weekly_volume_bars.dart';
 import 'package:liftlog_app/providers/app_providers.dart';
 import 'package:liftlog_app/shell/root_shell.dart';
 
@@ -241,6 +244,80 @@ void main() {
       findsNothing,
     );
     expect(find.text('No calorie data for this window.'), findsNothing);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets(
+      'weekly-volume: empty section copy renders when there are no completed sets',
+      (tester) async {
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    // Dedicated copy for the volume section — distinct from the weight /
+    // kcal empty-state copy and from the combined empty message.
+    expect(
+      find.text('Workouts — completed sets/week (last 8 weeks)'),
+      findsOneWidget,
+    );
+    expect(
+      find.text('No completed sets in the last 8 weeks.'),
+      findsOneWidget,
+    );
+    // Bars must not render when the series is empty.
+    expect(find.byType(WeeklyVolumeBars), findsNothing);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets(
+      'weekly-volume: bars render when there are completed sets, '
+      'planned/skipped excluded', (tester) async {
+    final sessionRepo = WorkoutSessionRepository(db);
+    final setRepo = ExerciseSetRepository(db);
+
+    // Session this current week (Monday 2026-04-20). fakeNow is Thu 4/23.
+    final sessionId = await sessionRepo.add(WorkoutSessionsCompanion.insert(
+      startedAt: DateTime(2026, 4, 22, 18),
+    ));
+    // 3 completed, 2 planned, 1 skipped → only 3 counted.
+    final statuses = [
+      WorkoutSetStatus.completed,
+      WorkoutSetStatus.completed,
+      WorkoutSetStatus.completed,
+      WorkoutSetStatus.planned,
+      WorkoutSetStatus.planned,
+      WorkoutSetStatus.skipped,
+    ];
+    for (var i = 0; i < statuses.length; i++) {
+      await setRepo.add(ExerciseSetsCompanion.insert(
+        sessionId: sessionId,
+        exerciseName: 'Bench Press',
+        reps: 8,
+        weight: 80.0,
+        weightUnit: WeightUnit.kg,
+        status: statuses[i],
+        orderIndex: i,
+      ));
+    }
+
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    expect(find.byType(WeeklyVolumeBars), findsOneWidget);
+    expect(
+      find.text('No completed sets in the last 8 weeks.'),
+      findsNothing,
+    );
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ProgressScreen)),
+    );
+    final volume = await container.read(weeklyVolumeProvider.future);
+    expect(volume.completedSets.length, 8);
+    expect(volume.completedSets.last, 3,
+        reason: 'only completed sets count; planned and skipped excluded');
+    expect(volume.isEmpty, isFalse);
 
     await _drainDriftTimers(tester);
   });

--- a/test/features/progress/weekly_volume_bars_test.dart
+++ b/test/features/progress/weekly_volume_bars_test.dart
@@ -1,0 +1,59 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/features/progress/progress_data.dart';
+import 'package:liftlog_app/features/progress/weekly_volume_bars.dart';
+
+WeeklyVolumeSeries _series(List<int> counts) {
+  // Eight Mondays oldest-first; exact dates don't matter for painter logic.
+  final starts = [for (var i = 0; i < 8; i++) DateTime(2026, 3, 2 + 7 * i)];
+  return WeeklyVolumeSeries(weekStarts: starts, completedSets: counts);
+}
+
+void main() {
+  group('WeeklyVolumeBarsPainter', () {
+    test(
+      'paint() handles empty, all-zero, and mixed-count weeks without throwing',
+      () {
+        final recorder = PictureRecorder();
+        final canvas = Canvas(recorder);
+        const size = Size(300, 140);
+
+        WeeklyVolumeBarsPainter(
+          series: const WeeklyVolumeSeries(weekStarts: [], completedSets: []),
+          color: Colors.blue,
+        ).paint(canvas, size);
+
+        WeeklyVolumeBarsPainter(
+          series: _series(const [0, 0, 0, 0, 0, 0, 0, 0]),
+          color: Colors.blue,
+        ).paint(canvas, size);
+
+        WeeklyVolumeBarsPainter(
+          series: _series(const [2, 0, 5, 3, 0, 12, 8, 10]),
+          color: Colors.blue,
+        ).paint(canvas, size);
+
+        recorder.endRecording();
+      },
+    );
+
+    test('shouldRepaint reflects series / color changes', () {
+      final s = _series(const [3, 4, 5, 6, 7, 8, 9, 10]);
+      final a = WeeklyVolumeBarsPainter(series: s, color: Colors.blue);
+      final sameRef = WeeklyVolumeBarsPainter(series: s, color: Colors.blue);
+      expect(a.shouldRepaint(sameRef), isFalse);
+
+      final other = WeeklyVolumeBarsPainter(
+        series: _series(const [0, 0, 0, 0, 0, 0, 0, 1]),
+        color: Colors.blue,
+      );
+      expect(a.shouldRepaint(other), isTrue);
+
+      final otherColor = WeeklyVolumeBarsPainter(series: s, color: Colors.red);
+      expect(a.shouldRepaint(otherColor), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a 3rd section to the Progress tab: weekly completed-set volume over the trailing 8 ISO weeks. Independent of the 7d / 30d / all selector.
- New `WorkoutSessionRepository.listRangeWithSets(from, to)` — two-query implementation (sessions in range, then sets by sessionId) rather than a SQL join. Simpler to type and fine at single-user scale.
- `WeeklyVolumeSeries` + `buildWeeklyVolumeSeries` aggregator: exhaustive switch over `WorkoutSetStatus`; only `completed` counts, `planned` and `skipped` explicitly excluded.
- Pre-built Monday→index map for bucketing (not `Duration.inDays` — spring-forward weeks were dropping to 6 days in a test).
- New `WeeklyVolumeBars` painter matching the kcal bars style (140 height, no axes).

## AC coverage (from #24)
- [x] #1 `WorkoutSetStatus` enumerated exhaustively in the filter with inline comment.
- [x] #2 Aggregator unit tests: 3c + 2p + 1s → 3; two-week split; all-skipped window → `isEmpty`; plus several boundary cases (Monday midnight, Sunday 23:59, out-of-window session, orphan sets).
- [x] #3 Provider builds from repo; widget test asserts bars render.
- [x] #4 Empty-state copy "No completed sets in the last 8 weeks." renders when `isEmpty`.
- [x] #5 Arch test still green.
- [x] #6 `flutter analyze` clean (1 pre-existing warning, not from this PR); 95 tests green.
- [x] #7 No new pub deps.

## Data-layer choice
Went with Option A (`WorkoutSessionRepository.listRangeWithSets`) over a standalone `ExerciseSetRepository.listRangeBySessionStart`. The aggregator signature takes `(sets, sessions, now)`, so keeping sets co-located with their parent session matches the data flow. Implementation is two queries (not a SQL join): fetch sessions, then `WHERE sessionId IN (...)` on sets. Cheaper to read than assembling a drift `join`, and SQLite makes this trivially fast for single-user data.

## DST surprise
Initial implementation used `.difference(...).inDays ~/ 7` to map a session's Monday to a bucket index. Test hit a case where two consecutive civil Mondays spanned spring-forward (EU 2026-03-29): `.inDays` returned 6, and the bucket index was off by one. Fixed by pre-building a `Map<DateTime, int>` from the 8 Mondays and looking up directly — no difference math needed. Added a test comment so the next person doesn't re-introduce this.

## Test plan
- [ ] Run `flutter test` — expect 95 pass.
- [ ] Run `flutter analyze` — expect clean (one pre-existing warning unrelated to this PR).
- [ ] Sanity-check on iPhone 15 Simulator: 3rd section renders below kcal bars with the correct label and either bars or empty copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)