### PR TITLE
#32 — Recent-foods quick-add

### DIFF
--- a/lib/data/repositories/food_entry_repository.dart
+++ b/lib/data/repositories/food_entry_repository.dart
@@ -41,15 +41,13 @@ class FoodEntryRepository {
   Future<int> delete(int id) =>
       (_db.delete(_db.foodEntries)..where((t) => t.id.equals(id))).go();
 
-  Stream<List<FoodEntry>> watchAll() =>
-      (_db.select(_db.foodEntries)
-            ..orderBy([(t) => OrderingTerm.desc(t.timestamp)]))
-          .watch();
+  Stream<List<FoodEntry>> watchAll() => (_db.select(
+    _db.foodEntries,
+  )..orderBy([(t) => OrderingTerm.desc(t.timestamp)])).watch();
 
-  Future<List<FoodEntry>> listAll() =>
-      (_db.select(_db.foodEntries)
-            ..orderBy([(t) => OrderingTerm.desc(t.timestamp)]))
-          .get();
+  Future<List<FoodEntry>> listAll() => (_db.select(
+    _db.foodEntries,
+  )..orderBy([(t) => OrderingTerm.desc(t.timestamp)])).get();
 
   Stream<List<FoodEntry>> watchByDate(DateTime day) {
     final range = DayRange(day);
@@ -71,9 +69,11 @@ class FoodEntryRepository {
   /// to exclusive), ordered by timestamp descending.
   Future<List<FoodEntry>> listRange(DateTime from, DateTime to) =>
       (_db.select(_db.foodEntries)
-            ..where((t) =>
-                t.timestamp.isBiggerOrEqualValue(from) &
-                t.timestamp.isSmallerThanValue(to))
+            ..where(
+              (t) =>
+                  t.timestamp.isBiggerOrEqualValue(from) &
+                  t.timestamp.isSmallerThanValue(to),
+            )
             ..orderBy([(t) => OrderingTerm.desc(t.timestamp)]))
           .get();
 
@@ -100,6 +100,46 @@ class FoodEntryRepository {
     return DailyTotals(kcal: kcal, proteinG: protein);
   }
 
+  /// Returns the most recent distinct-by-name entries, newest first.
+  ///
+  /// Used by the Food tab's recent-foods quick-add strip. "Distinct" means
+  /// we keep only the newest entry per `name`; older rows with the same
+  /// name are collapsed away. `limit` caps the result length after
+  /// collapsing, so callers get a stable number of chips regardless of how
+  /// many duplicate rows exist upstream.
+  ///
+  /// The implementation is deliberately simple: pull every entry ordered
+  /// by timestamp descending, then group-by-name in Dart. A window-function
+  /// SQL variant would be faster at large row counts but isn't warranted
+  /// today.
+  Stream<List<FoodEntry>> watchRecentDistinctNames({int limit = 10}) {
+    return (_db.select(_db.foodEntries)
+          ..orderBy([(t) => OrderingTerm.desc(t.timestamp)]))
+        .watch()
+        .map((entries) => _collapseByName(entries, limit));
+  }
+
+  Future<List<FoodEntry>> listRecentDistinctNames({int limit = 10}) async {
+    final entries = await (_db.select(
+      _db.foodEntries,
+    )..orderBy([(t) => OrderingTerm.desc(t.timestamp)])).get();
+    return _collapseByName(entries, limit);
+  }
+
+  /// Collapses [entries] (already newest-first) to the first hit per `name`,
+  /// then caps at [limit]. Empty names are kept as a single bucket — matches
+  /// how the food form treats them elsewhere.
+  List<FoodEntry> _collapseByName(List<FoodEntry> entries, int limit) {
+    final seen = <String>{};
+    final out = <FoodEntry>[];
+    for (final e in entries) {
+      if (!seen.add(e.name)) continue;
+      out.add(e);
+      if (out.length >= limit) break;
+    }
+    return out;
+  }
+
   Stream<List<DailySummary>> watchDailySummaries() {
     return (_db.select(_db.foodEntries)
           ..orderBy([(t) => OrderingTerm.desc(t.timestamp)]))
@@ -108,16 +148,20 @@ class FoodEntryRepository {
   }
 
   Future<List<DailySummary>> listDailySummaries() async {
-    final entries = await (_db.select(_db.foodEntries)
-          ..orderBy([(t) => OrderingTerm.desc(t.timestamp)]))
-        .get();
+    final entries = await (_db.select(
+      _db.foodEntries,
+    )..orderBy([(t) => OrderingTerm.desc(t.timestamp)])).get();
     return _summarize(entries);
   }
 
   List<DailySummary> _summarize(List<FoodEntry> entries) {
     final buckets = <DateTime, List<FoodEntry>>{};
     for (final e in entries) {
-      final day = DateTime(e.timestamp.year, e.timestamp.month, e.timestamp.day);
+      final day = DateTime(
+        e.timestamp.year,
+        e.timestamp.month,
+        e.timestamp.day,
+      );
       buckets.putIfAbsent(day, () => []).add(e);
     }
     final summaries = buckets.entries.map((b) {
@@ -128,8 +172,7 @@ class FoodEntryRepository {
         protein += e.proteinG;
       }
       return DailySummary(day: b.key, kcal: kcal, proteinG: protein);
-    }).toList()
-      ..sort((a, b) => b.day.compareTo(a.day));
+    }).toList()..sort((a, b) => b.day.compareTo(a.day));
     return summaries;
   }
 }

--- a/lib/features/food/food_log_screen.dart
+++ b/lib/features/food/food_log_screen.dart
@@ -9,6 +9,7 @@ import 'date_label.dart';
 import 'estimate_badge.dart';
 import 'food_entry_form_screen.dart';
 import 'food_providers.dart';
+import 'recent_foods_strip.dart';
 
 class FoodLogScreen extends ConsumerWidget {
   const FoodLogScreen({super.key});
@@ -19,9 +20,7 @@ class FoodLogScreen extends ConsumerWidget {
     final totals = ref.watch(todayTotalsProvider);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('LiftLog'),
-      ),
+      appBar: AppBar(title: const Text('LiftLog')),
       floatingActionButton: FloatingActionButton(
         onPressed: () => _openForm(context),
         child: const Icon(Icons.add),
@@ -30,6 +29,7 @@ class FoodLogScreen extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           _TotalsHeader(totals: totals),
+          const RecentFoodsStrip(),
           const Divider(height: 1),
           Expanded(
             child: entries.when(
@@ -69,9 +69,9 @@ class FoodLogScreen extends ConsumerWidget {
   }
 
   void _openForm(BuildContext context, {FoodEntry? entry}) {
-    Navigator.of(context).push(MaterialPageRoute(
-      builder: (_) => FoodEntryFormScreen(entry: entry),
-    ));
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => FoodEntryFormScreen(entry: entry)),
+    );
   }
 }
 
@@ -117,10 +117,12 @@ class _Metric extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Column(children: [
-      Text(value, style: theme.textTheme.headlineMedium),
-      Text(label, style: theme.textTheme.titleMedium),
-    ]);
+    return Column(
+      children: [
+        Text(value, style: theme.textTheme.headlineMedium),
+        Text(label, style: theme.textTheme.titleMedium),
+      ],
+    );
   }
 }
 

--- a/lib/features/food/food_providers.dart
+++ b/lib/features/food/food_providers.dart
@@ -13,3 +13,12 @@ final todayTotalsProvider = StreamProvider<DailyTotals>((ref) {
   final repo = ref.watch(foodEntryRepositoryProvider);
   return repo.watchDailyTotals(DateTime.now());
 });
+
+/// Feeds the Food tab's recent-foods quick-add strip. Streams the newest
+/// distinct-by-name entries across all days (not just today) so the chip
+/// strip stays populated even on a fresh morning. See
+/// `FoodEntryRepository.watchRecentDistinctNames` for the collapse rule.
+final recentFoodsProvider = StreamProvider<List<FoodEntry>>((ref) {
+  final repo = ref.watch(foodEntryRepositoryProvider);
+  return repo.watchRecentDistinctNames();
+});

--- a/lib/features/food/recent_foods_strip.dart
+++ b/lib/features/food/recent_foods_strip.dart
@@ -1,0 +1,101 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/database.dart';
+import '../../providers/app_providers.dart';
+import '../../ui/formatters.dart';
+import '../../ui/show_save_error.dart';
+import 'food_providers.dart';
+
+/// Horizontal strip of one-tap re-log chips shown above the food log list.
+///
+/// Each chip represents the most recent distinct-named food the user has
+/// logged. Tapping inserts a new row that clones the template's
+/// `name`/`kcal`/`proteinG`/`mealType`/`entryType` with a fresh `timestamp`
+/// of `DateTime.now()`. `note` is deliberately not copied — notes are
+/// per-occasion, not per-food.
+///
+/// When there is nothing to show, the strip collapses to `SizedBox.shrink()`
+/// so it reserves zero vertical space.
+class RecentFoodsStrip extends ConsumerWidget {
+  const RecentFoodsStrip({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final recent = ref.watch(recentFoodsProvider);
+    return recent.when(
+      data: (entries) {
+        if (entries.isEmpty) return const SizedBox.shrink();
+        return SizedBox(
+          height: 56,
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+            child: Row(
+              children: [
+                for (final e in entries) ...[
+                  _RecentFoodChip(template: e),
+                  const SizedBox(width: 8),
+                ],
+              ],
+            ),
+          ),
+        );
+      },
+      // Keep the space collapsed while loading / on error — the rest of
+      // the log screen is already the source of truth for entries. A
+      // chip-strip error must not mask the main list.
+      loading: () => const SizedBox.shrink(),
+      error: (_, _) => const SizedBox.shrink(),
+    );
+  }
+}
+
+class _RecentFoodChip extends ConsumerWidget {
+  const _RecentFoodChip({required this.template});
+
+  final FoodEntry template;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final label =
+        '${template.name.isEmpty ? "(unnamed)" : template.name}'
+        ' · ${formatKcal(template.kcal)} kcal';
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 180),
+      child: ActionChip(
+        label: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
+        onPressed: () => _relog(context, ref),
+      ),
+    );
+  }
+
+  Future<void> _relog(BuildContext context, WidgetRef ref) async {
+    final repo = ref.read(foodEntryRepositoryProvider);
+    try {
+      // Clone the template. `entryType` is copied from the template — a
+      // re-log of an `estimate` stays an estimate. We intentionally do NOT
+      // copy `note`; notes are per-occasion and would be misleading on a
+      // one-tap re-log.
+      await repo.add(
+        FoodEntriesCompanion.insert(
+          timestamp: DateTime.now(),
+          name: Value(template.name),
+          kcal: template.kcal,
+          proteinG: template.proteinG,
+          mealType: template.mealType,
+          entryType: template.entryType,
+        ),
+      );
+      if (!context.mounted) return;
+      showSaveSuccess(
+        context,
+        'Added ${template.name} (${formatKcal(template.kcal)} kcal)',
+      );
+    } catch (e) {
+      if (!context.mounted) return;
+      showSaveError(context, 'add entry', e);
+    }
+  }
+}

--- a/lib/ui/show_save_error.dart
+++ b/lib/ui/show_save_error.dart
@@ -9,7 +9,20 @@ import 'package:flutter/material.dart';
 /// Trust rule: persistence failures must surface to the UI — no silent
 /// fallbacks (see `CLAUDE.md`). This helper is the surfacing mechanism.
 void showSaveError(BuildContext context, String operation, Object error) {
+  ScaffoldMessenger.of(
+    context,
+  ).showSnackBar(SnackBar(content: Text('Could not $operation: $error')));
+}
+
+/// Standardized success SnackBar for quick, non-destructive actions.
+///
+/// Neutral visual (no success-green tint — we use the default SnackBar
+/// styling so the signal stays calm) and a short 2-second duration so it
+/// doesn't linger over the main content. No action button: success paths
+/// that need an undo must wire one up explicitly — this helper is for the
+/// "done, you can keep going" case.
+void showSaveSuccess(BuildContext context, String message) {
   ScaffoldMessenger.of(context).showSnackBar(
-    SnackBar(content: Text('Could not $operation: $error')),
+    SnackBar(content: Text(message), duration: const Duration(seconds: 2)),
   );
 }

--- a/test/features/food/recent_foods_test.dart
+++ b/test/features/food/recent_foods_test.dart
@@ -1,0 +1,209 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/data/repositories/food_entry_repository.dart';
+import 'package:liftlog_app/features/food/food_log_screen.dart';
+import 'package:liftlog_app/providers/app_providers.dart';
+
+void main() {
+  late AppDatabase db;
+  late FoodEntryRepository repo;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = FoodEntryRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  Widget app() => ProviderScope(
+    overrides: [appDatabaseProvider.overrideWithValue(db)],
+    child: const MaterialApp(home: FoodLogScreen()),
+  );
+
+  Future<int> add({
+    required DateTime timestamp,
+    required String name,
+    required int kcal,
+    double proteinG = 10.0,
+    MealType mealType = MealType.breakfast,
+    FoodEntryType entryType = FoodEntryType.manual,
+  }) {
+    return repo.add(
+      FoodEntriesCompanion.insert(
+        timestamp: timestamp,
+        name: Value(name),
+        kcal: kcal,
+        proteinG: proteinG,
+        mealType: mealType,
+        entryType: entryType,
+      ),
+    );
+  }
+
+  group('listRecentDistinctNames', () {
+    test('collapses duplicates keeping newest per name', () async {
+      // Three Eggs rows; the newest one wins.
+      await add(timestamp: DateTime(2026, 4, 20, 8), name: 'Eggs', kcal: 120);
+      await add(timestamp: DateTime(2026, 4, 21, 8), name: 'Eggs', kcal: 130);
+      await add(timestamp: DateTime(2026, 4, 22, 8), name: 'Eggs', kcal: 140);
+      await add(
+        timestamp: DateTime(2026, 4, 19, 12),
+        name: 'Chicken',
+        kcal: 310,
+      );
+
+      final recent = await repo.listRecentDistinctNames();
+      expect(recent.map((e) => e.name), ['Eggs', 'Chicken']);
+      // Newest Eggs wins (140 kcal, 2026-04-22).
+      expect(recent.first.kcal, 140);
+      expect(recent.first.timestamp, DateTime(2026, 4, 22, 8));
+    });
+
+    test('respects the limit', () async {
+      for (var i = 0; i < 15; i++) {
+        await add(
+          timestamp: DateTime(2026, 4, 23, 8, i),
+          name: 'Food $i',
+          kcal: 100 + i,
+        );
+      }
+      final recent = await repo.listRecentDistinctNames(limit: 5);
+      expect(recent, hasLength(5));
+      // Newest-first ordering — highest minute index sorted top.
+      expect(recent.first.name, 'Food 14');
+    });
+
+    test('newest-first ordering holds for distinct names', () async {
+      await add(timestamp: DateTime(2026, 4, 22, 8), name: 'Oats', kcal: 300);
+      await add(timestamp: DateTime(2026, 4, 23, 9), name: 'Banana', kcal: 90);
+      await add(timestamp: DateTime(2026, 4, 23, 12), name: 'Salad', kcal: 200);
+
+      final recent = await repo.listRecentDistinctNames();
+      expect(recent.map((e) => e.name), ['Salad', 'Banana', 'Oats']);
+    });
+  });
+
+  group('FoodLogScreen recent-foods strip', () {
+    testWidgets('renders distinct chips in newest-first order', (tester) async {
+      await add(
+        timestamp: DateTime.now().subtract(const Duration(days: 3)),
+        name: 'Eggs',
+        kcal: 140,
+      );
+      // Duplicate Eggs — collapsed away.
+      await add(
+        timestamp: DateTime.now().subtract(const Duration(days: 2)),
+        name: 'Eggs',
+        kcal: 150,
+      );
+      await add(
+        timestamp: DateTime.now().subtract(const Duration(days: 1)),
+        name: 'Chicken',
+        kcal: 310,
+      );
+
+      await tester.pumpWidget(app());
+      await tester.pumpAndSettle();
+
+      // Chicken first (newest), then the latest-Eggs label (150 kcal).
+      expect(find.text('Chicken · 310 kcal'), findsOneWidget);
+      expect(find.text('Eggs · 150 kcal'), findsOneWidget);
+      expect(find.text('Eggs · 140 kcal'), findsNothing);
+
+      await _drainDriftTimers(tester);
+    });
+
+    testWidgets('empty state: strip renders nothing when there are no rows', (
+      tester,
+    ) async {
+      await tester.pumpWidget(app());
+      await tester.pumpAndSettle();
+
+      // No action chips at all — the strip collapses to SizedBox.shrink()
+      // so it reserves zero vertical space.
+      expect(find.byType(ActionChip), findsNothing);
+
+      await _drainDriftTimers(tester);
+    });
+
+    testWidgets(
+      'tapping a chip inserts a new row and shows the success snackbar',
+      (tester) async {
+        await add(
+          timestamp: DateTime.now().subtract(const Duration(days: 1)),
+          name: 'Eggs',
+          kcal: 140,
+          proteinG: 12.0,
+        );
+
+        await tester.pumpWidget(app());
+        await tester.pumpAndSettle();
+
+        expect(await repo.listAll(), hasLength(1));
+
+        await tester.tap(find.text('Eggs · 140 kcal'));
+        await tester.pump();
+
+        final after = await repo.listAll();
+        expect(after, hasLength(2));
+        // The newest row is the re-log; timestamp is fresh, but name/kcal/protein
+        // match the template.
+        final newest = after.first;
+        expect(newest.name, 'Eggs');
+        expect(newest.kcal, 140);
+        expect(newest.proteinG, 12.0);
+        expect(newest.entryType, FoodEntryType.manual);
+
+        // Settle the snackbar animation and confirm its text.
+        await tester.pump(const Duration(milliseconds: 500));
+        expect(find.text('Added Eggs (140 kcal)'), findsOneWidget);
+
+        await _drainDriftTimers(tester);
+      },
+    );
+
+    testWidgets('re-log clones entryType (estimate stays estimate)', (
+      tester,
+    ) async {
+      await add(
+        timestamp: DateTime.now().subtract(const Duration(days: 1)),
+        name: 'Guess Bowl',
+        kcal: 500,
+        proteinG: 25.0,
+        mealType: MealType.dinner,
+        entryType: FoodEntryType.estimate,
+      );
+
+      await tester.pumpWidget(app());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Guess Bowl · 500 kcal'));
+      await tester.pump();
+
+      final after = await repo.listAll();
+      expect(after, hasLength(2));
+      // Both rows — original and re-log — carry the estimate type.
+      expect(
+        after.every((e) => e.entryType == FoodEntryType.estimate),
+        isTrue,
+        reason: 'entryType must be cloned from the template, not hardcoded',
+      );
+
+      await _drainDriftTimers(tester);
+    });
+  });
+}
+
+/// Drift schedules a zero-duration Timer when its stream is cancelled on
+/// dispose. Advance fake_async's clock so the Timer fires before the
+/// framework's post-test !timersPending invariant check runs.
+Future<void> _drainDriftTimers(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox());
+  await tester.pump(const Duration(milliseconds: 1));
+}


### PR DESCRIPTION
## Summary
- Adds a horizontal chip strip on the Food tab that surfaces the most recently logged distinct foods; one tap clones the template as a new entry with a fresh timestamp.
- Data layer: new `watchRecentDistinctNames` / `listRecentDistinctNames` on `FoodEntryRepository` — pulls every row newest-first and collapses in Dart to the first hit per `name`, capped at `limit` (default 10).
- UI layer: `RecentFoodsStrip` renders between `_TotalsHeader` and the `Divider`; collapses to `SizedBox.shrink()` when empty so it reserves zero vertical space. Re-log clones `entryType` (an estimate stays an estimate — no silent promotion). `note` is intentionally not copied (per-occasion).
- `showSaveSuccess` added to `ui/show_save_error.dart` — neutral styling, 2s duration, no undo. Failures still surface through `showSaveError`.

## Decisions (noted per agent spec)
- Simple group-by-name in Dart, not a SQL window function. Fits row counts today; follow-up if growth warrants.
- 180pt max chip width with ellipsis — keeps long food names from producing giant chips.
- Re-log does NOT copy `note`: notes are per-occasion and would be misleading on a one-tap re-log.
- Recent strip sources from ALL days (not just today) so the strip stays populated on a fresh morning.

## AC coverage
1. Repo method collapses duplicates to newest, caps at `limit`, newest-first — covered by aggregator tests.
2. Strip renders exactly the distinct names in order; empty = nothing rendered — widget test.
3. Tap inserts a new row (+1) and shows a verified SnackBar — widget test.
4. `entryType` cloned from template (estimate stays estimate) — widget test.
5. Arch test still green.
6. `flutter analyze`: clean. `flutter test`: 102 passing.

## Test plan
- [x] `flutter analyze` — clean.
- [x] `flutter test` — 102 pass.
- [ ] Manual: open Food tab on iPhone 15 Simulator, confirm strip above list.

No new pub deps. No schema change. iOS only.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>