### PR TITLE
#34 — Progress summary card

### DIFF
--- a/lib/features/progress/progress_data.dart
+++ b/lib/features/progress/progress_data.dart
@@ -82,6 +82,31 @@ class KcalSeries {
 /// bucketing stays testable without touching [DateTime.now].
 DateTime _dayOf(DateTime t) => DateTime(t.year, t.month, t.day);
 
+/// Number of calendar days in the `[from, to)` window. `from` is inclusive,
+/// `to` is exclusive; both are truncated to local-midnight before the count
+/// so a partial day on either end still counts as 1.
+///
+/// We walk by calendar-day increments (`DateTime(y, m, d + 1)`) rather than
+/// dividing `Duration.inDays` — on DST transition days two consecutive civil
+/// midnights are 23 or 25 wall-clock hours apart, and `.inDays` rounds the
+/// short direction. Calendar-day arithmetic is the only way to stay exact.
+///
+/// Used as the denominator for the Progress summary's averages: dividing by
+/// the number of calendar days in the window (not the number of logged days)
+/// is the "seven-day average" a user expects, even with gaps.
+int calendarDaysInWindow({required DateTime from, required DateTime to}) {
+  final start = _dayOf(from);
+  final end = _dayOf(to);
+  if (!start.isBefore(end)) return 0;
+  var count = 0;
+  var cursor = start;
+  while (cursor.isBefore(end)) {
+    count += 1;
+    cursor = DateTime(cursor.year, cursor.month, cursor.day + 1);
+  }
+  return count;
+}
+
 /// Returns the local-midnight Monday of the ISO week that [t] falls in.
 /// [DateTime.weekday] is `1` for Monday through `7` for Sunday, so subtracting
 /// `(weekday - 1)` civil days always lands on that week's Monday. Calendar
@@ -274,4 +299,132 @@ WeeklyVolumeSeries buildWeeklyVolumeSeries(
   }
 
   return WeeklyVolumeSeries(weekStarts: weekStarts, completedSets: counts);
+}
+
+/// The at-a-glance summary rendered above the window selector on the
+/// Progress tab. Every field is nullable because the card shows an em-dash
+/// for any metric that can't be computed honestly (no data, mixed units,
+/// etc) — the alternative would be to fabricate a `0` that reads as "logged
+/// zero", and that's a trust-rule violation.
+///
+/// Nullability rules (deliberately encoded in the aggregator so the widget
+/// stays dumb):
+/// - [avgKcalPerDay], [avgProteinGPerDay]: `null` when the window contains
+///   zero calendar days (shouldn't happen in practice) or when there are no
+///   food entries at all in the `all`-window case (no anchor for the day
+///   count). Otherwise we divide total kcal / protein by the number of
+///   *calendar* days in the window — not the count of logged days — so a
+///   user with 2 logged days in a 7-day window sees `total / 7`, which is
+///   the "average day" number they expect.
+/// - [weightDelta]: `null` when the weight series has fewer than 2 points
+///   in the dominant unit, OR when the window has mixed units. We never
+///   display a delta that crosses a unit boundary (no silent conversion).
+/// - [weightDeltaUnit]: null iff [weightDelta] is null.
+/// - [sessionsCompleted]: `0` is a valid value — never null. A window with
+///   no finished sessions renders "0 completed", not an em-dash, because
+///   that count *is* meaningful: it means "you finished nothing in this
+///   window", which is the honest read.
+class ProgressSummary {
+  const ProgressSummary({
+    required this.avgKcalPerDay,
+    required this.avgProteinGPerDay,
+    required this.weightDelta,
+    required this.weightDeltaUnit,
+    required this.sessionsCompleted,
+  });
+
+  final int? avgKcalPerDay;
+  final double? avgProteinGPerDay;
+  final double? weightDelta;
+  final WeightUnit? weightDeltaUnit;
+  final int sessionsCompleted;
+}
+
+/// Builds a [ProgressSummary] for the `[from, to)` window.
+///
+/// Inputs are already-filtered lists from the repositories (so this stays
+/// pure-Dart and trivially unit-testable). The caller is responsible for
+/// passing lists filtered to the window — we don't re-filter here, to keep
+/// a single source of truth for the window math.
+///
+/// `weightSeries` carries `mixedUnits` and `dominantUnit`; both decisions
+/// about the delta flow through it. When `mixedUnits == true`, the delta
+/// is `null` even if the filtered series has 2+ points, because mixing
+/// units across a single metric is exactly what the trust rule forbids.
+ProgressSummary buildProgressSummary({
+  required List<FoodEntry> foods,
+  required WeightSeries weightSeries,
+  required List<({WorkoutSession session, List<ExerciseSet> sets})> sessionsWithSets,
+  required DateTime from,
+  required DateTime to,
+}) {
+  // --- Averages: divide by *calendar* days, not logged days. ---
+  // If there are no food entries in the window we render em-dashes rather
+  // than "0 kcal/day": a synthesized zero would read as "you logged zero",
+  // which is a different claim than "nothing to average". Trust rule:
+  // empty data must surface as em-dash, never as a fabricated number.
+  //
+  // For bounded windows the denominator is the number of calendar days in
+  // the window. For the all-window (from == epoch-0), the denominator is
+  // the number of calendar days between the oldest entry's day and `to` —
+  // otherwise we'd divide by thousands of empty days back to 1970.
+  int? avgKcal;
+  double? avgProtein;
+  if (foods.isNotEmpty) {
+    final DateTime effectiveFrom;
+    if (from.millisecondsSinceEpoch <= 0) {
+      final oldest =
+          foods.map((e) => e.timestamp).reduce((a, b) => a.isBefore(b) ? a : b);
+      effectiveFrom = _dayOf(oldest);
+    } else {
+      effectiveFrom = from;
+    }
+    final days = calendarDaysInWindow(from: effectiveFrom, to: to);
+    if (days > 0) {
+      var totalKcal = 0;
+      var totalProtein = 0.0;
+      for (final e in foods) {
+        totalKcal += e.kcal;
+        totalProtein += e.proteinG;
+      }
+      avgKcal = (totalKcal / days).round();
+      avgProtein = totalProtein / days;
+    }
+  }
+
+  // --- Weight delta: last - first, only in dominant unit. ---
+  // Trust rule: never synthesize a delta that crosses kg↔lb. Both the
+  // `mixedUnits == true` case and the `<2 points` case resolve to null,
+  // and both are covered by dedicated unit tests.
+  double? weightDelta;
+  WeightUnit? weightDeltaUnit;
+  if (!weightSeries.mixedUnits &&
+      weightSeries.points.length >= 2 &&
+      weightSeries.dominantUnit != null) {
+    final first = weightSeries.points.first.value;
+    final last = weightSeries.points.last.value;
+    weightDelta = last - first;
+    weightDeltaUnit = weightSeries.dominantUnit;
+  }
+
+  // --- Sessions completed in window. ---
+  // "Completed" means `endedAt != null` — an in-progress session doesn't
+  // count toward a window's completion metric. Window membership is by
+  // `startedAt`, matching how every other range filter in this file works.
+  var sessionsCompleted = 0;
+  for (final g in sessionsWithSets) {
+    final s = g.session;
+    if (s.endedAt == null) continue;
+    if (s.startedAt.isBefore(from)) continue;
+    if (!s.startedAt.isBefore(to)) continue;
+    sessionsCompleted += 1;
+  }
+
+  return ProgressSummary(
+    avgKcalPerDay: avgKcal,
+    avgProteinGPerDay: avgProtein,
+    weightDelta: weightDelta,
+    weightDeltaUnit: weightDeltaUnit,
+    sessionsCompleted: sessionsCompleted,
+  );
 }

--- a/lib/features/progress/progress_providers.dart
+++ b/lib/features/progress/progress_providers.dart
@@ -35,6 +35,36 @@ final kcalSeriesProvider = FutureProvider<KcalSeries>((ref) async {
   return buildKcalSeries(entries, from: range.from, to: range.to);
 });
 
+/// Summary metrics rendered in the card above the window selector. Reads
+/// the same `[from, to)` range as [weightSeriesProvider] / [kcalSeriesProvider]
+/// so the four tiles and the charts below are always in sync.
+///
+/// We re-`await` the weight series here instead of calling
+/// `buildWeightSeries` a second time because Riverpod's dependency graph
+/// handles the caching — when the window changes, both providers re-run
+/// once, not twice. Sessions come via `listRangeWithSets` so the aggregator
+/// can count completed sessions without the UI touching Drift directly.
+final progressSummaryProvider = FutureProvider<ProgressSummary>((ref) async {
+  final window = ref.watch(progressWindowProvider);
+  final now = ref.watch(progressNowProvider);
+  final range = resolveWindow(window, now: now);
+
+  final foodRepo = ref.watch(foodEntryRepositoryProvider);
+  final sessionRepo = ref.watch(workoutSessionRepositoryProvider);
+
+  final foods = await foodRepo.listRange(range.from, range.to);
+  final weightSeries = await ref.watch(weightSeriesProvider.future);
+  final sessionsWithSets = await sessionRepo.listRangeWithSets(range.from, range.to);
+
+  return buildProgressSummary(
+    foods: foods,
+    weightSeries: weightSeries,
+    sessionsWithSets: sessionsWithSets,
+    from: range.from,
+    to: range.to,
+  );
+});
+
 /// Weekly completed-set volume for the trailing 8 ISO weeks. Independent of
 /// the 7d / 30d / all selector — the brief fixes this section at 8 weeks.
 /// Uses the one-shot `listRangeWithSets` repository method (not `watch*`) so

--- a/lib/features/progress/progress_screen.dart
+++ b/lib/features/progress/progress_screen.dart
@@ -5,6 +5,7 @@ import '../../ui/labels.dart';
 import 'kcal_bars.dart';
 import 'progress_data.dart';
 import 'progress_providers.dart';
+import 'summary_card.dart';
 import 'weekly_volume_bars.dart';
 import 'weight_sparkline.dart';
 
@@ -26,8 +27,11 @@ class ProgressScreen extends ConsumerWidget {
       body: ListView(
         padding: const EdgeInsets.only(bottom: 24),
         children: [
+          // Order: summary card (headline) → window selector (re-slice) →
+          // charts (deep-dive). Rationale in the issue (#34).
+          const SummaryCard(),
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
             child: SizedBox(
               width: double.infinity,
               child: SegmentedButton<ProgressWindow>(

--- a/lib/features/progress/summary_card.dart
+++ b/lib/features/progress/summary_card.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/enums.dart';
+import '../../ui/formatters.dart';
+import 'progress_data.dart';
+import 'progress_providers.dart';
+
+/// Summary card above the window selector on the Progress tab. Renders four
+/// metrics in a 2×2 grid: average kcal/day, average protein/day, weight
+/// delta, and sessions completed in the window.
+///
+/// Layout: we use [Wrap] with a fixed-width [_MetricTile] rather than a
+/// [GridView] so that at the iPhone 15 viewport (393pt logical width minus
+/// two 16pt margins = 361pt usable) the tiles always fit as 2×2 with ~180pt
+/// each, but the layout degrades gracefully to 1-per-row on any narrower
+/// surface without a hard break. [GridView] would need a nested
+/// `shrinkWrap` + `physics: NeverScrollable...` to coexist with the outer
+/// `ListView` — [Wrap] sidesteps that complexity.
+///
+/// Trust rule: every metric that can't be computed honestly (mixed units,
+/// no entries, etc) renders as an em-dash (`—`, U+2014), never as `0`. The
+/// aggregator in [buildProgressSummary] returns null for those cases; this
+/// widget just renders the null.
+class SummaryCard extends ConsumerWidget {
+  const SummaryCard({super.key});
+
+  /// Fixed tile width. 2 × 170 + 16pt inter-tile gap = 356pt, which fits
+  /// inside the ~361pt usable width on iPhone 15 portrait and leaves enough
+  /// room for headline-sized numbers without mid-value truncation. Long
+  /// values (e.g. `-99.9 kg`) fit on a single line; overflow falls back to
+  /// ellipsis via the tile's Text widgets.
+  static const double _tileWidth = 170;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(progressSummaryProvider);
+    return Card(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: async.when(
+          data: (s) => _grid(s),
+          loading: () => const SizedBox(
+            height: 140,
+            child: Center(child: CircularProgressIndicator()),
+          ),
+          error: (err, _) => Text('Summary unavailable: $err'),
+        ),
+      ),
+    );
+  }
+
+  Widget _grid(ProgressSummary s) {
+    return Wrap(
+      direction: Axis.horizontal,
+      spacing: 16,
+      runSpacing: 16,
+      children: [
+        _MetricTile(
+          width: _tileWidth,
+          label: 'Avg kcal / day',
+          value: s.avgKcalPerDay == null ? null : formatKcal(s.avgKcalPerDay!),
+        ),
+        _MetricTile(
+          width: _tileWidth,
+          label: 'Avg protein / day',
+          value: s.avgProteinGPerDay == null
+              ? null
+              : '${formatGrams(s.avgProteinGPerDay!)} g',
+        ),
+        _MetricTile(
+          width: _tileWidth,
+          label: 'Weight change',
+          value: _formatWeightDelta(s.weightDelta, s.weightDeltaUnit),
+        ),
+        _MetricTile(
+          width: _tileWidth,
+          label: 'Sessions completed',
+          // Sessions-completed is never null: 0 is an honest number
+          // ("you finished nothing this window"), not a missing-data case.
+          value: s.sessionsCompleted.toString(),
+        ),
+      ],
+    );
+  }
+
+  /// Signed weight delta, routed through [formatWeight] so the unit suffix
+  /// stays canonical. Negative values already carry their own minus sign
+  /// from `formatGrams`; we only need to prepend `+` for positive values
+  /// so the user can distinguish "gained 0.5" from "lost 0.5" at a glance.
+  /// Zero renders as `0 kg` with no sign — matching how the number
+  /// formatters elsewhere treat it.
+  String? _formatWeightDelta(double? delta, WeightUnit? unit) {
+    if (delta == null || unit == null) return null;
+    final formatted = formatWeight(delta, unit);
+    if (delta > 0) return '+$formatted';
+    return formatted;
+  }
+}
+
+/// One tile in the 2×2 summary grid. Fixed-width so the `Wrap` parent can
+/// deterministically lay out two-per-row at iPhone 15 width. Renders the
+/// label in `bodySmall`, the value in bold `headlineSmall`. Null values
+/// become an em-dash (U+2014) — never hidden, never `0`.
+class _MetricTile extends StatelessWidget {
+  const _MetricTile({
+    required this.width,
+    required this.label,
+    required this.value,
+  });
+
+  final double width;
+  final String label;
+  final String? value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SizedBox(
+      width: width,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            label,
+            style: theme.textTheme.bodySmall,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            // U+2014 EM DASH — the shared null-marker across the card.
+            // Unit tests assert on this literal, so it must match exactly.
+            value ?? '\u2014',
+            style: theme.textTheme.headlineSmall
+                ?.copyWith(fontWeight: FontWeight.bold),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/progress/progress_data_test.dart
+++ b/test/features/progress/progress_data_test.dart
@@ -37,6 +37,25 @@ ExerciseSet _set(int sessionId, WorkoutSetStatus status, {int order = 0}) =>
       orderIndex: order,
     );
 
+WorkoutSession _sessionWithEnd(int id, DateTime startedAt, DateTime? endedAt) =>
+    WorkoutSession(
+      id: id,
+      startedAt: startedAt,
+      endedAt: endedAt,
+      note: null,
+    );
+
+FoodEntry _foodWithProtein(DateTime t, int kcal, double proteinG) => FoodEntry(
+      id: 1,
+      timestamp: t,
+      name: '',
+      kcal: kcal,
+      proteinG: proteinG,
+      mealType: MealType.other,
+      entryType: FoodEntryType.manual,
+      note: null,
+    );
+
 void main() {
   group('resolveWindow', () {
     final now = DateTime(2026, 4, 23, 15, 30); // mid-day
@@ -319,6 +338,281 @@ void main() {
       );
       expect(s.completedSets[6], 1, reason: 'prior week (Mon 4/13)');
       expect(s.completedSets[7], 0);
+    });
+  });
+
+  group('calendarDaysInWindow', () {
+    test('bounded 7-day window returns 7', () {
+      expect(
+        calendarDaysInWindow(
+          from: DateTime(2026, 4, 17),
+          to: DateTime(2026, 4, 24),
+        ),
+        7,
+      );
+    });
+
+    test('single-day window returns 1', () {
+      expect(
+        calendarDaysInWindow(
+          from: DateTime(2026, 4, 23),
+          to: DateTime(2026, 4, 24),
+        ),
+        1,
+      );
+    });
+
+    test('from >= to returns 0', () {
+      expect(
+        calendarDaysInWindow(
+          from: DateTime(2026, 4, 24),
+          to: DateTime(2026, 4, 24),
+        ),
+        0,
+      );
+    });
+
+    test('truncates sub-day times to midnight on both ends', () {
+      // from = 4/17 23:59 → truncates to 4/17 00:00.
+      // to   = 4/24 00:01 → truncates to 4/24 00:00.
+      expect(
+        calendarDaysInWindow(
+          from: DateTime(2026, 4, 17, 23, 59),
+          to: DateTime(2026, 4, 24, 0, 1),
+        ),
+        7,
+      );
+    });
+  });
+
+  group('buildProgressSummary', () {
+    final now = DateTime(2026, 4, 23, 15, 30); // Thursday
+    final range = resolveWindow(ProgressWindow.sevenDays, now: now);
+
+    test('populated 7d window: averages + delta + sessions all non-null', () {
+      // 2 food entries across 2 days inside the window → denominator is 7
+      // (calendar days), NOT 2. This is the core "averages use calendar
+      // days, not logged-day count" contract (AC #2).
+      final foods = [
+        _foodWithProtein(DateTime(2026, 4, 19, 12), 700, 40.0),
+        _foodWithProtein(DateTime(2026, 4, 23, 13), 1400, 80.0),
+      ];
+      final weight = buildWeightSeries([
+        _weight(DateTime(2026, 4, 17), 80.0, WeightUnit.kg),
+        _weight(DateTime(2026, 4, 23), 80.7, WeightUnit.kg),
+      ]);
+      final session = _sessionWithEnd(
+        1,
+        DateTime(2026, 4, 22, 18),
+        DateTime(2026, 4, 22, 19),
+      );
+      final grouped = [
+        (
+          session: session,
+          sets: <ExerciseSet>[_set(1, WorkoutSetStatus.completed)],
+        ),
+      ];
+      final s = buildProgressSummary(
+        foods: foods,
+        weightSeries: weight,
+        sessionsWithSets: grouped,
+        from: range.from,
+        to: range.to,
+      );
+      // (700 + 1400) / 7 = 300 kcal/day.
+      expect(s.avgKcalPerDay, 300);
+      // (40 + 80) / 7 ≈ 17.14 g/day. Compare with tolerance for floating-point.
+      expect(s.avgProteinGPerDay, closeTo(120.0 / 7.0, 0.0001));
+      // Delta is 80.7 - 80.0 = 0.7 kg (rounding tolerance for FP).
+      expect(s.weightDelta, closeTo(0.7, 0.0001));
+      expect(s.weightDeltaUnit, WeightUnit.kg);
+      expect(s.sessionsCompleted, 1);
+    });
+
+    test('averages divide by 7 calendar days, not 2 logged days (AC #2)', () {
+      // Only 2 days have entries, but the window is 7 calendar days wide.
+      // Denominator must be 7 — not 2. Testing the exact kcal value catches
+      // any accidental regression to logged-day arithmetic.
+      final foods = [
+        _foodWithProtein(DateTime(2026, 4, 19, 9), 1400, 100.0),
+        _foodWithProtein(DateTime(2026, 4, 23, 9), 700, 50.0),
+      ];
+      final s = buildProgressSummary(
+        foods: foods,
+        weightSeries: const WeightSeries(
+          points: [],
+          dominantUnit: null,
+          mixedUnits: false,
+        ),
+        sessionsWithSets: const [],
+        from: range.from,
+        to: range.to,
+      );
+      expect(s.avgKcalPerDay, 300, reason: '(1400+700)/7 = 300');
+      expect(s.avgProteinGPerDay, closeTo(150.0 / 7.0, 0.0001));
+    });
+
+    test('empty window: averages null, delta null, sessions 0', () {
+      final weight = buildWeightSeries(const []);
+      final s = buildProgressSummary(
+        foods: const [],
+        weightSeries: weight,
+        sessionsWithSets: const [],
+        from: range.from,
+        to: range.to,
+      );
+      expect(s.avgKcalPerDay, isNull);
+      expect(s.avgProteinGPerDay, isNull);
+      expect(s.weightDelta, isNull);
+      expect(s.weightDeltaUnit, isNull);
+      expect(s.sessionsCompleted, 0);
+    });
+
+    test('single-unit delta: last minus first in dominant unit', () {
+      // 3 kg points inside the window. Delta = 81.0 - 80.0 = 1.0 kg.
+      final weight = buildWeightSeries([
+        _weight(DateTime(2026, 4, 17), 80.0, WeightUnit.kg),
+        _weight(DateTime(2026, 4, 20), 80.5, WeightUnit.kg),
+        _weight(DateTime(2026, 4, 23), 81.0, WeightUnit.kg),
+      ]);
+      final s = buildProgressSummary(
+        foods: const [],
+        weightSeries: weight,
+        sessionsWithSets: const [],
+        from: range.from,
+        to: range.to,
+      );
+      expect(s.weightDelta, closeTo(1.0, 0.0001));
+      expect(s.weightDeltaUnit, WeightUnit.kg);
+    });
+
+    test('mixed-unit window: weight delta is null (never silently converted)',
+        () {
+      // Trust rule: don't fabricate a delta that crosses kg↔lb, even if we
+      // could filter to the dominant unit and have 2+ points left.
+      final weight = buildWeightSeries([
+        _weight(DateTime(2026, 4, 17), 176.0, WeightUnit.lb),
+        _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
+        _weight(DateTime(2026, 4, 23), 80.5, WeightUnit.kg),
+      ]);
+      expect(weight.mixedUnits, isTrue); // sanity check
+      final s = buildProgressSummary(
+        foods: const [],
+        weightSeries: weight,
+        sessionsWithSets: const [],
+        from: range.from,
+        to: range.to,
+      );
+      expect(s.weightDelta, isNull);
+      expect(s.weightDeltaUnit, isNull);
+    });
+
+    test('single weight point: delta is null', () {
+      final weight = buildWeightSeries([
+        _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
+      ]);
+      final s = buildProgressSummary(
+        foods: const [],
+        weightSeries: weight,
+        sessionsWithSets: const [],
+        from: range.from,
+        to: range.to,
+      );
+      expect(s.weightDelta, isNull);
+      expect(s.weightDeltaUnit, isNull);
+    });
+
+    test('in-progress sessions do not count toward sessionsCompleted', () {
+      // Session started in-window but never ended → endedAt is null → skip.
+      final inProgress = _sessionWithEnd(
+        1,
+        DateTime(2026, 4, 22, 18),
+        null,
+      );
+      final finished = _sessionWithEnd(
+        2,
+        DateTime(2026, 4, 21, 18),
+        DateTime(2026, 4, 21, 19),
+      );
+      final s = buildProgressSummary(
+        foods: const [],
+        weightSeries: const WeightSeries(
+          points: [],
+          dominantUnit: null,
+          mixedUnits: false,
+        ),
+        sessionsWithSets: [
+          (session: inProgress, sets: const <ExerciseSet>[]),
+          (session: finished, sets: const <ExerciseSet>[]),
+        ],
+        from: range.from,
+        to: range.to,
+      );
+      expect(s.sessionsCompleted, 1);
+    });
+
+    test('sessions outside window are excluded', () {
+      // Session ended but startedAt is before the window → not counted.
+      final out = _sessionWithEnd(
+        1,
+        DateTime(2026, 4, 10, 18),
+        DateTime(2026, 4, 10, 19),
+      );
+      final s = buildProgressSummary(
+        foods: const [],
+        weightSeries: const WeightSeries(
+          points: [],
+          dominantUnit: null,
+          mixedUnits: false,
+        ),
+        sessionsWithSets: [
+          (session: out, sets: const <ExerciseSet>[]),
+        ],
+        from: range.from,
+        to: range.to,
+      );
+      expect(s.sessionsCompleted, 0);
+    });
+
+    test('all-window, no entries: averages null (no honest denominator)', () {
+      final allRange = resolveWindow(ProgressWindow.all, now: now);
+      final s = buildProgressSummary(
+        foods: const [],
+        weightSeries: const WeightSeries(
+          points: [],
+          dominantUnit: null,
+          mixedUnits: false,
+        ),
+        sessionsWithSets: const [],
+        from: allRange.from,
+        to: allRange.to,
+      );
+      expect(s.avgKcalPerDay, isNull);
+      expect(s.avgProteinGPerDay, isNull);
+    });
+
+    test('all-window with entries: divides by days from oldest entry to today',
+        () {
+      // Oldest entry on 4/20, "now" is 4/23 → span is 4 calendar days
+      // (4/20, 4/21, 4/22, 4/23). Totals 2000 kcal / 4 = 500 kcal/day.
+      final foods = [
+        _foodWithProtein(DateTime(2026, 4, 20, 12), 1200, 60.0),
+        _foodWithProtein(DateTime(2026, 4, 23, 12), 800, 40.0),
+      ];
+      final allRange = resolveWindow(ProgressWindow.all, now: now);
+      final s = buildProgressSummary(
+        foods: foods,
+        weightSeries: const WeightSeries(
+          points: [],
+          dominantUnit: null,
+          mixedUnits: false,
+        ),
+        sessionsWithSets: const [],
+        from: allRange.from,
+        to: allRange.to,
+      );
+      expect(s.avgKcalPerDay, 500);
+      expect(s.avgProteinGPerDay, closeTo(25.0, 0.0001));
     });
   });
 }

--- a/test/features/progress/progress_screen_test.dart
+++ b/test/features/progress/progress_screen_test.dart
@@ -13,6 +13,7 @@ import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
 import 'package:liftlog_app/features/progress/progress_data.dart';
 import 'package:liftlog_app/features/progress/progress_providers.dart';
 import 'package:liftlog_app/features/progress/progress_screen.dart';
+import 'package:liftlog_app/features/progress/summary_card.dart';
 import 'package:liftlog_app/features/progress/weekly_volume_bars.dart';
 import 'package:liftlog_app/providers/app_providers.dart';
 import 'package:liftlog_app/shell/root_shell.dart';
@@ -318,6 +319,165 @@ void main() {
     expect(volume.completedSets.last, 3,
         reason: 'only completed sets count; planned and skipped excluded');
     expect(volume.isEmpty, isFalse);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('summary card renders all four metrics when populated',
+      (tester) async {
+    // Food in 7d window → kcal + protein averages land on real numbers,
+    // divided by 7 (calendar days), not by the logged-day count.
+    final foodRepo = FoodEntryRepository(db);
+    await foodRepo.add(FoodEntriesCompanion.insert(
+      timestamp: fakeNow.subtract(const Duration(days: 2)),
+      name: const Value('Lunch'),
+      kcal: 700,
+      proteinG: 40.0,
+      mealType: MealType.lunch,
+      entryType: FoodEntryType.manual,
+    ));
+    await foodRepo.add(FoodEntriesCompanion.insert(
+      timestamp: fakeNow,
+      name: const Value('Dinner'),
+      kcal: 1400,
+      proteinG: 80.0,
+      mealType: MealType.dinner,
+      entryType: FoodEntryType.manual,
+    ));
+    // Two kg weight logs → non-null delta.
+    final wRepo = BodyWeightLogRepository(db);
+    await wRepo.add(BodyWeightLogsCompanion.insert(
+      timestamp: fakeNow.subtract(const Duration(days: 3)),
+      value: 80.0,
+      unit: WeightUnit.kg,
+    ));
+    await wRepo.add(BodyWeightLogsCompanion.insert(
+      timestamp: fakeNow,
+      value: 80.5,
+      unit: WeightUnit.kg,
+    ));
+    // One finished session in-window → sessionsCompleted: 1.
+    final sessionRepo = WorkoutSessionRepository(db);
+    await sessionRepo.add(WorkoutSessionsCompanion.insert(
+      startedAt: fakeNow.subtract(const Duration(days: 1)),
+      endedAt: Value(fakeNow.subtract(const Duration(days: 1))),
+    ));
+
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    // Card itself renders (above the window selector).
+    expect(find.byType(SummaryCard), findsOneWidget);
+
+    // All four tile labels are present.
+    expect(find.text('Avg kcal / day'), findsOneWidget);
+    expect(find.text('Avg protein / day'), findsOneWidget);
+    expect(find.text('Weight change'), findsOneWidget);
+    expect(find.text('Sessions completed'), findsOneWidget);
+
+    // Exact values: (700+1400)/7 = 300 kcal, (40+80)/7 ≈ 17.1 g.
+    expect(find.text('300'), findsOneWidget);
+    expect(find.text('17.1 g'), findsOneWidget);
+    // Weight delta: +0.5 kg (positive → '+' prefix).
+    expect(find.text('+0.5 kg'), findsOneWidget);
+    // Sessions completed: 1.
+    expect(find.text('1'), findsOneWidget);
+
+    // No em-dash tiles when everything is populated.
+    expect(find.text('\u2014'), findsNothing);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('summary card shows em-dash for every null-able metric when empty',
+      (tester) async {
+    // Empty DB → every metric except sessionsCompleted resolves to null.
+    // sessionsCompleted = 0 renders as '0', not as '—'.
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SummaryCard), findsOneWidget);
+    // Three em-dashes: kcal, protein, weight delta.
+    expect(find.text('\u2014'), findsNWidgets(3));
+    // Sessions completed shows 0, not em-dash.
+    expect(find.text('0'), findsOneWidget);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('summary card weight-delta is em-dash when units are mixed',
+      (tester) async {
+    // Mixed-unit history → delta must be null (no silent conversion).
+    final wRepo = BodyWeightLogRepository(db);
+    await wRepo.add(BodyWeightLogsCompanion.insert(
+      timestamp: fakeNow.subtract(const Duration(days: 3)),
+      value: 176.0,
+      unit: WeightUnit.lb,
+    ));
+    await wRepo.add(BodyWeightLogsCompanion.insert(
+      timestamp: fakeNow,
+      value: 80.0,
+      unit: WeightUnit.kg,
+    ));
+
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    // Read summary directly to confirm weightDelta is null.
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ProgressScreen)),
+    );
+    final summary = await container.read(progressSummaryProvider.future);
+    expect(summary.weightDelta, isNull);
+    expect(summary.weightDeltaUnit, isNull);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('window toggle updates summary values', (tester) async {
+    // Old entry (10 days back) lands in 30d/all but not in 7d.
+    // Today entry lands in all three windows.
+    final foodRepo = FoodEntryRepository(db);
+    await foodRepo.add(FoodEntriesCompanion.insert(
+      timestamp: fakeNow.subtract(const Duration(days: 10)),
+      name: const Value('Old meal'),
+      kcal: 2100,
+      proteinG: 70.0,
+      mealType: MealType.lunch,
+      entryType: FoodEntryType.manual,
+    ));
+    await foodRepo.add(FoodEntriesCompanion.insert(
+      timestamp: fakeNow,
+      name: const Value('Today meal'),
+      kcal: 2100,
+      proteinG: 70.0,
+      mealType: MealType.lunch,
+      entryType: FoodEntryType.manual,
+    ));
+
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ProgressScreen)),
+    );
+
+    // 7d: 2100 / 7 = 300.
+    var summary = await container.read(progressSummaryProvider.future);
+    expect(summary.avgKcalPerDay, 300);
+
+    // Flip to 30d: (2100 + 2100) / 30 = 140.
+    await tester.tap(find.text('30d'));
+    await tester.pumpAndSettle();
+    summary = await container.read(progressSummaryProvider.future);
+    expect(summary.avgKcalPerDay, 140);
+
+    // Flip to All: oldest is 10 days back, today inclusive → 11 calendar
+    // days. (2100 + 2100) / 11 ≈ 382.
+    await tester.tap(find.text('All'));
+    await tester.pumpAndSettle();
+    summary = await container.read(progressSummaryProvider.future);
+    expect(summary.avgKcalPerDay, (4200 / 11).round());
 
     await _drainDriftTimers(tester);
   });


### PR DESCRIPTION
Closes #34.

## Summary
- Adds a 2×2 summary card above the window selector on the Progress tab: avg kcal/day, avg protein/day, weight delta, sessions completed.
- Aggregator (`buildProgressSummary`) is pure-Dart and reuses existing `listRange` / `listRangeWithSets` repository methods — no new Drift queries, so the arch boundary test stays green.
- Introduces `calendarDaysInWindow(from, to)` using calendar-day arithmetic (no `Duration`) so DST transitions don't skew the denominator.

## Trust-rule notes
- Averages divide by *calendar days* in the window, not by logged-day count (2 logged days in a 7-day window still divides by 7). Test dedicated to this contract.
- Weight delta is `null` when the window has mixed units OR fewer than 2 points in the dominant unit — never a silent kg↔lb conversion.
- Empty food data surfaces as em-dash (`—`, U+2014), not `0 kcal/day`. Sessions-completed stays numeric (`0` is honest: "nothing finished in this window").
- Completed sessions = `endedAt != null` AND `startedAt ∈ [from, to)`; in-progress sessions are excluded.

## Layout
- `Wrap` of fixed-width (170pt) tiles rather than `GridView`, so it coexists with the outer `ListView` without nested-scroll gymnastics and degrades gracefully to one-per-row on narrower viewports.
- At iPhone 15 logical width (393pt − 2×16pt margins = 361pt usable), 2×170 + 16pt gap = 356pt fits comfortably. Long values (`-99.9 kg`) render single-line; overflow falls back to ellipsis.
- Value style: bold `headlineSmall`. Label style: `bodySmall`. 16pt outer margin + 16pt internal padding on the `Card`.

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — 120 passed (53 in `test/features/progress/` including new aggregator + widget tests)
- [x] Aggregator unit tests cover: populated 7d, empty window, single-unit delta, mixed-unit → null delta, single-point → null delta, calendar-day denominator (2 logged days / 7 calendar days), in-progress / out-of-window session exclusion, all-window with / without entries.
- [x] Widget tests cover: all four metrics render with correct values; em-dash for null-able metrics when empty; weight-delta em-dash on mixed units; window toggle re-pumps the summary.
- [x] Arch guardrail (`test/arch/data_access_boundary_test.dart`) — green; no new Drift imports in features.

## Dependencies
- No new pub deps.

## Out of scope
- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)