### PR TITLE
#41 — JSON import (round-trip of #37)

### DIFF
--- a/lib/features/export/import_controller.dart
+++ b/lib/features/export/import_controller.dart
@@ -1,0 +1,114 @@
+// Import flow controller. Wraps "open iOS file picker → read UTF-8 →
+// parse/validate → return ImportResult" as a single `pickAndImport()`
+// call. The UI layer (History tab) is responsible for the two-stage
+// destructive confirm flow — this controller stays thin and keeps its
+// surface synchronous-looking to the widget.
+//
+// State shape is `AsyncValue<void>`:
+//  - `AsyncData(null)`  — idle or just-succeeded.
+//  - `AsyncLoading()`   — import in flight; button disabled.
+//  - `AsyncError(...)`  — last import failed with an unhandled exception.
+//    Non-success `ImportResult`s do NOT throw — they flow through the
+//    return value of `pickAndImport()` so the UI can surface a
+//    specific SnackBar per result type.
+//
+// v2 trust rule: import is restoration, not creation. No entitlement
+// gate in this PR (StoreKit is E9); future wiring will NOT gate this
+// flow — the comment stays for anyone skimming what "gated" means here.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/app_providers.dart';
+import 'import_service.dart';
+
+/// The piece of work the controller returns to the widget. Bundles the
+/// service-level `ImportResult` with the user-cancel case (no file
+/// picked) which otherwise would need its own exception / sentinel.
+sealed class ImportAttempt {
+  const ImportAttempt();
+}
+
+/// User dismissed the file picker. No DB change, no SnackBar — the
+/// widget should quietly do nothing.
+class ImportCancelled extends ImportAttempt {
+  const ImportCancelled();
+}
+
+/// File was picked, payload parsed. The wrapped [result] is whatever
+/// the service returned — the widget switches on it to decide which
+/// SnackBar / follow-up confirm to show.
+class ImportCompleted extends ImportAttempt {
+  const ImportCompleted(this.result);
+  final ImportResult result;
+}
+
+/// Opens the iOS document picker, reads the chosen file as UTF-8, and
+/// runs the requested import variant against it.
+///
+/// [replace] — when `false`, uses `importJson` (safe mode: refuses a
+/// non-empty DB). When `true`, uses `importJsonReplacing` (wipes then
+/// inserts). The UI collects the user's second destructive confirm
+/// before setting `replace: true`.
+class ImportController extends AsyncNotifier<void> {
+  @override
+  Future<void> build() async {
+    // Idle state. Nothing to prepare.
+  }
+
+  Future<ImportAttempt> pickAndImport({required bool replace}) async {
+    state = const AsyncLoading();
+    try {
+      final picked = await FilePicker.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: const ['json'],
+        withData: false,
+      );
+      if (picked == null || picked.files.isEmpty) {
+        state = const AsyncData(null);
+        return const ImportCancelled();
+      }
+      final path = picked.files.single.path;
+      if (path == null) {
+        // iOS normally always populates `path`, but defensively handle
+        // the cloud-picked case where `bytes` is set and `path` is not.
+        final bytes = picked.files.single.bytes;
+        if (bytes == null) {
+          throw StateError(
+            'Selected file has neither a local path nor byte buffer.',
+          );
+        }
+        final payload = utf8.decode(bytes);
+        final result = await _runImport(payload, replace: replace);
+        state = const AsyncData(null);
+        return ImportCompleted(result);
+      }
+      final payload = await File(path).readAsString();
+      final result = await _runImport(payload, replace: replace);
+      state = const AsyncData(null);
+      return ImportCompleted(result);
+    } catch (error, stack) {
+      // Trust rule: IO / platform failures must surface. Record in
+      // state (drives any observers) and rethrow so the caller's
+      // catch can SnackBar it.
+      state = AsyncError(error, stack);
+      rethrow;
+    }
+  }
+
+  Future<ImportResult> _runImport(String payload, {required bool replace}) {
+    final db = ref.read(appDatabaseProvider);
+    final now = DateTime.now();
+    if (replace) {
+      return importJsonReplacing(db: db, jsonPayload: payload, now: now);
+    }
+    return importJson(db: db, jsonPayload: payload, now: now);
+  }
+}
+
+final importControllerProvider = AsyncNotifierProvider<ImportController, void>(
+  ImportController.new,
+);

--- a/lib/features/export/import_service.dart
+++ b/lib/features/export/import_service.dart
@@ -1,0 +1,526 @@
+// LiftLog data import — deserializes a JSON payload produced by
+// `buildExportJson` (issue #37) and restores it into an empty-or-to-be-
+// wiped Drift DB. This is the round-trip partner of `export_service.dart`.
+//
+// Scope (issue #41):
+//  - One-shot full restore. No merge semantics, no partial import, no
+//    diffing against existing rows. If the DB has rows, the caller picks
+//    between refusing (safe mode) or wiping.
+//  - Trust rules apply: no silent fallbacks, no silent data mutation,
+//    explicit user confirm lives in the UI layer. The service-level
+//    invariant is "if we return anything other than ImportSuccess, the
+//    DB has NOT been modified".
+//  - Pure and testable: all inputs passed in, no Flutter / platform
+//    imports. Feature-layer code runs under the arch guardrail, which
+//    allows only `package:drift/drift.dart' show Value` — hence the
+//    dance of writing through Companions rather than constructing Drift
+//    table accessors directly.
+//
+// API surface — two entry points:
+//  - `importJson(safeMode: true)` — refuses to touch a non-empty DB,
+//    returning `ImportDatabaseNotEmpty(rowCount)`. Use this when the
+//    caller hasn't yet confirmed a destructive replace.
+//  - `importJsonReplacing()` — always wipes then inserts. Use this
+//    AFTER the UI has collected the second destructive confirm.
+// Both validate format_version, JSON shape, and every enum string
+// BEFORE touching the DB. The two methods share a single transactional
+// insert path; only the pre-insert wipe differs.
+
+import 'dart:convert';
+
+import 'package:drift/drift.dart' show Value;
+
+import '../../data/database.dart';
+import '../../data/enums.dart';
+import '../../data/repositories/body_weight_log_repository.dart';
+import '../../data/repositories/exercise_set_repository.dart';
+import '../../data/repositories/food_entry_repository.dart';
+import '../../data/repositories/workout_session_repository.dart';
+import 'export_service.dart';
+
+/// Result of an import attempt.
+///
+/// Sealed so controllers can `switch` exhaustively without a default —
+/// any new result type at the service layer forces a compile-time visit
+/// of every caller. The `reason` / metadata on each non-success subclass
+/// is what the UI renders into the SnackBar.
+sealed class ImportResult {
+  const ImportResult();
+}
+
+/// Import succeeded. [rowsImported] is the total count across all four
+/// entity tables — matches the sum of counts in the source payload.
+class ImportSuccess extends ImportResult {
+  const ImportSuccess({required this.rowsImported});
+  final int rowsImported;
+}
+
+/// The payload's `meta.format_version` didn't match the current app's
+/// [kExportFormatVersion]. No rows were inserted and the DB was not
+/// touched. [got] is the offending value verbatim.
+class ImportFormatVersionMismatch extends ImportResult {
+  const ImportFormatVersionMismatch({
+    required this.got,
+    required this.expected,
+  });
+  final String got;
+  final String expected;
+}
+
+/// The DB had rows and the caller asked for a safe import. No rows were
+/// inserted and the DB was not touched. [existingRowCount] is the total
+/// across all four entities — surfaced in the UI so the user sees what
+/// they'd be replacing.
+class ImportDatabaseNotEmpty extends ImportResult {
+  const ImportDatabaseNotEmpty({required this.existingRowCount});
+  final int existingRowCount;
+}
+
+/// The JSON was malformed, missing a required key, had a wrong type, or
+/// contained an unknown enum string. No rows were inserted and the DB
+/// was not touched. [reason] is a short human-readable string suitable
+/// for the SnackBar.
+class ImportMalformed extends ImportResult {
+  const ImportMalformed({required this.reason});
+  final String reason;
+}
+
+/// Parses and validates [jsonPayload] without modifying the DB when the
+/// DB already has rows.
+///
+/// Validation order (fail-fast, DB-untouched):
+///  1. JSON decodes to a `Map`.
+///  2. `meta.format_version` equals [kExportFormatVersion].
+///  3. The four entity arrays are lists of maps; every field deserializes
+///     cleanly (types + enum `.values.byName` lookups).
+///  4. DB is empty — if not, returns `ImportDatabaseNotEmpty`.
+///
+/// Only after all four passes does it wipe (nothing to wipe — empty DB)
+/// and insert. On any validation failure, returns the appropriate
+/// `ImportResult` subclass; the DB stays as it was.
+///
+/// [now] is accepted so the caller can stamp deterministic logs — today
+/// we don't actually use it, but the signature mirrors `buildExportJson`
+/// and leaves room for a future `imported_at` audit row without changing
+/// callers.
+Future<ImportResult> importJson({
+  required AppDatabase db,
+  required String jsonPayload,
+  required DateTime now,
+}) async {
+  final parsed = _parseAndValidate(jsonPayload);
+  if (parsed is _ParseFailure) {
+    return parsed.result;
+  }
+  final payload = (parsed as _ParseSuccess).payload;
+
+  final existingRowCount = await _totalRowCount(db);
+  if (existingRowCount > 0) {
+    return ImportDatabaseNotEmpty(existingRowCount: existingRowCount);
+  }
+
+  await _insertAll(db, payload);
+  return ImportSuccess(rowsImported: payload.totalRows);
+}
+
+/// Always-wipes variant. Assumes the caller has already collected the
+/// double-confirm from the user; validates the payload first (so a bad
+/// payload does NOT wipe), then wipes and inserts atomically.
+///
+/// Wipe order is reverse-FK — `exercise_sets` (child) before
+/// `workout_sessions` (parent) — and the insert order is forward-FK so
+/// parent rows land before children that reference them. Original `id`
+/// values are preserved via `Value(id)` on each Companion so
+/// `exercise_sets.session_id` continues to reference the correct
+/// session row.
+Future<ImportResult> importJsonReplacing({
+  required AppDatabase db,
+  required String jsonPayload,
+  required DateTime now,
+}) async {
+  final parsed = _parseAndValidate(jsonPayload);
+  if (parsed is _ParseFailure) {
+    return parsed.result;
+  }
+  final payload = (parsed as _ParseSuccess).payload;
+
+  await db.transaction(() async {
+    await _wipeAll(db);
+    await _insertAll(db, payload);
+  });
+  return ImportSuccess(rowsImported: payload.totalRows);
+}
+
+/// Two-shot parser result — either the decoded payload, or the
+/// pre-formed failure result to return.
+sealed class _ParseOutcome {
+  const _ParseOutcome();
+}
+
+class _ParseSuccess extends _ParseOutcome {
+  const _ParseSuccess(this.payload);
+  final _ParsedPayload payload;
+}
+
+class _ParseFailure extends _ParseOutcome {
+  const _ParseFailure(this.result);
+  final ImportResult result;
+}
+
+/// Fully-validated in-memory shape of the payload. Everything here is
+/// ready to pass straight into Companion constructors — type coercions
+/// and enum lookups already happened upstream.
+class _ParsedPayload {
+  _ParsedPayload({
+    required this.foodEntries,
+    required this.bodyWeightLogs,
+    required this.workoutSessions,
+    required this.exerciseSets,
+  });
+
+  final List<FoodEntriesCompanion> foodEntries;
+  final List<BodyWeightLogsCompanion> bodyWeightLogs;
+  final List<WorkoutSessionsCompanion> workoutSessions;
+  final List<ExerciseSetsCompanion> exerciseSets;
+
+  int get totalRows =>
+      foodEntries.length +
+      bodyWeightLogs.length +
+      workoutSessions.length +
+      exerciseSets.length;
+}
+
+_ParseOutcome _parseAndValidate(String jsonPayload) {
+  final Object? raw;
+  try {
+    raw = jsonDecode(jsonPayload);
+  } catch (e) {
+    return _ParseFailure(ImportMalformed(reason: 'not valid JSON: $e'));
+  }
+  if (raw is! Map<String, dynamic>) {
+    return const _ParseFailure(
+      ImportMalformed(reason: 'top-level JSON value is not an object'),
+    );
+  }
+
+  final meta = raw['meta'];
+  if (meta is! Map<String, dynamic>) {
+    return const _ParseFailure(
+      ImportMalformed(reason: 'missing or malformed "meta" block'),
+    );
+  }
+  final formatVersion = meta['format_version'];
+  if (formatVersion is! String) {
+    return const _ParseFailure(
+      ImportMalformed(reason: '"meta.format_version" missing or not a string'),
+    );
+  }
+  if (formatVersion != kExportFormatVersion) {
+    return _ParseFailure(
+      ImportFormatVersionMismatch(
+        got: formatVersion,
+        expected: kExportFormatVersion,
+      ),
+    );
+  }
+
+  // Each entity array is optional (empty DB exports as empty list); but
+  // if present it must be a List<Map>. We also tolerate the key being
+  // absent — treat as empty.
+  final List<FoodEntriesCompanion> foodEntries;
+  final List<BodyWeightLogsCompanion> bodyWeightLogs;
+  final List<WorkoutSessionsCompanion> workoutSessions;
+  final List<ExerciseSetsCompanion> exerciseSets;
+  try {
+    foodEntries = _parseList(raw['food_entries'], _parseFoodEntry);
+    bodyWeightLogs = _parseList(raw['body_weight_logs'], _parseBodyWeightLog);
+    workoutSessions = _parseList(raw['workout_sessions'], _parseWorkoutSession);
+    exerciseSets = _parseList(raw['exercise_sets'], _parseExerciseSet);
+  } on _MalformedRow catch (e) {
+    return _ParseFailure(ImportMalformed(reason: e.reason));
+  }
+
+  return _ParseSuccess(
+    _ParsedPayload(
+      foodEntries: foodEntries,
+      bodyWeightLogs: bodyWeightLogs,
+      workoutSessions: workoutSessions,
+      exerciseSets: exerciseSets,
+    ),
+  );
+}
+
+List<T> _parseList<T>(Object? raw, T Function(Map<String, dynamic>) parseOne) {
+  if (raw == null) return const [];
+  if (raw is! List) {
+    throw _MalformedRow('expected array, got ${raw.runtimeType}');
+  }
+  return [
+    for (final row in raw)
+      if (row is Map<String, dynamic>)
+        parseOne(row)
+      else
+        throw _MalformedRow('expected object in array, got ${row.runtimeType}'),
+  ];
+}
+
+/// Thrown inside the per-row parsers to bubble a reason up to the outer
+/// `_parseAndValidate` frame without littering the signature with
+/// `Result` returns at every level.
+class _MalformedRow implements Exception {
+  _MalformedRow(this.reason);
+  final String reason;
+}
+
+FoodEntriesCompanion _parseFoodEntry(Map<String, dynamic> row) {
+  final id = _int(row, 'id', 'food_entries');
+  final timestamp = _dateTime(row, 'timestamp', 'food_entries');
+  final name = _string(row, 'name', 'food_entries');
+  final kcal = _int(row, 'kcal', 'food_entries');
+  final proteinG = _double(row, 'protein_g', 'food_entries');
+  final mealType = _enum<MealType>(
+    row,
+    'meal_type',
+    'food_entries',
+    MealType.values,
+  );
+  final entryType = _enum<FoodEntryType>(
+    row,
+    'entry_type',
+    'food_entries',
+    FoodEntryType.values,
+  );
+  final note = _nullableString(row, 'note', 'food_entries');
+
+  return FoodEntriesCompanion.insert(
+    id: Value(id),
+    timestamp: timestamp,
+    name: Value(name),
+    kcal: kcal,
+    proteinG: proteinG,
+    mealType: mealType,
+    entryType: entryType,
+    note: Value(note),
+  );
+}
+
+BodyWeightLogsCompanion _parseBodyWeightLog(Map<String, dynamic> row) {
+  final id = _int(row, 'id', 'body_weight_logs');
+  final timestamp = _dateTime(row, 'timestamp', 'body_weight_logs');
+  final value = _double(row, 'value', 'body_weight_logs');
+  final unit = _enum<WeightUnit>(
+    row,
+    'unit',
+    'body_weight_logs',
+    WeightUnit.values,
+  );
+
+  return BodyWeightLogsCompanion.insert(
+    id: Value(id),
+    timestamp: timestamp,
+    value: value,
+    unit: unit,
+  );
+}
+
+WorkoutSessionsCompanion _parseWorkoutSession(Map<String, dynamic> row) {
+  final id = _int(row, 'id', 'workout_sessions');
+  final startedAt = _dateTime(row, 'started_at', 'workout_sessions');
+  final endedAt = _nullableDateTime(row, 'ended_at', 'workout_sessions');
+  final note = _nullableString(row, 'note', 'workout_sessions');
+
+  return WorkoutSessionsCompanion.insert(
+    id: Value(id),
+    startedAt: startedAt,
+    endedAt: Value(endedAt),
+    note: Value(note),
+  );
+}
+
+ExerciseSetsCompanion _parseExerciseSet(Map<String, dynamic> row) {
+  final id = _int(row, 'id', 'exercise_sets');
+  final sessionId = _int(row, 'session_id', 'exercise_sets');
+  final exerciseName = _string(row, 'exercise_name', 'exercise_sets');
+  final reps = _int(row, 'reps', 'exercise_sets');
+  final weight = _double(row, 'weight', 'exercise_sets');
+  final weightUnit = _enum<WeightUnit>(
+    row,
+    'weight_unit',
+    'exercise_sets',
+    WeightUnit.values,
+  );
+  final status = _enum<WorkoutSetStatus>(
+    row,
+    'status',
+    'exercise_sets',
+    WorkoutSetStatus.values,
+  );
+  final orderIndex = _int(row, 'order_index', 'exercise_sets');
+
+  return ExerciseSetsCompanion.insert(
+    id: Value(id),
+    sessionId: sessionId,
+    exerciseName: exerciseName,
+    reps: reps,
+    weight: weight,
+    weightUnit: weightUnit,
+    status: status,
+    orderIndex: orderIndex,
+  );
+}
+
+int _int(Map<String, dynamic> row, String key, String entity) {
+  final v = row[key];
+  if (v is int) return v;
+  throw _MalformedRow('$entity.$key: expected int, got ${v.runtimeType}');
+}
+
+double _double(Map<String, dynamic> row, String key, String entity) {
+  final v = row[key];
+  // JSON numbers decoded to Dart may arrive as `int` when the value has
+  // no fractional part (e.g. `12` vs `12.0`). Accept both and coerce.
+  if (v is double) return v;
+  if (v is int) return v.toDouble();
+  throw _MalformedRow('$entity.$key: expected number, got ${v.runtimeType}');
+}
+
+String _string(Map<String, dynamic> row, String key, String entity) {
+  final v = row[key];
+  if (v is String) return v;
+  throw _MalformedRow('$entity.$key: expected string, got ${v.runtimeType}');
+}
+
+String? _nullableString(Map<String, dynamic> row, String key, String entity) {
+  final v = row[key];
+  if (v == null) return null;
+  if (v is String) return v;
+  throw _MalformedRow(
+    '$entity.$key: expected string or null, got ${v.runtimeType}',
+  );
+}
+
+DateTime _dateTime(Map<String, dynamic> row, String key, String entity) {
+  final v = row[key];
+  if (v is! String) {
+    throw _MalformedRow(
+      '$entity.$key: expected ISO-8601 string, got ${v.runtimeType}',
+    );
+  }
+  try {
+    // Export writes `toUtc().toIso8601String()` — the trailing `Z` makes
+    // `DateTime.parse` return a UTC `DateTime`. We keep it in UTC (no
+    // `.toLocal()` call) per the round-trip contract: store what was
+    // exported, not a timezone-shifted copy.
+    return DateTime.parse(v);
+  } catch (e) {
+    throw _MalformedRow('$entity.$key: not a valid ISO-8601 string: $v');
+  }
+}
+
+DateTime? _nullableDateTime(
+  Map<String, dynamic> row,
+  String key,
+  String entity,
+) {
+  final v = row[key];
+  if (v == null) return null;
+  return _dateTime(row, key, entity);
+}
+
+/// Resolves [row]`[key]` against [values] via `Enum.values.byName`.
+///
+/// Trust-rule: NEVER fall back to a default on unknown strings — a
+/// typo'd enum (`"brunch"` for a meal_type) is a malformed payload, not
+/// a license to silently pick `MealType.other`.
+T _enum<T extends Enum>(
+  Map<String, dynamic> row,
+  String key,
+  String entity,
+  List<T> values,
+) {
+  final v = row[key];
+  if (v is! String) {
+    throw _MalformedRow(
+      '$entity.$key: expected enum string, got ${v.runtimeType}',
+    );
+  }
+  try {
+    return values.byName(v);
+  } catch (_) {
+    throw _MalformedRow('$entity.$key: unknown enum value "$v"');
+  }
+}
+
+Future<int> _totalRowCount(AppDatabase db) async {
+  final foods = FoodEntryRepository(db);
+  final weights = BodyWeightLogRepository(db);
+  final sessions = WorkoutSessionRepository(db);
+  final sets = ExerciseSetRepository(db);
+  final results = await Future.wait<int>([
+    foods.listAll().then((l) => l.length),
+    weights.listAll().then((l) => l.length),
+    sessions.listAll().then((l) => l.length),
+    sets.listAll().then((l) => l.length),
+  ]);
+  return results.fold<int>(0, (a, b) => a + b);
+}
+
+/// Deletes every row across all four entities in reverse-FK order so
+/// `exercise_sets` (child) is cleared before `workout_sessions`
+/// (parent). `body_weight_logs` / `food_entries` have no FK relationship
+/// to the other two, so their order is arbitrary — we pick a
+/// deterministic ordering anyway.
+Future<void> _wipeAll(AppDatabase db) async {
+  // Feature code can only use `Value` from drift — but `_wipeAll` lives
+  // in a service file that the arch guardrail treats as feature code.
+  // Use the repositories' existing delete methods in a loop; we don't
+  // have a bulk-delete repo method, so we list-then-delete.
+  final foods = FoodEntryRepository(db);
+  final weights = BodyWeightLogRepository(db);
+  final sessions = WorkoutSessionRepository(db);
+  final sets = ExerciseSetRepository(db);
+
+  // Child first (exercise_sets). Cascade would also handle this via the
+  // sessions' `onDelete: cascade`, but being explicit keeps the step
+  // visible and doesn't rely on FK semantics that could change.
+  for (final s in await sets.listAll()) {
+    await sets.delete(s.id);
+  }
+  for (final s in await sessions.listAll()) {
+    await sessions.delete(s.id);
+  }
+  for (final w in await weights.listAll()) {
+    await weights.delete(w.id);
+  }
+  for (final f in await foods.listAll()) {
+    await foods.delete(f.id);
+  }
+}
+
+/// Inserts all rows in FK-forward order (parents before children so
+/// `exercise_sets.session_id` resolves to an existing row). Original
+/// `id` values from the payload are preserved via `Value(id)` on each
+/// Companion — this is what makes `exercise_sets.session_id` continue
+/// to reference the correct session after restore.
+Future<void> _insertAll(AppDatabase db, _ParsedPayload payload) async {
+  final foods = FoodEntryRepository(db);
+  final weights = BodyWeightLogRepository(db);
+  final sessions = WorkoutSessionRepository(db);
+  final sets = ExerciseSetRepository(db);
+
+  // food_entries and body_weight_logs have no FK dependencies — order
+  // among these two is arbitrary. workout_sessions must precede
+  // exercise_sets.
+  for (final row in payload.foodEntries) {
+    await foods.add(row);
+  }
+  for (final row in payload.bodyWeightLogs) {
+    await weights.add(row);
+  }
+  for (final row in payload.workoutSessions) {
+    await sessions.add(row);
+  }
+  for (final row in payload.exerciseSets) {
+    await sets.add(row);
+  }
+}

--- a/lib/features/history/history_screen.dart
+++ b/lib/features/history/history_screen.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../ui/delete_confirm.dart';
 import '../../ui/formatters.dart';
 import '../../ui/show_save_error.dart';
 import '../export/export_controller.dart';
+import '../export/import_controller.dart';
+import '../export/import_service.dart';
 import '../food/date_label.dart';
 import '../workouts/workout_session_screen.dart';
 import 'history_providers.dart';
@@ -73,6 +76,9 @@ class HistoryScreen extends ConsumerWidget {
           ),
           const SizedBox(height: 24),
           const _ExportSection(),
+          const SizedBox(height: 12),
+          const _ImportSection(),
+          const SizedBox(height: 24),
         ],
       ),
     );
@@ -94,7 +100,7 @@ class _ExportSection extends ConsumerWidget {
     final busy = state.isLoading;
 
     return Padding(
-      padding: const EdgeInsets.all(24),
+      padding: const EdgeInsets.symmetric(horizontal: 24),
       child: Center(
         child: FilledButton.tonalIcon(
           onPressed: busy
@@ -121,6 +127,170 @@ class _ExportSection extends ConsumerWidget {
   }
 }
 
+/// Import-all-data entry point. Sits directly below the export button
+/// (12pt gap, mirrored styling) so the "backup / restore" pair reads as
+/// a unit.
+///
+/// Flow:
+///   1. Tap → iOS document picker (JSON only).
+///   2. Parse happens in safe mode — if the payload is malformed or the
+///      format_version doesn't match, SnackBar with the reason and bail
+///      BEFORE asking any destructive confirms.
+///   3. If safe-mode import returns `ImportDatabaseNotEmpty`, show the
+///      first destructive confirm (names the row count), then a second
+///      destructive amplifier. Only on both confirms do we call
+///      `pickAndImport(replace: true)`.
+///   4. If safe-mode already succeeded (empty DB), we show the
+///      per-entity counts as the success SnackBar and stop.
+///
+/// Trust rules enforced:
+///   - Every destructive path goes through `showDeleteConfirm`.
+///   - Non-success `ImportResult`s surface specific SnackBars — no
+///     silent swallows.
+///   - Button is disabled for the whole round-trip so a double-tap
+///     can't race two file pickers.
+class _ImportSection extends ConsumerWidget {
+  const _ImportSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(importControllerProvider);
+    final busy = state.isLoading;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Center(
+        child: OutlinedButton.icon(
+          onPressed: busy ? null : () => _onTap(context, ref),
+          icon: const Icon(Icons.file_download),
+          label: const Text('Import all data (replaces current data)'),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _onTap(BuildContext context, WidgetRef ref) async {
+    final controller = ref.read(importControllerProvider.notifier);
+
+    // First pass: safe mode. Parses + validates; only touches the DB
+    // if it's already empty. This gives us a clean place to surface
+    // malformed / version-mismatch failures without a destructive prompt.
+    final ImportAttempt first;
+    try {
+      first = await controller.pickAndImport(replace: false);
+    } catch (e) {
+      if (context.mounted) showSaveError(context, 'import data', e);
+      return;
+    }
+
+    if (first is ImportCancelled) return; // quiet cancel, per picker norms
+    final firstResult = (first as ImportCompleted).result;
+
+    switch (firstResult) {
+      case ImportSuccess(:final rowsImported):
+        if (context.mounted) {
+          showSaveSuccess(context, 'Imported $rowsImported entries.');
+        }
+        return;
+      case ImportFormatVersionMismatch(:final got, :final expected):
+        if (context.mounted) {
+          showSaveError(
+            context,
+            'import data',
+            'format_version "$got" is not supported '
+                '(this app expects "$expected").',
+          );
+        }
+        return;
+      case ImportMalformed(:final reason):
+        if (context.mounted) {
+          showSaveError(context, 'import data', reason);
+        }
+        return;
+      case ImportDatabaseNotEmpty(:final existingRowCount):
+        // Fall through to destructive-confirm flow below.
+        if (!context.mounted) return;
+        await _confirmAndReplace(context, ref, existingRowCount);
+        return;
+    }
+  }
+
+  /// Two-stage destructive confirm. Both use `showDeleteConfirm` so the
+  /// `Delete` button picks up the red destructive styling. Cancel at
+  /// either stage leaves the DB unchanged.
+  Future<void> _confirmAndReplace(
+    BuildContext context,
+    WidgetRef ref,
+    int existingRowCount,
+  ) async {
+    final first = await showDeleteConfirm(
+      context,
+      title: 'Replace all current data?',
+      message:
+          'Import will replace your local data with the contents of the '
+          'picked file. This cannot be undone.',
+    );
+    if (!first) return;
+    if (!context.mounted) return;
+
+    final second = await showDeleteConfirm(
+      context,
+      title: 'Are you sure?',
+      message:
+          'Your local DB has $existingRowCount rows. '
+          'Import will replace them. Continue?',
+    );
+    if (!second) return;
+    if (!context.mounted) return;
+
+    final controller = ref.read(importControllerProvider.notifier);
+    final ImportAttempt attempt;
+    try {
+      attempt = await controller.pickAndImport(replace: true);
+    } catch (e) {
+      if (context.mounted) showSaveError(context, 'import data', e);
+      return;
+    }
+
+    if (attempt is ImportCancelled) return;
+    final result = (attempt as ImportCompleted).result;
+
+    switch (result) {
+      case ImportSuccess(:final rowsImported):
+        if (context.mounted) {
+          showSaveSuccess(context, 'Imported $rowsImported entries.');
+        }
+        return;
+      case ImportFormatVersionMismatch(:final got, :final expected):
+        if (context.mounted) {
+          showSaveError(
+            context,
+            'import data',
+            'format_version "$got" is not supported '
+                '(this app expects "$expected").',
+          );
+        }
+        return;
+      case ImportMalformed(:final reason):
+        if (context.mounted) {
+          showSaveError(context, 'import data', reason);
+        }
+        return;
+      case ImportDatabaseNotEmpty():
+        // Can't happen on the replace path (service doesn't check), but
+        // switch is exhaustive — surface defensively.
+        if (context.mounted) {
+          showSaveError(
+            context,
+            'import data',
+            'Unexpected non-empty DB during replace.',
+          );
+        }
+        return;
+    }
+  }
+}
+
 class _SectionHeader extends StatelessWidget {
   const _SectionHeader({required this.label});
   final String label;
@@ -129,10 +299,7 @@ class _SectionHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-      child: Text(
-        label,
-        style: Theme.of(context).textTheme.titleMedium,
-      ),
+      child: Text(label, style: Theme.of(context).textTheme.titleMedium),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -185,6 +185,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.7"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.12"
   drift:
     dependency: "direct main"
     description:
@@ -217,14 +225,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  ffi_leak_tracker:
-    dependency: transitive
-    description:
-      name: ffi_leak_tracker
-      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -233,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.2"
   fixnum:
     dependency: transitive
     description:
@@ -254,6 +262,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.34"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -496,6 +512,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -790,13 +814,13 @@ packages:
     source: hosted
     version: "3.0.3"
   win32:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: win32
-      sha256: ba7d5750e3441caa1bbe31d9e516348fcf8dfcb32aa29ef87a844a59f4d1f1d0
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -805,6 +829,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,25 @@ dependencies:
   # discovery UX most users won't find.
   share_plus: ^13.1.0
 
+  # iOS document picker for inbound restore (data import, issue #41).
+  # `share_plus` is outbound only — no pub dep covers the inbound
+  # UIDocumentPickerViewController surface except `file_picker`. Pinned
+  # to the current stable major (11.x) per PR discipline; bumps require
+  # a justification in the PR body. (The 8.x line conflicts with
+  # `share_plus ^13` on `win32` constraints — 11.x resolves cleanly.)
+  file_picker: ^11.0.0
+
+# iOS-only app: `win32` is a transitive Dart FFI dep of `file_picker`
+# (^5.9.0) and `share_plus` (^6.0.1) whose version ranges don't overlap.
+# Neither version is actually loaded on iOS (the plugin code path is
+# native, not Dart FFI to Windows), so we pin to the older `5.9.x`
+# line to keep file_picker's Windows-platform source compilable under
+# `flutter test` on macOS (the Dart VM unconditionally compiles the
+# package's Windows code path). If LiftLog ever targets Windows,
+# revisit: share_plus 13.x on Windows would need the newer `^6` line.
+dependency_overrides:
+  win32: ^5.9.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/features/export/import_service_test.dart
+++ b/test/features/export/import_service_test.dart
@@ -1,0 +1,431 @@
+// Unit tests for the LiftLog data-import service (issue #41).
+//
+// The import service is the round-trip partner of the export service
+// (`export_service.dart`, issue #37). Tests here enforce four things:
+//
+//   1. Round-trip fidelity. Seed every entity → `buildExportJson` →
+//      wipe-then-import → every field of every row matches.
+//   2. Fail-closed validation. A payload with a wrong `format_version`,
+//      malformed JSON, or an unknown enum string returns a specific
+//      `ImportResult` subclass and does NOT touch the DB.
+//   3. Safe mode refuses a non-empty DB. `importJson(safeMode)` returns
+//      `ImportDatabaseNotEmpty` with the existing row count intact.
+//   4. `importJsonReplacing` wipes-then-inserts atomically via a
+//      transaction — pre-existing rows are fully replaced.
+
+import 'dart:convert';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/data/repositories/body_weight_log_repository.dart';
+import 'package:liftlog_app/data/repositories/exercise_set_repository.dart';
+import 'package:liftlog_app/data/repositories/food_entry_repository.dart';
+import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
+import 'package:liftlog_app/features/export/export_service.dart';
+import 'package:liftlog_app/features/export/import_service.dart';
+
+void main() {
+  late AppDatabase db;
+  late FoodEntryRepository foods;
+  late BodyWeightLogRepository weights;
+  late WorkoutSessionRepository sessions;
+  late ExerciseSetRepository sets;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    foods = FoodEntryRepository(db);
+    weights = BodyWeightLogRepository(db);
+    sessions = WorkoutSessionRepository(db);
+    sets = ExerciseSetRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  // Seed mirrors the export-test fixture for parity: two foods (one
+  // with a null note, one with an 'estimate' enum value), two weight
+  // logs in different units, one completed and one in-progress session,
+  // and two sets (one completed, one skipped).
+  Future<void> seedAll() async {
+    await foods.add(
+      FoodEntriesCompanion.insert(
+        timestamp: DateTime.utc(2026, 4, 23, 8, 30),
+        name: const Value('Eggs'),
+        kcal: 140,
+        proteinG: 12.0,
+        mealType: MealType.breakfast,
+        entryType: FoodEntryType.manual,
+      ),
+    );
+    await foods.add(
+      FoodEntriesCompanion.insert(
+        timestamp: DateTime.utc(2026, 4, 22, 13, 15),
+        name: const Value('Eyeball guac'),
+        kcal: 300,
+        proteinG: 3.5,
+        mealType: MealType.snack,
+        entryType: FoodEntryType.estimate,
+        note: const Value('rough'),
+      ),
+    );
+
+    await weights.add(
+      BodyWeightLogsCompanion.insert(
+        timestamp: DateTime.utc(2026, 4, 23, 7),
+        value: 80.5,
+        unit: WeightUnit.kg,
+      ),
+    );
+    await weights.add(
+      BodyWeightLogsCompanion.insert(
+        timestamp: DateTime.utc(2026, 4, 22, 7),
+        value: 177.5,
+        unit: WeightUnit.lb,
+      ),
+    );
+
+    final completedId = await sessions.add(
+      WorkoutSessionsCompanion.insert(
+        startedAt: DateTime.utc(2026, 4, 21, 18),
+        endedAt: Value(DateTime.utc(2026, 4, 21, 19, 5)),
+      ),
+    );
+    await sessions.add(
+      WorkoutSessionsCompanion.insert(startedAt: DateTime.utc(2026, 4, 23, 18)),
+    );
+
+    await sets.add(
+      ExerciseSetsCompanion.insert(
+        sessionId: completedId,
+        exerciseName: 'Bench Press',
+        reps: 8,
+        weight: 80.0,
+        weightUnit: WeightUnit.kg,
+        status: WorkoutSetStatus.completed,
+        orderIndex: 0,
+      ),
+    );
+    await sets.add(
+      ExerciseSetsCompanion.insert(
+        sessionId: completedId,
+        exerciseName: 'Bench Press',
+        reps: 8,
+        weight: 80.0,
+        weightUnit: WeightUnit.kg,
+        status: WorkoutSetStatus.skipped,
+        orderIndex: 1,
+      ),
+    );
+  }
+
+  test('round-trip: export + importReplacing preserves every field', () async {
+    await seedAll();
+
+    final now = DateTime.utc(2026, 4, 24, 9, 14);
+    final exportedJson = await buildExportJson(db: db, now: now);
+
+    // Capture pre-import snapshots so we can compare after restore.
+    final preFoods = [...await foods.listAll()]
+      ..sort((a, b) => a.id.compareTo(b.id));
+    final preWeights = [...await weights.listAll()]
+      ..sort((a, b) => a.id.compareTo(b.id));
+    final preSessions = [...await sessions.listAll()]
+      ..sort((a, b) => a.id.compareTo(b.id));
+    final preSets = [...await sets.listAll()]
+      ..sort((a, b) => a.id.compareTo(b.id));
+
+    // Wipe + re-import via the replacing path.
+    final result = await importJsonReplacing(
+      db: db,
+      jsonPayload: exportedJson,
+      now: now,
+    );
+
+    expect(result, isA<ImportSuccess>());
+    expect(
+      (result as ImportSuccess).rowsImported,
+      preFoods.length + preWeights.length + preSessions.length + preSets.length,
+    );
+
+    final postFoods = [...await foods.listAll()]
+      ..sort((a, b) => a.id.compareTo(b.id));
+    final postWeights = [...await weights.listAll()]
+      ..sort((a, b) => a.id.compareTo(b.id));
+    final postSessions = [...await sessions.listAll()]
+      ..sort((a, b) => a.id.compareTo(b.id));
+    final postSets = [...await sets.listAll()]
+      ..sort((a, b) => a.id.compareTo(b.id));
+
+    expect(postFoods.length, preFoods.length);
+    for (var i = 0; i < preFoods.length; i++) {
+      final a = preFoods[i];
+      final b = postFoods[i];
+      expect(b.id, a.id);
+      expect(b.timestamp.toUtc(), a.timestamp.toUtc());
+      expect(b.name, a.name);
+      expect(b.kcal, a.kcal);
+      expect(b.proteinG, a.proteinG);
+      expect(b.mealType, a.mealType);
+      expect(b.entryType, a.entryType);
+      expect(b.note, a.note);
+    }
+
+    expect(postWeights.length, preWeights.length);
+    for (var i = 0; i < preWeights.length; i++) {
+      final a = preWeights[i];
+      final b = postWeights[i];
+      expect(b.id, a.id);
+      expect(b.timestamp.toUtc(), a.timestamp.toUtc());
+      expect(b.value, a.value);
+      expect(b.unit, a.unit);
+    }
+
+    expect(postSessions.length, preSessions.length);
+    for (var i = 0; i < preSessions.length; i++) {
+      final a = preSessions[i];
+      final b = postSessions[i];
+      expect(b.id, a.id);
+      expect(b.startedAt.toUtc(), a.startedAt.toUtc());
+      expect(b.endedAt?.toUtc(), a.endedAt?.toUtc());
+      expect(b.note, a.note);
+    }
+
+    expect(postSets.length, preSets.length);
+    for (var i = 0; i < preSets.length; i++) {
+      final a = preSets[i];
+      final b = postSets[i];
+      expect(b.id, a.id);
+      expect(b.sessionId, a.sessionId);
+      expect(b.exerciseName, a.exerciseName);
+      expect(b.reps, a.reps);
+      expect(b.weight, a.weight);
+      expect(b.weightUnit, a.weightUnit);
+      expect(b.status, a.status);
+      expect(b.orderIndex, a.orderIndex);
+    }
+  });
+
+  test('round-trip: second export after import is byte-identical', () async {
+    await seedAll();
+
+    final now = DateTime.utc(2026, 4, 24, 9, 14);
+    final first = await buildExportJson(db: db, now: now);
+
+    await importJsonReplacing(db: db, jsonPayload: first, now: now);
+
+    final second = await buildExportJson(db: db, now: now);
+    expect(
+      second,
+      first,
+      reason:
+          'round-trip must preserve id values + ordering exactly, '
+          'so re-exporting emits the identical bytes',
+    );
+  });
+
+  test('format_version mismatch returns ImportFormatVersionMismatch', () async {
+    final payload = jsonEncode(<String, Object?>{
+      'meta': <String, Object?>{
+        'format_version': '2',
+        'app_version': '1.0.0+1',
+        'schema_version': 2,
+        'exported_at': '2026-04-24T09:14:00.000Z',
+        'counts': <String, Object?>{
+          'food_entries': 0,
+          'body_weight_logs': 0,
+          'workout_sessions': 0,
+          'exercise_sets': 0,
+        },
+      },
+      'food_entries': <Object?>[],
+      'body_weight_logs': <Object?>[],
+      'workout_sessions': <Object?>[],
+      'exercise_sets': <Object?>[],
+    });
+
+    // Seed something so we can verify DB is untouched.
+    await seedAll();
+    final preFoodCount = (await foods.listAll()).length;
+
+    final result = await importJson(
+      db: db,
+      jsonPayload: payload,
+      now: DateTime.utc(2026, 4, 24),
+    );
+
+    expect(result, isA<ImportFormatVersionMismatch>());
+    final mismatch = result as ImportFormatVersionMismatch;
+    expect(mismatch.got, '2');
+    expect(mismatch.expected, '1');
+
+    // DB untouched — existing rows still there.
+    expect((await foods.listAll()).length, preFoodCount);
+  });
+
+  test('safe-mode import on non-empty DB returns ImportDatabaseNotEmpty '
+      'without wiping', () async {
+    await seedAll();
+    final preFoodCount = (await foods.listAll()).length;
+    final preTotal =
+        preFoodCount +
+        (await weights.listAll()).length +
+        (await sessions.listAll()).length +
+        (await sets.listAll()).length;
+
+    // Build a valid payload from the current DB; importing it into the
+    // same (non-empty) DB under safe mode must refuse.
+    final payload = await buildExportJson(
+      db: db,
+      now: DateTime.utc(2026, 4, 24),
+    );
+
+    final result = await importJson(
+      db: db,
+      jsonPayload: payload,
+      now: DateTime.utc(2026, 4, 24),
+    );
+
+    expect(result, isA<ImportDatabaseNotEmpty>());
+    expect((result as ImportDatabaseNotEmpty).existingRowCount, preTotal);
+
+    // DB state is exactly what it was — safe mode guarantee.
+    expect((await foods.listAll()).length, preFoodCount);
+  });
+
+  test('malformed JSON returns ImportMalformed without touching DB', () async {
+    await seedAll();
+    final preFoodCount = (await foods.listAll()).length;
+
+    final result = await importJson(
+      db: db,
+      jsonPayload: 'not valid json {',
+      now: DateTime.utc(2026, 4, 24),
+    );
+
+    expect(result, isA<ImportMalformed>());
+    expect((result as ImportMalformed).reason, contains('not valid JSON'));
+    expect((await foods.listAll()).length, preFoodCount);
+  });
+
+  test(
+    'unknown enum value (meal_type=brunch) returns ImportMalformed',
+    () async {
+      final payload = jsonEncode(<String, Object?>{
+        'meta': <String, Object?>{
+          'format_version': '1',
+          'app_version': '1.0.0+1',
+          'schema_version': 2,
+          'exported_at': '2026-04-24T09:14:00.000Z',
+          'counts': <String, Object?>{
+            'food_entries': 1,
+            'body_weight_logs': 0,
+            'workout_sessions': 0,
+            'exercise_sets': 0,
+          },
+        },
+        'food_entries': <Object?>[
+          <String, Object?>{
+            'id': 1,
+            'timestamp': '2026-04-23T08:30:00.000Z',
+            'name': 'Eggs',
+            'kcal': 140,
+            'protein_g': 12.0,
+            // Invalid enum value.
+            'meal_type': 'brunch',
+            'entry_type': 'manual',
+            'note': null,
+          },
+        ],
+        'body_weight_logs': <Object?>[],
+        'workout_sessions': <Object?>[],
+        'exercise_sets': <Object?>[],
+      });
+
+      final result = await importJsonReplacing(
+        db: db,
+        jsonPayload: payload,
+        now: DateTime.utc(2026, 4, 24),
+      );
+
+      expect(result, isA<ImportMalformed>());
+      expect(
+        (result as ImportMalformed).reason,
+        contains('brunch'),
+        reason: 'error surfaces the offending enum value for debugging',
+      );
+      // Empty DB stayed empty — validation failed BEFORE the wipe.
+      expect((await foods.listAll()).length, 0);
+    },
+  );
+
+  test('missing meta block returns ImportMalformed', () async {
+    final payload = jsonEncode(<String, Object?>{
+      'food_entries': <Object?>[],
+      'body_weight_logs': <Object?>[],
+      'workout_sessions': <Object?>[],
+      'exercise_sets': <Object?>[],
+    });
+
+    final result = await importJson(
+      db: db,
+      jsonPayload: payload,
+      now: DateTime.utc(2026, 4, 24),
+    );
+
+    expect(result, isA<ImportMalformed>());
+    expect((result as ImportMalformed).reason, contains('meta'));
+  });
+
+  test(
+    'ImportReplacing preserves FK integrity (session_id stays valid)',
+    () async {
+      await seedAll();
+      final json = await buildExportJson(
+        db: db,
+        now: DateTime.utc(2026, 4, 24),
+      );
+
+      await importJsonReplacing(
+        db: db,
+        jsonPayload: json,
+        now: DateTime.utc(2026, 4, 24),
+      );
+
+      // Every restored exercise_set.sessionId must reference an existing
+      // workout_session.id — if the insert order were wrong we'd either
+      // hit a FK violation (exception on insert) or orphan the child
+      // rows. A plain lookup is sufficient here.
+      final allSessions = await sessions.listAll();
+      final sessionIds = allSessions.map((s) => s.id).toSet();
+      final allSets = await sets.listAll();
+      expect(allSets, isNotEmpty);
+      for (final s in allSets) {
+        expect(
+          sessionIds.contains(s.sessionId),
+          isTrue,
+          reason:
+              'exercise_set.session_id=${s.sessionId} must reference '
+              'an existing session after round-trip',
+        );
+      }
+    },
+  );
+
+  test('empty payload into empty DB succeeds with 0 rows', () async {
+    final payload = await buildExportJson(
+      db: db,
+      now: DateTime.utc(2026, 4, 24),
+    );
+
+    final result = await importJson(
+      db: db,
+      jsonPayload: payload,
+      now: DateTime.utc(2026, 4, 24),
+    );
+    expect(result, isA<ImportSuccess>());
+    expect((result as ImportSuccess).rowsImported, 0);
+  });
+}

--- a/test/features/history/import_cancel_test.dart
+++ b/test/features/history/import_cancel_test.dart
@@ -1,0 +1,142 @@
+// Widget test: cancelling the first destructive confirm on the Import
+// flow must leave the DB unchanged.
+//
+// Scope: the issue (#41) calls out "widget tests cover Cancel at each
+// stage leaving DB unchanged". We can't exercise the iOS file-picker in
+// a widget test (it's a platform channel — MissingPluginException), so
+// we verify the dialog branch of the UI instead. Specifically, we
+// construct the destructive confirm directly (same helper the section
+// uses) and confirm Cancel returns false without any DB side effect.
+//
+// This keeps the test within the arch guardrails (UI layer only talks
+// to repositories / helpers) and doesn't require mocking the file
+// picker plugin.
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/data/repositories/food_entry_repository.dart';
+import 'package:liftlog_app/ui/delete_confirm.dart';
+
+void main() {
+  late AppDatabase db;
+  late FoodEntryRepository foods;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    foods = FoodEntryRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  testWidgets('Cancel on destructive-confirm dialog leaves DB unchanged', (
+    tester,
+  ) async {
+    await foods.add(
+      FoodEntriesCompanion.insert(
+        timestamp: DateTime.utc(2026, 4, 23, 8, 30),
+        name: const Value('Eggs'),
+        kcal: 140,
+        proteinG: 12.0,
+        mealType: MealType.breakfast,
+        entryType: FoodEntryType.manual,
+      ),
+    );
+    final before = (await foods.listAll()).length;
+    expect(before, 1);
+
+    bool? confirmResult;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => TextButton(
+              onPressed: () async {
+                confirmResult = await showDeleteConfirm(
+                  context,
+                  title: 'Replace all current data?',
+                  message:
+                      'Import will replace your local data with the '
+                      'contents of the picked file. This cannot be '
+                      'undone.',
+                );
+              },
+              child: const Text('Trigger'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Trigger'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Replace all current data?'), findsOneWidget);
+
+    // Tap Cancel → helper returns false; caller short-circuits and
+    // never reaches the wipe/import path.
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(confirmResult, isFalse);
+
+    final after = (await foods.listAll()).length;
+    expect(after, before, reason: 'DB must not change on Cancel');
+  });
+
+  testWidgets(
+    'Cancel on second destructive-confirm dialog leaves DB unchanged',
+    (tester) async {
+      // Parallel test for the amplifier dialog. The title differs; the
+      // invariant is the same — Cancel returns false and the DB stays.
+      await foods.add(
+        FoodEntriesCompanion.insert(
+          timestamp: DateTime.utc(2026, 4, 23, 8, 30),
+          name: const Value('Eggs'),
+          kcal: 140,
+          proteinG: 12.0,
+          mealType: MealType.breakfast,
+          entryType: FoodEntryType.manual,
+        ),
+      );
+      final before = (await foods.listAll()).length;
+
+      bool? secondConfirm;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: () async {
+                  secondConfirm = await showDeleteConfirm(
+                    context,
+                    title: 'Are you sure?',
+                    message:
+                        'Your local DB has 1 rows. Import will replace '
+                        'them. Continue?',
+                  );
+                },
+                child: const Text('Trigger'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Trigger'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Are you sure?'), findsOneWidget);
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(secondConfirm, isFalse);
+      expect((await foods.listAll()).length, before);
+    },
+  );
+}


### PR DESCRIPTION
Closes #41.

## Summary

Adds the inbound half of the backup/restore loop started by #37: the founder can pick a previously-exported JSON file from the iOS Files app and restore it into an empty (or confirmed-to-be-wiped) LiftLog DB. Full round-trip fidelity is enforced by test — seed → export → wipe → import re-exports byte-identically.

## File-picker dep justification

Adds `file_picker ^11.0.0`. Considered: `share_plus` (already in for #37) — it wraps `UIActivityViewController` and is outbound-only; no inbound `UIDocumentPickerViewController` surface. No other pub dep covers this. Pinned to the current stable major.

The brief said "pin to `^8`" but `^8` transitively conflicts with `share_plus ^13` on `win32` — 11.x is the current line and resolves cleanly except for one Dart-VM-only compile issue solved via the override below.

## `dependency_overrides: win32: ^5.9.0`

Required so `file_picker`'s Windows platform source continues to compile under `flutter test` on macOS. The Dart VM used by `flutter test` unconditionally compiles the package's Windows code path regardless of runtime target (file_picker's conditional export only guards against `dart.library.js_interop`, not against non-Windows native). LiftLog is iOS-only so no `win32` code runs either way. If Windows ever becomes a target, revisit — `share_plus 13` would then need `win32 ^6` and we'd need to pick a different file-picker approach.

## Design choices (noted per the brief)

- **Two service entry points rather than one with a flag.** `importJson` (safe mode — refuses a non-empty DB) vs `importJsonReplacing` (always wipes + inserts). Simpler for callers + the UI already has a two-stage confirm that naturally lines up with the two methods: first call is `importJson` to surface counts / format errors without asking for a destructive confirm; only after both confirms do we call `importJsonReplacing`. Documented in the file header.
- **Sealed `ImportResult`.** Dart 3 sealed class → exhaustive `switch` in the controller and UI, no default fallthrough. Any future variant is a compile error at every call site. Mirror-added `ImportAttempt` in the controller to fold the picker-cancel case in without exceptions.
- **Enum deserialization via `.values.byName` wrapped in try/catch.** Unknown strings surface as `ImportMalformed("unknown enum value \"brunch\"")` with the offending value in the reason, never silently picking a default (trust-rule: no silent fallback).
- **FK integrity via preserved `id` values + forward-FK insert order.** Original `exercise_sets.session_id` values point at preserved `workout_sessions.id` values after restore. Test `ImportReplacing preserves FK integrity` enforces this.
- **Wipe + insert inside `db.transaction`.** Validation runs BEFORE the transaction, so a bad payload never wipes.
- **No progress indicator / async UI.** Single-user scale → inserts against in-memory SQLite are subsecond. Button disabled during the run; SnackBar on completion.
- **Widget test covers Cancel via `showDeleteConfirm` directly**, not through the file picker (the iOS file picker is a platform channel — `MissingPluginException` under `flutter test`). Two cases: Cancel on first confirm and Cancel on the amplifier. Both verify DB unchanged.

## AC coverage

- (1) Pure `importJson` with no Flutter imports: yes — `import_service.dart` imports only `drift` (via `Value`) + stdlib.
- (2) Round-trip test: `test/features/export/import_service_test.dart` — `round-trip: export + importReplacing preserves every field` + `round-trip: second export after import is byte-identical`.
- (3) `format_version` mismatch test: `format_version mismatch returns ImportFormatVersionMismatch` — asserts `got: "2"`, `expected: "1"`, DB untouched.
- (4) Non-empty DB refusal: `safe-mode import on non-empty DB returns ImportDatabaseNotEmpty without wiping`.
- (5) Malformed JSON: `malformed JSON returns ImportMalformed without touching DB` + `missing meta block returns ImportMalformed`.
- (6) UI confirm Cancel: `test/features/history/import_cancel_test.dart` — two `testWidgets` covering first and second dialog Cancel.
- (7) Arch guardrail still passes (150/150 tests).
- (8) `flutter analyze` clean, `flutter test` green (150 tests, up from 139).

## Trust-rule mapping

- No silent fallbacks: every validation failure returns a specific `ImportResult` + specific SnackBar.
- No silent mutation: validation always runs before any wipe or insert.
- Explicit confirm for destructive ops: two dialogs via `showDeleteConfirm` (red styling) before any replace.
- Import is restoration, not creation (v2): no entitlement gate; available whenever the app can read data.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 150 passed
- [x] `grep -rn "jsonDecode" lib/features/export/` — only `import_service.dart` (service layer)
- [x] Arch guardrail test passes (`test/arch/data_access_boundary_test.dart`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)