### PR TITLE
#42 — Source enum, exercises table, schema v3

### DIFF
--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -18,6 +18,11 @@ class FoodEntries extends Table {
   TextColumn get mealType => textEnum<MealType>()();
   TextColumn get entryType => textEnum<FoodEntryType>()();
   TextColumn get note => text().nullable()();
+  // Provenance (v2.0 trust rule — every entity declares its `Source`).
+  // Defaulted so existing rows and inserts that pre-date the v3 schema
+  // stay valid without a data migration. Orthogonal to `entryType`.
+  TextColumn get source =>
+      textEnum<Source>().withDefault(const Constant('userEntered'))();
 }
 
 class WorkoutSessions extends Table {
@@ -25,6 +30,8 @@ class WorkoutSessions extends Table {
   DateTimeColumn get startedAt => dateTime()();
   DateTimeColumn get endedAt => dateTime().nullable()();
   TextColumn get note => text().nullable()();
+  TextColumn get source =>
+      textEnum<Source>().withDefault(const Constant('userEntered'))();
 }
 
 class ExerciseSets extends Table {
@@ -37,6 +44,13 @@ class ExerciseSets extends Table {
   TextColumn get weightUnit => textEnum<WeightUnit>()();
   TextColumn get status => textEnum<WorkoutSetStatus>()();
   IntColumn get orderIndex => integer()();
+  // Nullable FK to the first-class `Exercises` table (schema v3). Populated
+  // by the v2→v3 seeding pass and by future adaptive-programming work.
+  // UI still reads `exerciseName` as the authoritative name source for now.
+  IntColumn get exerciseId =>
+      integer().nullable().references(Exercises, #id)();
+  TextColumn get source =>
+      textEnum<Source>().withDefault(const Constant('userEntered'))();
 }
 
 class BodyWeightLogs extends Table {
@@ -44,16 +58,40 @@ class BodyWeightLogs extends Table {
   DateTimeColumn get timestamp => dateTime()();
   RealColumn get value => real()();
   TextColumn get unit => textEnum<WeightUnit>()();
+  TextColumn get source =>
+      textEnum<Source>().withDefault(const Constant('userEntered'))();
 }
 
-@DriftDatabase(tables: [FoodEntries, WorkoutSessions, ExerciseSets, BodyWeightLogs])
+/// Exercise as a first-class entity (schema v3).
+///
+/// Introduced so future adaptive-programming features (progression,
+/// volume-per-muscle-group analytics) can address the exercise once by
+/// id rather than round-tripping free-form `exerciseName` strings. For
+/// sprint 1 the column is populated by the v2→v3 seeding pass only;
+/// workout UI continues to write `exerciseName` as the authoritative
+/// name source. `canonicalName` is globally unique so the seeding pass
+/// is trivially idempotent (see `_seedExercisesFromHistory`).
+class Exercises extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get canonicalName => text().unique()();
+  TextColumn get muscleGroup => text().nullable()();
+  DateTimeColumn get createdAt => dateTime()();
+}
+
+@DriftDatabase(tables: [
+  FoodEntries,
+  WorkoutSessions,
+  ExerciseSets,
+  BodyWeightLogs,
+  Exercises,
+])
 class AppDatabase extends _$AppDatabase {
   AppDatabase() : super(_openConnection());
 
   AppDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 2;
+  int get schemaVersion => 3;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -64,11 +102,49 @@ class AppDatabase extends _$AppDatabase {
           if (from < 2) {
             await m.addColumn(foodEntries, foodEntries.name);
           }
+          if (from < 3) {
+            // Additive-only — no drops, no renames, no transforms beyond
+            // the one-time exercise seeding (idempotent via UNIQUE).
+            //
+            // 1. Provenance columns on every entity.
+            await m.addColumn(foodEntries, foodEntries.source);
+            await m.addColumn(bodyWeightLogs, bodyWeightLogs.source);
+            await m.addColumn(workoutSessions, workoutSessions.source);
+            await m.addColumn(exerciseSets, exerciseSets.source);
+            // 2. First-class `exercises` table.
+            await m.createTable(exercises);
+            // 3. Nullable FK from exercise_sets → exercises (no backfill
+            //    in this PR; UI still reads `exerciseName`).
+            await m.addColumn(exerciseSets, exerciseSets.exerciseId);
+            // 4. Seed exercises from the distinct historical names.
+            await _seedExercisesFromHistory();
+          }
         },
         beforeOpen: (details) async {
           await customStatement('PRAGMA foreign_keys = ON');
         },
       );
+
+  /// Seeds `exercises` with the distinct `exercise_name` values already
+  /// present in `exercise_sets`. Idempotent: the `canonicalName UNIQUE`
+  /// constraint plus `InsertMode.insertOrIgnore` means running this
+  /// twice yields the same row count as running it once.
+  Future<void> _seedExercisesFromHistory() async {
+    final rows = await customSelect(
+      'SELECT DISTINCT exercise_name FROM exercise_sets',
+    ).get();
+    final now = DateTime.now();
+    for (final row in rows) {
+      final name = row.read<String>('exercise_name');
+      await into(exercises).insert(
+        ExercisesCompanion.insert(
+          canonicalName: name,
+          createdAt: now,
+        ),
+        mode: InsertMode.insertOrIgnore,
+      );
+    }
+  }
 }
 
 LazyDatabase _openConnection() {

--- a/lib/data/database.g.dart
+++ b/lib/data/database.g.dart
@@ -91,6 +91,16 @@ class $FoodEntriesTable extends FoodEntries
     requiredDuringInsert: false,
   );
   @override
+  late final GeneratedColumnWithTypeConverter<Source, String> source =
+      GeneratedColumn<String>(
+        'source',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        defaultValue: const Constant('userEntered'),
+      ).withConverter<Source>($FoodEntriesTable.$convertersource);
+  @override
   List<GeneratedColumn> get $columns => [
     id,
     timestamp,
@@ -100,6 +110,7 @@ class $FoodEntriesTable extends FoodEntries
     mealType,
     entryType,
     note,
+    source,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -197,6 +208,12 @@ class $FoodEntriesTable extends FoodEntries
         DriftSqlType.string,
         data['${effectivePrefix}note'],
       ),
+      source: $FoodEntriesTable.$convertersource.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}source'],
+        )!,
+      ),
     );
   }
 
@@ -209,6 +226,8 @@ class $FoodEntriesTable extends FoodEntries
       const EnumNameConverter<MealType>(MealType.values);
   static JsonTypeConverter2<FoodEntryType, String, String> $converterentryType =
       const EnumNameConverter<FoodEntryType>(FoodEntryType.values);
+  static JsonTypeConverter2<Source, String, String> $convertersource =
+      const EnumNameConverter<Source>(Source.values);
 }
 
 class FoodEntry extends DataClass implements Insertable<FoodEntry> {
@@ -220,6 +239,7 @@ class FoodEntry extends DataClass implements Insertable<FoodEntry> {
   final MealType mealType;
   final FoodEntryType entryType;
   final String? note;
+  final Source source;
   const FoodEntry({
     required this.id,
     required this.timestamp,
@@ -229,6 +249,7 @@ class FoodEntry extends DataClass implements Insertable<FoodEntry> {
     required this.mealType,
     required this.entryType,
     this.note,
+    required this.source,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -251,6 +272,11 @@ class FoodEntry extends DataClass implements Insertable<FoodEntry> {
     if (!nullToAbsent || note != null) {
       map['note'] = Variable<String>(note);
     }
+    {
+      map['source'] = Variable<String>(
+        $FoodEntriesTable.$convertersource.toSql(source),
+      );
+    }
     return map;
   }
 
@@ -264,6 +290,7 @@ class FoodEntry extends DataClass implements Insertable<FoodEntry> {
       mealType: Value(mealType),
       entryType: Value(entryType),
       note: note == null && nullToAbsent ? const Value.absent() : Value(note),
+      source: Value(source),
     );
   }
 
@@ -285,6 +312,9 @@ class FoodEntry extends DataClass implements Insertable<FoodEntry> {
         serializer.fromJson<String>(json['entryType']),
       ),
       note: serializer.fromJson<String?>(json['note']),
+      source: $FoodEntriesTable.$convertersource.fromJson(
+        serializer.fromJson<String>(json['source']),
+      ),
     );
   }
   @override
@@ -303,6 +333,9 @@ class FoodEntry extends DataClass implements Insertable<FoodEntry> {
         $FoodEntriesTable.$converterentryType.toJson(entryType),
       ),
       'note': serializer.toJson<String?>(note),
+      'source': serializer.toJson<String>(
+        $FoodEntriesTable.$convertersource.toJson(source),
+      ),
     };
   }
 
@@ -315,6 +348,7 @@ class FoodEntry extends DataClass implements Insertable<FoodEntry> {
     MealType? mealType,
     FoodEntryType? entryType,
     Value<String?> note = const Value.absent(),
+    Source? source,
   }) => FoodEntry(
     id: id ?? this.id,
     timestamp: timestamp ?? this.timestamp,
@@ -324,6 +358,7 @@ class FoodEntry extends DataClass implements Insertable<FoodEntry> {
     mealType: mealType ?? this.mealType,
     entryType: entryType ?? this.entryType,
     note: note.present ? note.value : this.note,
+    source: source ?? this.source,
   );
   FoodEntry copyWithCompanion(FoodEntriesCompanion data) {
     return FoodEntry(
@@ -335,6 +370,7 @@ class FoodEntry extends DataClass implements Insertable<FoodEntry> {
       mealType: data.mealType.present ? data.mealType.value : this.mealType,
       entryType: data.entryType.present ? data.entryType.value : this.entryType,
       note: data.note.present ? data.note.value : this.note,
+      source: data.source.present ? data.source.value : this.source,
     );
   }
 
@@ -348,7 +384,8 @@ class FoodEntry extends DataClass implements Insertable<FoodEntry> {
           ..write('proteinG: $proteinG, ')
           ..write('mealType: $mealType, ')
           ..write('entryType: $entryType, ')
-          ..write('note: $note')
+          ..write('note: $note, ')
+          ..write('source: $source')
           ..write(')'))
         .toString();
   }
@@ -363,6 +400,7 @@ class FoodEntry extends DataClass implements Insertable<FoodEntry> {
     mealType,
     entryType,
     note,
+    source,
   );
   @override
   bool operator ==(Object other) =>
@@ -375,7 +413,8 @@ class FoodEntry extends DataClass implements Insertable<FoodEntry> {
           other.proteinG == this.proteinG &&
           other.mealType == this.mealType &&
           other.entryType == this.entryType &&
-          other.note == this.note);
+          other.note == this.note &&
+          other.source == this.source);
 }
 
 class FoodEntriesCompanion extends UpdateCompanion<FoodEntry> {
@@ -387,6 +426,7 @@ class FoodEntriesCompanion extends UpdateCompanion<FoodEntry> {
   final Value<MealType> mealType;
   final Value<FoodEntryType> entryType;
   final Value<String?> note;
+  final Value<Source> source;
   const FoodEntriesCompanion({
     this.id = const Value.absent(),
     this.timestamp = const Value.absent(),
@@ -396,6 +436,7 @@ class FoodEntriesCompanion extends UpdateCompanion<FoodEntry> {
     this.mealType = const Value.absent(),
     this.entryType = const Value.absent(),
     this.note = const Value.absent(),
+    this.source = const Value.absent(),
   });
   FoodEntriesCompanion.insert({
     this.id = const Value.absent(),
@@ -406,6 +447,7 @@ class FoodEntriesCompanion extends UpdateCompanion<FoodEntry> {
     required MealType mealType,
     required FoodEntryType entryType,
     this.note = const Value.absent(),
+    this.source = const Value.absent(),
   }) : timestamp = Value(timestamp),
        kcal = Value(kcal),
        proteinG = Value(proteinG),
@@ -420,6 +462,7 @@ class FoodEntriesCompanion extends UpdateCompanion<FoodEntry> {
     Expression<String>? mealType,
     Expression<String>? entryType,
     Expression<String>? note,
+    Expression<String>? source,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -430,6 +473,7 @@ class FoodEntriesCompanion extends UpdateCompanion<FoodEntry> {
       if (mealType != null) 'meal_type': mealType,
       if (entryType != null) 'entry_type': entryType,
       if (note != null) 'note': note,
+      if (source != null) 'source': source,
     });
   }
 
@@ -442,6 +486,7 @@ class FoodEntriesCompanion extends UpdateCompanion<FoodEntry> {
     Value<MealType>? mealType,
     Value<FoodEntryType>? entryType,
     Value<String?>? note,
+    Value<Source>? source,
   }) {
     return FoodEntriesCompanion(
       id: id ?? this.id,
@@ -452,6 +497,7 @@ class FoodEntriesCompanion extends UpdateCompanion<FoodEntry> {
       mealType: mealType ?? this.mealType,
       entryType: entryType ?? this.entryType,
       note: note ?? this.note,
+      source: source ?? this.source,
     );
   }
 
@@ -486,6 +532,11 @@ class FoodEntriesCompanion extends UpdateCompanion<FoodEntry> {
     if (note.present) {
       map['note'] = Variable<String>(note.value);
     }
+    if (source.present) {
+      map['source'] = Variable<String>(
+        $FoodEntriesTable.$convertersource.toSql(source.value),
+      );
+    }
     return map;
   }
 
@@ -499,7 +550,8 @@ class FoodEntriesCompanion extends UpdateCompanion<FoodEntry> {
           ..write('proteinG: $proteinG, ')
           ..write('mealType: $mealType, ')
           ..write('entryType: $entryType, ')
-          ..write('note: $note')
+          ..write('note: $note, ')
+          ..write('source: $source')
           ..write(')'))
         .toString();
   }
@@ -556,7 +608,17 @@ class $WorkoutSessionsTable extends WorkoutSessions
     requiredDuringInsert: false,
   );
   @override
-  List<GeneratedColumn> get $columns => [id, startedAt, endedAt, note];
+  late final GeneratedColumnWithTypeConverter<Source, String> source =
+      GeneratedColumn<String>(
+        'source',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        defaultValue: const Constant('userEntered'),
+      ).withConverter<Source>($WorkoutSessionsTable.$convertersource);
+  @override
+  List<GeneratedColumn> get $columns => [id, startedAt, endedAt, note, source];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -617,6 +679,12 @@ class $WorkoutSessionsTable extends WorkoutSessions
         DriftSqlType.string,
         data['${effectivePrefix}note'],
       ),
+      source: $WorkoutSessionsTable.$convertersource.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}source'],
+        )!,
+      ),
     );
   }
 
@@ -624,6 +692,9 @@ class $WorkoutSessionsTable extends WorkoutSessions
   $WorkoutSessionsTable createAlias(String alias) {
     return $WorkoutSessionsTable(attachedDatabase, alias);
   }
+
+  static JsonTypeConverter2<Source, String, String> $convertersource =
+      const EnumNameConverter<Source>(Source.values);
 }
 
 class WorkoutSession extends DataClass implements Insertable<WorkoutSession> {
@@ -631,11 +702,13 @@ class WorkoutSession extends DataClass implements Insertable<WorkoutSession> {
   final DateTime startedAt;
   final DateTime? endedAt;
   final String? note;
+  final Source source;
   const WorkoutSession({
     required this.id,
     required this.startedAt,
     this.endedAt,
     this.note,
+    required this.source,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -648,6 +721,11 @@ class WorkoutSession extends DataClass implements Insertable<WorkoutSession> {
     if (!nullToAbsent || note != null) {
       map['note'] = Variable<String>(note);
     }
+    {
+      map['source'] = Variable<String>(
+        $WorkoutSessionsTable.$convertersource.toSql(source),
+      );
+    }
     return map;
   }
 
@@ -659,6 +737,7 @@ class WorkoutSession extends DataClass implements Insertable<WorkoutSession> {
           ? const Value.absent()
           : Value(endedAt),
       note: note == null && nullToAbsent ? const Value.absent() : Value(note),
+      source: Value(source),
     );
   }
 
@@ -672,6 +751,9 @@ class WorkoutSession extends DataClass implements Insertable<WorkoutSession> {
       startedAt: serializer.fromJson<DateTime>(json['startedAt']),
       endedAt: serializer.fromJson<DateTime?>(json['endedAt']),
       note: serializer.fromJson<String?>(json['note']),
+      source: $WorkoutSessionsTable.$convertersource.fromJson(
+        serializer.fromJson<String>(json['source']),
+      ),
     );
   }
   @override
@@ -682,6 +764,9 @@ class WorkoutSession extends DataClass implements Insertable<WorkoutSession> {
       'startedAt': serializer.toJson<DateTime>(startedAt),
       'endedAt': serializer.toJson<DateTime?>(endedAt),
       'note': serializer.toJson<String?>(note),
+      'source': serializer.toJson<String>(
+        $WorkoutSessionsTable.$convertersource.toJson(source),
+      ),
     };
   }
 
@@ -690,11 +775,13 @@ class WorkoutSession extends DataClass implements Insertable<WorkoutSession> {
     DateTime? startedAt,
     Value<DateTime?> endedAt = const Value.absent(),
     Value<String?> note = const Value.absent(),
+    Source? source,
   }) => WorkoutSession(
     id: id ?? this.id,
     startedAt: startedAt ?? this.startedAt,
     endedAt: endedAt.present ? endedAt.value : this.endedAt,
     note: note.present ? note.value : this.note,
+    source: source ?? this.source,
   );
   WorkoutSession copyWithCompanion(WorkoutSessionsCompanion data) {
     return WorkoutSession(
@@ -702,6 +789,7 @@ class WorkoutSession extends DataClass implements Insertable<WorkoutSession> {
       startedAt: data.startedAt.present ? data.startedAt.value : this.startedAt,
       endedAt: data.endedAt.present ? data.endedAt.value : this.endedAt,
       note: data.note.present ? data.note.value : this.note,
+      source: data.source.present ? data.source.value : this.source,
     );
   }
 
@@ -711,13 +799,14 @@ class WorkoutSession extends DataClass implements Insertable<WorkoutSession> {
           ..write('id: $id, ')
           ..write('startedAt: $startedAt, ')
           ..write('endedAt: $endedAt, ')
-          ..write('note: $note')
+          ..write('note: $note, ')
+          ..write('source: $source')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(id, startedAt, endedAt, note);
+  int get hashCode => Object.hash(id, startedAt, endedAt, note, source);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -725,7 +814,8 @@ class WorkoutSession extends DataClass implements Insertable<WorkoutSession> {
           other.id == this.id &&
           other.startedAt == this.startedAt &&
           other.endedAt == this.endedAt &&
-          other.note == this.note);
+          other.note == this.note &&
+          other.source == this.source);
 }
 
 class WorkoutSessionsCompanion extends UpdateCompanion<WorkoutSession> {
@@ -733,29 +823,34 @@ class WorkoutSessionsCompanion extends UpdateCompanion<WorkoutSession> {
   final Value<DateTime> startedAt;
   final Value<DateTime?> endedAt;
   final Value<String?> note;
+  final Value<Source> source;
   const WorkoutSessionsCompanion({
     this.id = const Value.absent(),
     this.startedAt = const Value.absent(),
     this.endedAt = const Value.absent(),
     this.note = const Value.absent(),
+    this.source = const Value.absent(),
   });
   WorkoutSessionsCompanion.insert({
     this.id = const Value.absent(),
     required DateTime startedAt,
     this.endedAt = const Value.absent(),
     this.note = const Value.absent(),
+    this.source = const Value.absent(),
   }) : startedAt = Value(startedAt);
   static Insertable<WorkoutSession> custom({
     Expression<int>? id,
     Expression<DateTime>? startedAt,
     Expression<DateTime>? endedAt,
     Expression<String>? note,
+    Expression<String>? source,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
       if (startedAt != null) 'started_at': startedAt,
       if (endedAt != null) 'ended_at': endedAt,
       if (note != null) 'note': note,
+      if (source != null) 'source': source,
     });
   }
 
@@ -764,12 +859,14 @@ class WorkoutSessionsCompanion extends UpdateCompanion<WorkoutSession> {
     Value<DateTime>? startedAt,
     Value<DateTime?>? endedAt,
     Value<String?>? note,
+    Value<Source>? source,
   }) {
     return WorkoutSessionsCompanion(
       id: id ?? this.id,
       startedAt: startedAt ?? this.startedAt,
       endedAt: endedAt ?? this.endedAt,
       note: note ?? this.note,
+      source: source ?? this.source,
     );
   }
 
@@ -788,6 +885,11 @@ class WorkoutSessionsCompanion extends UpdateCompanion<WorkoutSession> {
     if (note.present) {
       map['note'] = Variable<String>(note.value);
     }
+    if (source.present) {
+      map['source'] = Variable<String>(
+        $WorkoutSessionsTable.$convertersource.toSql(source.value),
+      );
+    }
     return map;
   }
 
@@ -797,7 +899,325 @@ class WorkoutSessionsCompanion extends UpdateCompanion<WorkoutSession> {
           ..write('id: $id, ')
           ..write('startedAt: $startedAt, ')
           ..write('endedAt: $endedAt, ')
-          ..write('note: $note')
+          ..write('note: $note, ')
+          ..write('source: $source')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $ExercisesTable extends Exercises
+    with TableInfo<$ExercisesTable, Exercise> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $ExercisesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _canonicalNameMeta = const VerificationMeta(
+    'canonicalName',
+  );
+  @override
+  late final GeneratedColumn<String> canonicalName = GeneratedColumn<String>(
+    'canonical_name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
+  );
+  static const VerificationMeta _muscleGroupMeta = const VerificationMeta(
+    'muscleGroup',
+  );
+  @override
+  late final GeneratedColumn<String> muscleGroup = GeneratedColumn<String>(
+    'muscle_group',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    canonicalName,
+    muscleGroup,
+    createdAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'exercises';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<Exercise> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('canonical_name')) {
+      context.handle(
+        _canonicalNameMeta,
+        canonicalName.isAcceptableOrUnknown(
+          data['canonical_name']!,
+          _canonicalNameMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_canonicalNameMeta);
+    }
+    if (data.containsKey('muscle_group')) {
+      context.handle(
+        _muscleGroupMeta,
+        muscleGroup.isAcceptableOrUnknown(
+          data['muscle_group']!,
+          _muscleGroupMeta,
+        ),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  Exercise map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Exercise(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      canonicalName: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}canonical_name'],
+      )!,
+      muscleGroup: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}muscle_group'],
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+    );
+  }
+
+  @override
+  $ExercisesTable createAlias(String alias) {
+    return $ExercisesTable(attachedDatabase, alias);
+  }
+}
+
+class Exercise extends DataClass implements Insertable<Exercise> {
+  final int id;
+  final String canonicalName;
+  final String? muscleGroup;
+  final DateTime createdAt;
+  const Exercise({
+    required this.id,
+    required this.canonicalName,
+    this.muscleGroup,
+    required this.createdAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['canonical_name'] = Variable<String>(canonicalName);
+    if (!nullToAbsent || muscleGroup != null) {
+      map['muscle_group'] = Variable<String>(muscleGroup);
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    return map;
+  }
+
+  ExercisesCompanion toCompanion(bool nullToAbsent) {
+    return ExercisesCompanion(
+      id: Value(id),
+      canonicalName: Value(canonicalName),
+      muscleGroup: muscleGroup == null && nullToAbsent
+          ? const Value.absent()
+          : Value(muscleGroup),
+      createdAt: Value(createdAt),
+    );
+  }
+
+  factory Exercise.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return Exercise(
+      id: serializer.fromJson<int>(json['id']),
+      canonicalName: serializer.fromJson<String>(json['canonicalName']),
+      muscleGroup: serializer.fromJson<String?>(json['muscleGroup']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'canonicalName': serializer.toJson<String>(canonicalName),
+      'muscleGroup': serializer.toJson<String?>(muscleGroup),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+    };
+  }
+
+  Exercise copyWith({
+    int? id,
+    String? canonicalName,
+    Value<String?> muscleGroup = const Value.absent(),
+    DateTime? createdAt,
+  }) => Exercise(
+    id: id ?? this.id,
+    canonicalName: canonicalName ?? this.canonicalName,
+    muscleGroup: muscleGroup.present ? muscleGroup.value : this.muscleGroup,
+    createdAt: createdAt ?? this.createdAt,
+  );
+  Exercise copyWithCompanion(ExercisesCompanion data) {
+    return Exercise(
+      id: data.id.present ? data.id.value : this.id,
+      canonicalName: data.canonicalName.present
+          ? data.canonicalName.value
+          : this.canonicalName,
+      muscleGroup: data.muscleGroup.present
+          ? data.muscleGroup.value
+          : this.muscleGroup,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('Exercise(')
+          ..write('id: $id, ')
+          ..write('canonicalName: $canonicalName, ')
+          ..write('muscleGroup: $muscleGroup, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, canonicalName, muscleGroup, createdAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Exercise &&
+          other.id == this.id &&
+          other.canonicalName == this.canonicalName &&
+          other.muscleGroup == this.muscleGroup &&
+          other.createdAt == this.createdAt);
+}
+
+class ExercisesCompanion extends UpdateCompanion<Exercise> {
+  final Value<int> id;
+  final Value<String> canonicalName;
+  final Value<String?> muscleGroup;
+  final Value<DateTime> createdAt;
+  const ExercisesCompanion({
+    this.id = const Value.absent(),
+    this.canonicalName = const Value.absent(),
+    this.muscleGroup = const Value.absent(),
+    this.createdAt = const Value.absent(),
+  });
+  ExercisesCompanion.insert({
+    this.id = const Value.absent(),
+    required String canonicalName,
+    this.muscleGroup = const Value.absent(),
+    required DateTime createdAt,
+  }) : canonicalName = Value(canonicalName),
+       createdAt = Value(createdAt);
+  static Insertable<Exercise> custom({
+    Expression<int>? id,
+    Expression<String>? canonicalName,
+    Expression<String>? muscleGroup,
+    Expression<DateTime>? createdAt,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (canonicalName != null) 'canonical_name': canonicalName,
+      if (muscleGroup != null) 'muscle_group': muscleGroup,
+      if (createdAt != null) 'created_at': createdAt,
+    });
+  }
+
+  ExercisesCompanion copyWith({
+    Value<int>? id,
+    Value<String>? canonicalName,
+    Value<String?>? muscleGroup,
+    Value<DateTime>? createdAt,
+  }) {
+    return ExercisesCompanion(
+      id: id ?? this.id,
+      canonicalName: canonicalName ?? this.canonicalName,
+      muscleGroup: muscleGroup ?? this.muscleGroup,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (canonicalName.present) {
+      map['canonical_name'] = Variable<String>(canonicalName.value);
+    }
+    if (muscleGroup.present) {
+      map['muscle_group'] = Variable<String>(muscleGroup.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ExercisesCompanion(')
+          ..write('id: $id, ')
+          ..write('canonicalName: $canonicalName, ')
+          ..write('muscleGroup: $muscleGroup, ')
+          ..write('createdAt: $createdAt')
           ..write(')'))
         .toString();
   }
@@ -894,6 +1314,30 @@ class $ExerciseSetsTable extends ExerciseSets
     type: DriftSqlType.int,
     requiredDuringInsert: true,
   );
+  static const VerificationMeta _exerciseIdMeta = const VerificationMeta(
+    'exerciseId',
+  );
+  @override
+  late final GeneratedColumn<int> exerciseId = GeneratedColumn<int>(
+    'exercise_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES exercises (id)',
+    ),
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<Source, String> source =
+      GeneratedColumn<String>(
+        'source',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        defaultValue: const Constant('userEntered'),
+      ).withConverter<Source>($ExerciseSetsTable.$convertersource);
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -904,6 +1348,8 @@ class $ExerciseSetsTable extends ExerciseSets
     weightUnit,
     status,
     orderIndex,
+    exerciseId,
+    source,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -963,6 +1409,12 @@ class $ExerciseSetsTable extends ExerciseSets
     } else if (isInserting) {
       context.missing(_orderIndexMeta);
     }
+    if (data.containsKey('exercise_id')) {
+      context.handle(
+        _exerciseIdMeta,
+        exerciseId.isAcceptableOrUnknown(data['exercise_id']!, _exerciseIdMeta),
+      );
+    }
     return context;
   }
 
@@ -1008,6 +1460,16 @@ class $ExerciseSetsTable extends ExerciseSets
         DriftSqlType.int,
         data['${effectivePrefix}order_index'],
       )!,
+      exerciseId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}exercise_id'],
+      ),
+      source: $ExerciseSetsTable.$convertersource.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}source'],
+        )!,
+      ),
     );
   }
 
@@ -1020,6 +1482,8 @@ class $ExerciseSetsTable extends ExerciseSets
       const EnumNameConverter<WeightUnit>(WeightUnit.values);
   static JsonTypeConverter2<WorkoutSetStatus, String, String> $converterstatus =
       const EnumNameConverter<WorkoutSetStatus>(WorkoutSetStatus.values);
+  static JsonTypeConverter2<Source, String, String> $convertersource =
+      const EnumNameConverter<Source>(Source.values);
 }
 
 class ExerciseSet extends DataClass implements Insertable<ExerciseSet> {
@@ -1031,6 +1495,8 @@ class ExerciseSet extends DataClass implements Insertable<ExerciseSet> {
   final WeightUnit weightUnit;
   final WorkoutSetStatus status;
   final int orderIndex;
+  final int? exerciseId;
+  final Source source;
   const ExerciseSet({
     required this.id,
     required this.sessionId,
@@ -1040,6 +1506,8 @@ class ExerciseSet extends DataClass implements Insertable<ExerciseSet> {
     required this.weightUnit,
     required this.status,
     required this.orderIndex,
+    this.exerciseId,
+    required this.source,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -1060,6 +1528,14 @@ class ExerciseSet extends DataClass implements Insertable<ExerciseSet> {
       );
     }
     map['order_index'] = Variable<int>(orderIndex);
+    if (!nullToAbsent || exerciseId != null) {
+      map['exercise_id'] = Variable<int>(exerciseId);
+    }
+    {
+      map['source'] = Variable<String>(
+        $ExerciseSetsTable.$convertersource.toSql(source),
+      );
+    }
     return map;
   }
 
@@ -1073,6 +1549,10 @@ class ExerciseSet extends DataClass implements Insertable<ExerciseSet> {
       weightUnit: Value(weightUnit),
       status: Value(status),
       orderIndex: Value(orderIndex),
+      exerciseId: exerciseId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(exerciseId),
+      source: Value(source),
     );
   }
 
@@ -1094,6 +1574,10 @@ class ExerciseSet extends DataClass implements Insertable<ExerciseSet> {
         serializer.fromJson<String>(json['status']),
       ),
       orderIndex: serializer.fromJson<int>(json['orderIndex']),
+      exerciseId: serializer.fromJson<int?>(json['exerciseId']),
+      source: $ExerciseSetsTable.$convertersource.fromJson(
+        serializer.fromJson<String>(json['source']),
+      ),
     );
   }
   @override
@@ -1112,6 +1596,10 @@ class ExerciseSet extends DataClass implements Insertable<ExerciseSet> {
         $ExerciseSetsTable.$converterstatus.toJson(status),
       ),
       'orderIndex': serializer.toJson<int>(orderIndex),
+      'exerciseId': serializer.toJson<int?>(exerciseId),
+      'source': serializer.toJson<String>(
+        $ExerciseSetsTable.$convertersource.toJson(source),
+      ),
     };
   }
 
@@ -1124,6 +1612,8 @@ class ExerciseSet extends DataClass implements Insertable<ExerciseSet> {
     WeightUnit? weightUnit,
     WorkoutSetStatus? status,
     int? orderIndex,
+    Value<int?> exerciseId = const Value.absent(),
+    Source? source,
   }) => ExerciseSet(
     id: id ?? this.id,
     sessionId: sessionId ?? this.sessionId,
@@ -1133,6 +1623,8 @@ class ExerciseSet extends DataClass implements Insertable<ExerciseSet> {
     weightUnit: weightUnit ?? this.weightUnit,
     status: status ?? this.status,
     orderIndex: orderIndex ?? this.orderIndex,
+    exerciseId: exerciseId.present ? exerciseId.value : this.exerciseId,
+    source: source ?? this.source,
   );
   ExerciseSet copyWithCompanion(ExerciseSetsCompanion data) {
     return ExerciseSet(
@@ -1150,6 +1642,10 @@ class ExerciseSet extends DataClass implements Insertable<ExerciseSet> {
       orderIndex: data.orderIndex.present
           ? data.orderIndex.value
           : this.orderIndex,
+      exerciseId: data.exerciseId.present
+          ? data.exerciseId.value
+          : this.exerciseId,
+      source: data.source.present ? data.source.value : this.source,
     );
   }
 
@@ -1163,7 +1659,9 @@ class ExerciseSet extends DataClass implements Insertable<ExerciseSet> {
           ..write('weight: $weight, ')
           ..write('weightUnit: $weightUnit, ')
           ..write('status: $status, ')
-          ..write('orderIndex: $orderIndex')
+          ..write('orderIndex: $orderIndex, ')
+          ..write('exerciseId: $exerciseId, ')
+          ..write('source: $source')
           ..write(')'))
         .toString();
   }
@@ -1178,6 +1676,8 @@ class ExerciseSet extends DataClass implements Insertable<ExerciseSet> {
     weightUnit,
     status,
     orderIndex,
+    exerciseId,
+    source,
   );
   @override
   bool operator ==(Object other) =>
@@ -1190,7 +1690,9 @@ class ExerciseSet extends DataClass implements Insertable<ExerciseSet> {
           other.weight == this.weight &&
           other.weightUnit == this.weightUnit &&
           other.status == this.status &&
-          other.orderIndex == this.orderIndex);
+          other.orderIndex == this.orderIndex &&
+          other.exerciseId == this.exerciseId &&
+          other.source == this.source);
 }
 
 class ExerciseSetsCompanion extends UpdateCompanion<ExerciseSet> {
@@ -1202,6 +1704,8 @@ class ExerciseSetsCompanion extends UpdateCompanion<ExerciseSet> {
   final Value<WeightUnit> weightUnit;
   final Value<WorkoutSetStatus> status;
   final Value<int> orderIndex;
+  final Value<int?> exerciseId;
+  final Value<Source> source;
   const ExerciseSetsCompanion({
     this.id = const Value.absent(),
     this.sessionId = const Value.absent(),
@@ -1211,6 +1715,8 @@ class ExerciseSetsCompanion extends UpdateCompanion<ExerciseSet> {
     this.weightUnit = const Value.absent(),
     this.status = const Value.absent(),
     this.orderIndex = const Value.absent(),
+    this.exerciseId = const Value.absent(),
+    this.source = const Value.absent(),
   });
   ExerciseSetsCompanion.insert({
     this.id = const Value.absent(),
@@ -1221,6 +1727,8 @@ class ExerciseSetsCompanion extends UpdateCompanion<ExerciseSet> {
     required WeightUnit weightUnit,
     required WorkoutSetStatus status,
     required int orderIndex,
+    this.exerciseId = const Value.absent(),
+    this.source = const Value.absent(),
   }) : sessionId = Value(sessionId),
        exerciseName = Value(exerciseName),
        reps = Value(reps),
@@ -1237,6 +1745,8 @@ class ExerciseSetsCompanion extends UpdateCompanion<ExerciseSet> {
     Expression<String>? weightUnit,
     Expression<String>? status,
     Expression<int>? orderIndex,
+    Expression<int>? exerciseId,
+    Expression<String>? source,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -1247,6 +1757,8 @@ class ExerciseSetsCompanion extends UpdateCompanion<ExerciseSet> {
       if (weightUnit != null) 'weight_unit': weightUnit,
       if (status != null) 'status': status,
       if (orderIndex != null) 'order_index': orderIndex,
+      if (exerciseId != null) 'exercise_id': exerciseId,
+      if (source != null) 'source': source,
     });
   }
 
@@ -1259,6 +1771,8 @@ class ExerciseSetsCompanion extends UpdateCompanion<ExerciseSet> {
     Value<WeightUnit>? weightUnit,
     Value<WorkoutSetStatus>? status,
     Value<int>? orderIndex,
+    Value<int?>? exerciseId,
+    Value<Source>? source,
   }) {
     return ExerciseSetsCompanion(
       id: id ?? this.id,
@@ -1269,6 +1783,8 @@ class ExerciseSetsCompanion extends UpdateCompanion<ExerciseSet> {
       weightUnit: weightUnit ?? this.weightUnit,
       status: status ?? this.status,
       orderIndex: orderIndex ?? this.orderIndex,
+      exerciseId: exerciseId ?? this.exerciseId,
+      source: source ?? this.source,
     );
   }
 
@@ -1303,6 +1819,14 @@ class ExerciseSetsCompanion extends UpdateCompanion<ExerciseSet> {
     if (orderIndex.present) {
       map['order_index'] = Variable<int>(orderIndex.value);
     }
+    if (exerciseId.present) {
+      map['exercise_id'] = Variable<int>(exerciseId.value);
+    }
+    if (source.present) {
+      map['source'] = Variable<String>(
+        $ExerciseSetsTable.$convertersource.toSql(source.value),
+      );
+    }
     return map;
   }
 
@@ -1316,7 +1840,9 @@ class ExerciseSetsCompanion extends UpdateCompanion<ExerciseSet> {
           ..write('weight: $weight, ')
           ..write('weightUnit: $weightUnit, ')
           ..write('status: $status, ')
-          ..write('orderIndex: $orderIndex')
+          ..write('orderIndex: $orderIndex, ')
+          ..write('exerciseId: $exerciseId, ')
+          ..write('source: $source')
           ..write(')'))
         .toString();
   }
@@ -1371,7 +1897,17 @@ class $BodyWeightLogsTable extends BodyWeightLogs
         requiredDuringInsert: true,
       ).withConverter<WeightUnit>($BodyWeightLogsTable.$converterunit);
   @override
-  List<GeneratedColumn> get $columns => [id, timestamp, value, unit];
+  late final GeneratedColumnWithTypeConverter<Source, String> source =
+      GeneratedColumn<String>(
+        'source',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        defaultValue: const Constant('userEntered'),
+      ).withConverter<Source>($BodyWeightLogsTable.$convertersource);
+  @override
+  List<GeneratedColumn> get $columns => [id, timestamp, value, unit, source];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -1430,6 +1966,12 @@ class $BodyWeightLogsTable extends BodyWeightLogs
           data['${effectivePrefix}unit'],
         )!,
       ),
+      source: $BodyWeightLogsTable.$convertersource.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}source'],
+        )!,
+      ),
     );
   }
 
@@ -1440,6 +1982,8 @@ class $BodyWeightLogsTable extends BodyWeightLogs
 
   static JsonTypeConverter2<WeightUnit, String, String> $converterunit =
       const EnumNameConverter<WeightUnit>(WeightUnit.values);
+  static JsonTypeConverter2<Source, String, String> $convertersource =
+      const EnumNameConverter<Source>(Source.values);
 }
 
 class BodyWeightLog extends DataClass implements Insertable<BodyWeightLog> {
@@ -1447,11 +1991,13 @@ class BodyWeightLog extends DataClass implements Insertable<BodyWeightLog> {
   final DateTime timestamp;
   final double value;
   final WeightUnit unit;
+  final Source source;
   const BodyWeightLog({
     required this.id,
     required this.timestamp,
     required this.value,
     required this.unit,
+    required this.source,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -1464,6 +2010,11 @@ class BodyWeightLog extends DataClass implements Insertable<BodyWeightLog> {
         $BodyWeightLogsTable.$converterunit.toSql(unit),
       );
     }
+    {
+      map['source'] = Variable<String>(
+        $BodyWeightLogsTable.$convertersource.toSql(source),
+      );
+    }
     return map;
   }
 
@@ -1473,6 +2024,7 @@ class BodyWeightLog extends DataClass implements Insertable<BodyWeightLog> {
       timestamp: Value(timestamp),
       value: Value(value),
       unit: Value(unit),
+      source: Value(source),
     );
   }
 
@@ -1488,6 +2040,9 @@ class BodyWeightLog extends DataClass implements Insertable<BodyWeightLog> {
       unit: $BodyWeightLogsTable.$converterunit.fromJson(
         serializer.fromJson<String>(json['unit']),
       ),
+      source: $BodyWeightLogsTable.$convertersource.fromJson(
+        serializer.fromJson<String>(json['source']),
+      ),
     );
   }
   @override
@@ -1500,6 +2055,9 @@ class BodyWeightLog extends DataClass implements Insertable<BodyWeightLog> {
       'unit': serializer.toJson<String>(
         $BodyWeightLogsTable.$converterunit.toJson(unit),
       ),
+      'source': serializer.toJson<String>(
+        $BodyWeightLogsTable.$convertersource.toJson(source),
+      ),
     };
   }
 
@@ -1508,11 +2066,13 @@ class BodyWeightLog extends DataClass implements Insertable<BodyWeightLog> {
     DateTime? timestamp,
     double? value,
     WeightUnit? unit,
+    Source? source,
   }) => BodyWeightLog(
     id: id ?? this.id,
     timestamp: timestamp ?? this.timestamp,
     value: value ?? this.value,
     unit: unit ?? this.unit,
+    source: source ?? this.source,
   );
   BodyWeightLog copyWithCompanion(BodyWeightLogsCompanion data) {
     return BodyWeightLog(
@@ -1520,6 +2080,7 @@ class BodyWeightLog extends DataClass implements Insertable<BodyWeightLog> {
       timestamp: data.timestamp.present ? data.timestamp.value : this.timestamp,
       value: data.value.present ? data.value.value : this.value,
       unit: data.unit.present ? data.unit.value : this.unit,
+      source: data.source.present ? data.source.value : this.source,
     );
   }
 
@@ -1529,13 +2090,14 @@ class BodyWeightLog extends DataClass implements Insertable<BodyWeightLog> {
           ..write('id: $id, ')
           ..write('timestamp: $timestamp, ')
           ..write('value: $value, ')
-          ..write('unit: $unit')
+          ..write('unit: $unit, ')
+          ..write('source: $source')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(id, timestamp, value, unit);
+  int get hashCode => Object.hash(id, timestamp, value, unit, source);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -1543,7 +2105,8 @@ class BodyWeightLog extends DataClass implements Insertable<BodyWeightLog> {
           other.id == this.id &&
           other.timestamp == this.timestamp &&
           other.value == this.value &&
-          other.unit == this.unit);
+          other.unit == this.unit &&
+          other.source == this.source);
 }
 
 class BodyWeightLogsCompanion extends UpdateCompanion<BodyWeightLog> {
@@ -1551,17 +2114,20 @@ class BodyWeightLogsCompanion extends UpdateCompanion<BodyWeightLog> {
   final Value<DateTime> timestamp;
   final Value<double> value;
   final Value<WeightUnit> unit;
+  final Value<Source> source;
   const BodyWeightLogsCompanion({
     this.id = const Value.absent(),
     this.timestamp = const Value.absent(),
     this.value = const Value.absent(),
     this.unit = const Value.absent(),
+    this.source = const Value.absent(),
   });
   BodyWeightLogsCompanion.insert({
     this.id = const Value.absent(),
     required DateTime timestamp,
     required double value,
     required WeightUnit unit,
+    this.source = const Value.absent(),
   }) : timestamp = Value(timestamp),
        value = Value(value),
        unit = Value(unit);
@@ -1570,12 +2136,14 @@ class BodyWeightLogsCompanion extends UpdateCompanion<BodyWeightLog> {
     Expression<DateTime>? timestamp,
     Expression<double>? value,
     Expression<String>? unit,
+    Expression<String>? source,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
       if (timestamp != null) 'timestamp': timestamp,
       if (value != null) 'value': value,
       if (unit != null) 'unit': unit,
+      if (source != null) 'source': source,
     });
   }
 
@@ -1584,12 +2152,14 @@ class BodyWeightLogsCompanion extends UpdateCompanion<BodyWeightLog> {
     Value<DateTime>? timestamp,
     Value<double>? value,
     Value<WeightUnit>? unit,
+    Value<Source>? source,
   }) {
     return BodyWeightLogsCompanion(
       id: id ?? this.id,
       timestamp: timestamp ?? this.timestamp,
       value: value ?? this.value,
       unit: unit ?? this.unit,
+      source: source ?? this.source,
     );
   }
 
@@ -1610,6 +2180,11 @@ class BodyWeightLogsCompanion extends UpdateCompanion<BodyWeightLog> {
         $BodyWeightLogsTable.$converterunit.toSql(unit.value),
       );
     }
+    if (source.present) {
+      map['source'] = Variable<String>(
+        $BodyWeightLogsTable.$convertersource.toSql(source.value),
+      );
+    }
     return map;
   }
 
@@ -1619,7 +2194,8 @@ class BodyWeightLogsCompanion extends UpdateCompanion<BodyWeightLog> {
           ..write('id: $id, ')
           ..write('timestamp: $timestamp, ')
           ..write('value: $value, ')
-          ..write('unit: $unit')
+          ..write('unit: $unit, ')
+          ..write('source: $source')
           ..write(')'))
         .toString();
   }
@@ -1632,6 +2208,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $WorkoutSessionsTable workoutSessions = $WorkoutSessionsTable(
     this,
   );
+  late final $ExercisesTable exercises = $ExercisesTable(this);
   late final $ExerciseSetsTable exerciseSets = $ExerciseSetsTable(this);
   late final $BodyWeightLogsTable bodyWeightLogs = $BodyWeightLogsTable(this);
   @override
@@ -1641,6 +2218,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   List<DatabaseSchemaEntity> get allSchemaEntities => [
     foodEntries,
     workoutSessions,
+    exercises,
     exerciseSets,
     bodyWeightLogs,
   ];
@@ -1666,6 +2244,7 @@ typedef $$FoodEntriesTableCreateCompanionBuilder =
       required MealType mealType,
       required FoodEntryType entryType,
       Value<String?> note,
+      Value<Source> source,
     });
 typedef $$FoodEntriesTableUpdateCompanionBuilder =
     FoodEntriesCompanion Function({
@@ -1677,6 +2256,7 @@ typedef $$FoodEntriesTableUpdateCompanionBuilder =
       Value<MealType> mealType,
       Value<FoodEntryType> entryType,
       Value<String?> note,
+      Value<Source> source,
     });
 
 class $$FoodEntriesTableFilterComposer
@@ -1729,6 +2309,12 @@ class $$FoodEntriesTableFilterComposer
     column: $table.note,
     builder: (column) => ColumnFilters(column),
   );
+
+  ColumnWithTypeConverterFilters<Source, Source, String> get source =>
+      $composableBuilder(
+        column: $table.source,
+        builder: (column) => ColumnWithTypeConverterFilters(column),
+      );
 }
 
 class $$FoodEntriesTableOrderingComposer
@@ -1779,6 +2365,11 @@ class $$FoodEntriesTableOrderingComposer
     column: $table.note,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<String> get source => $composableBuilder(
+    column: $table.source,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$FoodEntriesTableAnnotationComposer
@@ -1813,6 +2404,9 @@ class $$FoodEntriesTableAnnotationComposer
 
   GeneratedColumn<String> get note =>
       $composableBuilder(column: $table.note, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<Source, String> get source =>
+      $composableBuilder(column: $table.source, builder: (column) => column);
 }
 
 class $$FoodEntriesTableTableManager
@@ -1854,6 +2448,7 @@ class $$FoodEntriesTableTableManager
                 Value<MealType> mealType = const Value.absent(),
                 Value<FoodEntryType> entryType = const Value.absent(),
                 Value<String?> note = const Value.absent(),
+                Value<Source> source = const Value.absent(),
               }) => FoodEntriesCompanion(
                 id: id,
                 timestamp: timestamp,
@@ -1863,6 +2458,7 @@ class $$FoodEntriesTableTableManager
                 mealType: mealType,
                 entryType: entryType,
                 note: note,
+                source: source,
               ),
           createCompanionCallback:
               ({
@@ -1874,6 +2470,7 @@ class $$FoodEntriesTableTableManager
                 required MealType mealType,
                 required FoodEntryType entryType,
                 Value<String?> note = const Value.absent(),
+                Value<Source> source = const Value.absent(),
               }) => FoodEntriesCompanion.insert(
                 id: id,
                 timestamp: timestamp,
@@ -1883,6 +2480,7 @@ class $$FoodEntriesTableTableManager
                 mealType: mealType,
                 entryType: entryType,
                 note: note,
+                source: source,
               ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
@@ -1912,6 +2510,7 @@ typedef $$WorkoutSessionsTableCreateCompanionBuilder =
       required DateTime startedAt,
       Value<DateTime?> endedAt,
       Value<String?> note,
+      Value<Source> source,
     });
 typedef $$WorkoutSessionsTableUpdateCompanionBuilder =
     WorkoutSessionsCompanion Function({
@@ -1919,6 +2518,7 @@ typedef $$WorkoutSessionsTableUpdateCompanionBuilder =
       Value<DateTime> startedAt,
       Value<DateTime?> endedAt,
       Value<String?> note,
+      Value<Source> source,
     });
 
 final class $$WorkoutSessionsTableReferences
@@ -1981,6 +2581,12 @@ class $$WorkoutSessionsTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnWithTypeConverterFilters<Source, Source, String> get source =>
+      $composableBuilder(
+        column: $table.source,
+        builder: (column) => ColumnWithTypeConverterFilters(column),
+      );
+
   Expression<bool> exerciseSetsRefs(
     Expression<bool> Function($$ExerciseSetsTableFilterComposer f) f,
   ) {
@@ -2035,6 +2641,11 @@ class $$WorkoutSessionsTableOrderingComposer
     column: $table.note,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<String> get source => $composableBuilder(
+    column: $table.source,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$WorkoutSessionsTableAnnotationComposer
@@ -2057,6 +2668,9 @@ class $$WorkoutSessionsTableAnnotationComposer
 
   GeneratedColumn<String> get note =>
       $composableBuilder(column: $table.note, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<Source, String> get source =>
+      $composableBuilder(column: $table.source, builder: (column) => column);
 
   Expression<T> exerciseSetsRefs<T extends Object>(
     Expression<T> Function($$ExerciseSetsTableAnnotationComposer a) f,
@@ -2118,11 +2732,13 @@ class $$WorkoutSessionsTableTableManager
                 Value<DateTime> startedAt = const Value.absent(),
                 Value<DateTime?> endedAt = const Value.absent(),
                 Value<String?> note = const Value.absent(),
+                Value<Source> source = const Value.absent(),
               }) => WorkoutSessionsCompanion(
                 id: id,
                 startedAt: startedAt,
                 endedAt: endedAt,
                 note: note,
+                source: source,
               ),
           createCompanionCallback:
               ({
@@ -2130,11 +2746,13 @@ class $$WorkoutSessionsTableTableManager
                 required DateTime startedAt,
                 Value<DateTime?> endedAt = const Value.absent(),
                 Value<String?> note = const Value.absent(),
+                Value<Source> source = const Value.absent(),
               }) => WorkoutSessionsCompanion.insert(
                 id: id,
                 startedAt: startedAt,
                 endedAt: endedAt,
                 note: note,
+                source: source,
               ),
           withReferenceMapper: (p0) => p0
               .map(
@@ -2192,6 +2810,289 @@ typedef $$WorkoutSessionsTableProcessedTableManager =
       WorkoutSession,
       PrefetchHooks Function({bool exerciseSetsRefs})
     >;
+typedef $$ExercisesTableCreateCompanionBuilder =
+    ExercisesCompanion Function({
+      Value<int> id,
+      required String canonicalName,
+      Value<String?> muscleGroup,
+      required DateTime createdAt,
+    });
+typedef $$ExercisesTableUpdateCompanionBuilder =
+    ExercisesCompanion Function({
+      Value<int> id,
+      Value<String> canonicalName,
+      Value<String?> muscleGroup,
+      Value<DateTime> createdAt,
+    });
+
+final class $$ExercisesTableReferences
+    extends BaseReferences<_$AppDatabase, $ExercisesTable, Exercise> {
+  $$ExercisesTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<$ExerciseSetsTable, List<ExerciseSet>>
+  _exerciseSetsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+    db.exerciseSets,
+    aliasName: $_aliasNameGenerator(
+      db.exercises.id,
+      db.exerciseSets.exerciseId,
+    ),
+  );
+
+  $$ExerciseSetsTableProcessedTableManager get exerciseSetsRefs {
+    final manager = $$ExerciseSetsTableTableManager(
+      $_db,
+      $_db.exerciseSets,
+    ).filter((f) => f.exerciseId.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_exerciseSetsRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
+
+class $$ExercisesTableFilterComposer
+    extends Composer<_$AppDatabase, $ExercisesTable> {
+  $$ExercisesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get canonicalName => $composableBuilder(
+    column: $table.canonicalName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get muscleGroup => $composableBuilder(
+    column: $table.muscleGroup,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  Expression<bool> exerciseSetsRefs(
+    Expression<bool> Function($$ExerciseSetsTableFilterComposer f) f,
+  ) {
+    final $$ExerciseSetsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.exerciseSets,
+      getReferencedColumn: (t) => t.exerciseId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ExerciseSetsTableFilterComposer(
+            $db: $db,
+            $table: $db.exerciseSets,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$ExercisesTableOrderingComposer
+    extends Composer<_$AppDatabase, $ExercisesTable> {
+  $$ExercisesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get canonicalName => $composableBuilder(
+    column: $table.canonicalName,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get muscleGroup => $composableBuilder(
+    column: $table.muscleGroup,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$ExercisesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $ExercisesTable> {
+  $$ExercisesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get canonicalName => $composableBuilder(
+    column: $table.canonicalName,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get muscleGroup => $composableBuilder(
+    column: $table.muscleGroup,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  Expression<T> exerciseSetsRefs<T extends Object>(
+    Expression<T> Function($$ExerciseSetsTableAnnotationComposer a) f,
+  ) {
+    final $$ExerciseSetsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.exerciseSets,
+      getReferencedColumn: (t) => t.exerciseId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ExerciseSetsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.exerciseSets,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$ExercisesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $ExercisesTable,
+          Exercise,
+          $$ExercisesTableFilterComposer,
+          $$ExercisesTableOrderingComposer,
+          $$ExercisesTableAnnotationComposer,
+          $$ExercisesTableCreateCompanionBuilder,
+          $$ExercisesTableUpdateCompanionBuilder,
+          (Exercise, $$ExercisesTableReferences),
+          Exercise,
+          PrefetchHooks Function({bool exerciseSetsRefs})
+        > {
+  $$ExercisesTableTableManager(_$AppDatabase db, $ExercisesTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$ExercisesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$ExercisesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$ExercisesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> canonicalName = const Value.absent(),
+                Value<String?> muscleGroup = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+              }) => ExercisesCompanion(
+                id: id,
+                canonicalName: canonicalName,
+                muscleGroup: muscleGroup,
+                createdAt: createdAt,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String canonicalName,
+                Value<String?> muscleGroup = const Value.absent(),
+                required DateTime createdAt,
+              }) => ExercisesCompanion.insert(
+                id: id,
+                canonicalName: canonicalName,
+                muscleGroup: muscleGroup,
+                createdAt: createdAt,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$ExercisesTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({exerciseSetsRefs = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [if (exerciseSetsRefs) db.exerciseSets],
+              addJoins: null,
+              getPrefetchedDataCallback: (items) async {
+                return [
+                  if (exerciseSetsRefs)
+                    await $_getPrefetchedData<
+                      Exercise,
+                      $ExercisesTable,
+                      ExerciseSet
+                    >(
+                      currentTable: table,
+                      referencedTable: $$ExercisesTableReferences
+                          ._exerciseSetsRefsTable(db),
+                      managerFromTypedResult: (p0) =>
+                          $$ExercisesTableReferences(
+                            db,
+                            table,
+                            p0,
+                          ).exerciseSetsRefs,
+                      referencedItemsForCurrentItem: (item, referencedItems) =>
+                          referencedItems.where((e) => e.exerciseId == item.id),
+                      typedResults: items,
+                    ),
+                ];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$ExercisesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $ExercisesTable,
+      Exercise,
+      $$ExercisesTableFilterComposer,
+      $$ExercisesTableOrderingComposer,
+      $$ExercisesTableAnnotationComposer,
+      $$ExercisesTableCreateCompanionBuilder,
+      $$ExercisesTableUpdateCompanionBuilder,
+      (Exercise, $$ExercisesTableReferences),
+      Exercise,
+      PrefetchHooks Function({bool exerciseSetsRefs})
+    >;
 typedef $$ExerciseSetsTableCreateCompanionBuilder =
     ExerciseSetsCompanion Function({
       Value<int> id,
@@ -2202,6 +3103,8 @@ typedef $$ExerciseSetsTableCreateCompanionBuilder =
       required WeightUnit weightUnit,
       required WorkoutSetStatus status,
       required int orderIndex,
+      Value<int?> exerciseId,
+      Value<Source> source,
     });
 typedef $$ExerciseSetsTableUpdateCompanionBuilder =
     ExerciseSetsCompanion Function({
@@ -2213,6 +3116,8 @@ typedef $$ExerciseSetsTableUpdateCompanionBuilder =
       Value<WeightUnit> weightUnit,
       Value<WorkoutSetStatus> status,
       Value<int> orderIndex,
+      Value<int?> exerciseId,
+      Value<Source> source,
     });
 
 final class $$ExerciseSetsTableReferences
@@ -2232,6 +3137,25 @@ final class $$ExerciseSetsTableReferences
       $_db.workoutSessions,
     ).filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_sessionIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static $ExercisesTable _exerciseIdTable(_$AppDatabase db) =>
+      db.exercises.createAlias(
+        $_aliasNameGenerator(db.exerciseSets.exerciseId, db.exercises.id),
+      );
+
+  $$ExercisesTableProcessedTableManager? get exerciseId {
+    final $_column = $_itemColumn<int>('exercise_id');
+    if ($_column == null) return null;
+    final manager = $$ExercisesTableTableManager(
+      $_db,
+      $_db.exercises,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_exerciseIdTable($_db));
     if (item == null) return manager;
     return ProcessedTableManager(
       manager.$state.copyWith(prefetchedData: [item]),
@@ -2285,6 +3209,12 @@ class $$ExerciseSetsTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnWithTypeConverterFilters<Source, Source, String> get source =>
+      $composableBuilder(
+        column: $table.source,
+        builder: (column) => ColumnWithTypeConverterFilters(column),
+      );
+
   $$WorkoutSessionsTableFilterComposer get sessionId {
     final $$WorkoutSessionsTableFilterComposer composer = $composerBuilder(
       composer: this,
@@ -2299,6 +3229,29 @@ class $$ExerciseSetsTableFilterComposer
           }) => $$WorkoutSessionsTableFilterComposer(
             $db: $db,
             $table: $db.workoutSessions,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$ExercisesTableFilterComposer get exerciseId {
+    final $$ExercisesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.exerciseId,
+      referencedTable: $db.exercises,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ExercisesTableFilterComposer(
+            $db: $db,
+            $table: $db.exercises,
             $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
             joinBuilder: joinBuilder,
             $removeJoinBuilderFromRootComposer:
@@ -2353,6 +3306,11 @@ class $$ExerciseSetsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get source => $composableBuilder(
+    column: $table.source,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   $$WorkoutSessionsTableOrderingComposer get sessionId {
     final $$WorkoutSessionsTableOrderingComposer composer = $composerBuilder(
       composer: this,
@@ -2367,6 +3325,29 @@ class $$ExerciseSetsTableOrderingComposer
           }) => $$WorkoutSessionsTableOrderingComposer(
             $db: $db,
             $table: $db.workoutSessions,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$ExercisesTableOrderingComposer get exerciseId {
+    final $$ExercisesTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.exerciseId,
+      referencedTable: $db.exercises,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ExercisesTableOrderingComposer(
+            $db: $db,
+            $table: $db.exercises,
             $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
             joinBuilder: joinBuilder,
             $removeJoinBuilderFromRootComposer:
@@ -2414,6 +3395,9 @@ class $$ExerciseSetsTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumnWithTypeConverter<Source, String> get source =>
+      $composableBuilder(column: $table.source, builder: (column) => column);
+
   $$WorkoutSessionsTableAnnotationComposer get sessionId {
     final $$WorkoutSessionsTableAnnotationComposer composer = $composerBuilder(
       composer: this,
@@ -2428,6 +3412,29 @@ class $$ExerciseSetsTableAnnotationComposer
           }) => $$WorkoutSessionsTableAnnotationComposer(
             $db: $db,
             $table: $db.workoutSessions,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$ExercisesTableAnnotationComposer get exerciseId {
+    final $$ExercisesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.exerciseId,
+      referencedTable: $db.exercises,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ExercisesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.exercises,
             $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
             joinBuilder: joinBuilder,
             $removeJoinBuilderFromRootComposer:
@@ -2451,7 +3458,7 @@ class $$ExerciseSetsTableTableManager
           $$ExerciseSetsTableUpdateCompanionBuilder,
           (ExerciseSet, $$ExerciseSetsTableReferences),
           ExerciseSet,
-          PrefetchHooks Function({bool sessionId})
+          PrefetchHooks Function({bool sessionId, bool exerciseId})
         > {
   $$ExerciseSetsTableTableManager(_$AppDatabase db, $ExerciseSetsTable table)
     : super(
@@ -2474,6 +3481,8 @@ class $$ExerciseSetsTableTableManager
                 Value<WeightUnit> weightUnit = const Value.absent(),
                 Value<WorkoutSetStatus> status = const Value.absent(),
                 Value<int> orderIndex = const Value.absent(),
+                Value<int?> exerciseId = const Value.absent(),
+                Value<Source> source = const Value.absent(),
               }) => ExerciseSetsCompanion(
                 id: id,
                 sessionId: sessionId,
@@ -2483,6 +3492,8 @@ class $$ExerciseSetsTableTableManager
                 weightUnit: weightUnit,
                 status: status,
                 orderIndex: orderIndex,
+                exerciseId: exerciseId,
+                source: source,
               ),
           createCompanionCallback:
               ({
@@ -2494,6 +3505,8 @@ class $$ExerciseSetsTableTableManager
                 required WeightUnit weightUnit,
                 required WorkoutSetStatus status,
                 required int orderIndex,
+                Value<int?> exerciseId = const Value.absent(),
+                Value<Source> source = const Value.absent(),
               }) => ExerciseSetsCompanion.insert(
                 id: id,
                 sessionId: sessionId,
@@ -2503,6 +3516,8 @@ class $$ExerciseSetsTableTableManager
                 weightUnit: weightUnit,
                 status: status,
                 orderIndex: orderIndex,
+                exerciseId: exerciseId,
+                source: source,
               ),
           withReferenceMapper: (p0) => p0
               .map(
@@ -2512,7 +3527,7 @@ class $$ExerciseSetsTableTableManager
                 ),
               )
               .toList(),
-          prefetchHooksCallback: ({sessionId = false}) {
+          prefetchHooksCallback: ({sessionId = false, exerciseId = false}) {
             return PrefetchHooks(
               db: db,
               explicitlyWatchedTables: [],
@@ -2545,6 +3560,19 @@ class $$ExerciseSetsTableTableManager
                               )
                               as T;
                     }
+                    if (exerciseId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.exerciseId,
+                                referencedTable: $$ExerciseSetsTableReferences
+                                    ._exerciseIdTable(db),
+                                referencedColumn: $$ExerciseSetsTableReferences
+                                    ._exerciseIdTable(db)
+                                    .id,
+                              )
+                              as T;
+                    }
 
                     return state;
                   },
@@ -2569,7 +3597,7 @@ typedef $$ExerciseSetsTableProcessedTableManager =
       $$ExerciseSetsTableUpdateCompanionBuilder,
       (ExerciseSet, $$ExerciseSetsTableReferences),
       ExerciseSet,
-      PrefetchHooks Function({bool sessionId})
+      PrefetchHooks Function({bool sessionId, bool exerciseId})
     >;
 typedef $$BodyWeightLogsTableCreateCompanionBuilder =
     BodyWeightLogsCompanion Function({
@@ -2577,6 +3605,7 @@ typedef $$BodyWeightLogsTableCreateCompanionBuilder =
       required DateTime timestamp,
       required double value,
       required WeightUnit unit,
+      Value<Source> source,
     });
 typedef $$BodyWeightLogsTableUpdateCompanionBuilder =
     BodyWeightLogsCompanion Function({
@@ -2584,6 +3613,7 @@ typedef $$BodyWeightLogsTableUpdateCompanionBuilder =
       Value<DateTime> timestamp,
       Value<double> value,
       Value<WeightUnit> unit,
+      Value<Source> source,
     });
 
 class $$BodyWeightLogsTableFilterComposer
@@ -2613,6 +3643,12 @@ class $$BodyWeightLogsTableFilterComposer
   ColumnWithTypeConverterFilters<WeightUnit, WeightUnit, String> get unit =>
       $composableBuilder(
         column: $table.unit,
+        builder: (column) => ColumnWithTypeConverterFilters(column),
+      );
+
+  ColumnWithTypeConverterFilters<Source, Source, String> get source =>
+      $composableBuilder(
+        column: $table.source,
         builder: (column) => ColumnWithTypeConverterFilters(column),
       );
 }
@@ -2645,6 +3681,11 @@ class $$BodyWeightLogsTableOrderingComposer
     column: $table.unit,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<String> get source => $composableBuilder(
+    column: $table.source,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$BodyWeightLogsTableAnnotationComposer
@@ -2667,6 +3708,9 @@ class $$BodyWeightLogsTableAnnotationComposer
 
   GeneratedColumnWithTypeConverter<WeightUnit, String> get unit =>
       $composableBuilder(column: $table.unit, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<Source, String> get source =>
+      $composableBuilder(column: $table.source, builder: (column) => column);
 }
 
 class $$BodyWeightLogsTableTableManager
@@ -2706,11 +3750,13 @@ class $$BodyWeightLogsTableTableManager
                 Value<DateTime> timestamp = const Value.absent(),
                 Value<double> value = const Value.absent(),
                 Value<WeightUnit> unit = const Value.absent(),
+                Value<Source> source = const Value.absent(),
               }) => BodyWeightLogsCompanion(
                 id: id,
                 timestamp: timestamp,
                 value: value,
                 unit: unit,
+                source: source,
               ),
           createCompanionCallback:
               ({
@@ -2718,11 +3764,13 @@ class $$BodyWeightLogsTableTableManager
                 required DateTime timestamp,
                 required double value,
                 required WeightUnit unit,
+                Value<Source> source = const Value.absent(),
               }) => BodyWeightLogsCompanion.insert(
                 id: id,
                 timestamp: timestamp,
                 value: value,
                 unit: unit,
+                source: source,
               ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
@@ -2757,6 +3805,8 @@ class $AppDatabaseManager {
       $$FoodEntriesTableTableManager(_db, _db.foodEntries);
   $$WorkoutSessionsTableTableManager get workoutSessions =>
       $$WorkoutSessionsTableTableManager(_db, _db.workoutSessions);
+  $$ExercisesTableTableManager get exercises =>
+      $$ExercisesTableTableManager(_db, _db.exercises);
   $$ExerciseSetsTableTableManager get exerciseSets =>
       $$ExerciseSetsTableTableManager(_db, _db.exerciseSets);
   $$BodyWeightLogsTableTableManager get bodyWeightLogs =>

--- a/lib/data/enums.dart
+++ b/lib/data/enums.dart
@@ -5,3 +5,31 @@ enum FoodEntryType { manual, savedFood, barcode, estimate }
 enum WorkoutSetStatus { planned, completed, skipped }
 
 enum WeightUnit { kg, lb }
+
+/// Provenance — where a row's values came from.
+///
+/// First-class per v2.0 trust rules: every entity (food, body weight,
+/// workout session, exercise set) must declare its `Source`. Orthogonal
+/// to `FoodEntryType` — do not conflate. `FoodEntryType` captures the
+/// food-domain shape of an entry (manual text, a saved template, a
+/// barcode lookup, an estimate); `Source` captures the provenance
+/// channel the row came in through (user-entered, HealthKit import,
+/// photo/voice-estimated, derived, etc.).
+///
+/// Stored via `textEnum<Source>()` — Dart `.name` is the storage string
+/// (`"userEntered"`, `"savedTemplate"`, ...) — consistent with the
+/// existing `MealType` / `FoodEntryType` / `WeightUnit` pattern.
+///
+/// See CLAUDE.md (canonical enums) and the v2.0 contract. Features must
+/// never construct `Source` values directly — they receive them from
+/// repositories. Enforced by `test/arch/data_access_boundary_test.dart`.
+enum Source {
+  userEntered,
+  savedTemplate,
+  healthKit,
+  photoEstimate,
+  voiceEstimate,
+  barcode,
+  derived,
+  imported,
+}

--- a/lib/data/repositories/exercise_repository.dart
+++ b/lib/data/repositories/exercise_repository.dart
@@ -1,0 +1,86 @@
+import 'package:drift/drift.dart';
+
+import '../database.dart';
+import '../enums.dart';
+
+/// Access to the first-class `Exercises` table (schema v3 — issue #42).
+///
+/// The `exercises` table was introduced so future adaptive-programming
+/// features can address an exercise by id rather than free-form name.
+/// For sprint 1 the UI still writes `exerciseName` on `ExerciseSets` as
+/// the authoritative name source; this repository is the read surface
+/// for the catalogue plus an `addIfMissing` write path so callers (e.g.
+/// the v2→v3 seeding pass, or future exercise-pickers) can idempotently
+/// register a new exercise without racing the UNIQUE constraint.
+class ExerciseRepository {
+  ExerciseRepository(this._db);
+
+  final AppDatabase _db;
+
+  /// Streams every row, newest-first. Ordering prefers `createdAt DESC`
+  /// and breaks ties on `id DESC` so rows created inside the same Dart
+  /// tick (seeding pass uses a single `DateTime.now()`) stay stable.
+  Stream<List<Exercise>> watchAll() => (_db.select(_db.exercises)
+        ..orderBy([
+          (t) => OrderingTerm.desc(t.createdAt),
+          (t) => OrderingTerm.desc(t.id),
+        ]))
+      .watch();
+
+  /// One-shot counterpart to [watchAll]. Widget tests use this to avoid
+  /// the Drift + fake_async hang — see the v2 trust-rules note in
+  /// `CLAUDE.md` about always pairing `watch*` with `list*`.
+  Future<List<Exercise>> listAll() => (_db.select(_db.exercises)
+        ..orderBy([
+          (t) => OrderingTerm.desc(t.createdAt),
+          (t) => OrderingTerm.desc(t.id),
+        ]))
+      .get();
+
+  /// Returns the row whose `canonicalName == name`, or `null` if no
+  /// row matches. Exact-match lookup (case-sensitive, no trimming) —
+  /// mirrors how `ExerciseSetRepository.listRecentDistinctExerciseNames`
+  /// refuses to canonicalize whitespace: silent normalization would
+  /// mutate what the user sees (trust-rule violation).
+  Future<Exercise?> findByName(String name) => (_db.select(_db.exercises)
+        ..where((t) => t.canonicalName.equals(name))
+        ..limit(1))
+      .getSingleOrNull();
+
+  /// Inserts `name` if it isn't already present, then returns the row
+  /// (either the existing one or the one just inserted).
+  ///
+  /// Idempotent: the `canonicalName UNIQUE` constraint combined with
+  /// `InsertMode.insertOrIgnore` means concurrent callers race safely —
+  /// at worst we no-op and re-read. The `source` argument is required
+  /// (first-class provenance per v2.0 trust rules) but is not persisted
+  /// on the `Exercises` table itself; it exists on the argument list so
+  /// callers are forced to declare where the insert came from, and so
+  /// future schema additions (e.g. per-row `source`) don't require
+  /// call-site changes. `muscleGroup` is optional.
+  Future<Exercise> addIfMissing(
+    String name, {
+    String? muscleGroup,
+    required Source source,
+  }) async {
+    await _db.into(_db.exercises).insert(
+          ExercisesCompanion.insert(
+            canonicalName: name,
+            createdAt: DateTime.now(),
+            muscleGroup: Value(muscleGroup),
+          ),
+          mode: InsertMode.insertOrIgnore,
+        );
+    final row = await findByName(name);
+    if (row == null) {
+      // Should be unreachable: the insert-or-ignore either created the
+      // row or found one already present. Surface rather than silently
+      // return a placeholder — no silent fallbacks (CLAUDE.md).
+      throw StateError(
+        'ExerciseRepository.addIfMissing: row for "$name" not found after '
+        'insertOrIgnore; the UNIQUE constraint may have been dropped.',
+      );
+    }
+    return row;
+  }
+}

--- a/lib/providers/app_providers.dart
+++ b/lib/providers/app_providers.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../data/database.dart';
 import '../data/repositories/body_weight_log_repository.dart';
+import '../data/repositories/exercise_repository.dart';
 import '../data/repositories/exercise_set_repository.dart';
 import '../data/repositories/food_entry_repository.dart';
 import '../data/repositories/workout_session_repository.dart';
@@ -26,4 +27,8 @@ final exerciseSetRepositoryProvider = Provider<ExerciseSetRepository>((ref) {
 
 final bodyWeightLogRepositoryProvider = Provider<BodyWeightLogRepository>((ref) {
   return BodyWeightLogRepository(ref.watch(appDatabaseProvider));
+});
+
+final exerciseRepositoryProvider = Provider<ExerciseRepository>((ref) {
+  return ExerciseRepository(ref.watch(appDatabaseProvider));
 });

--- a/test/arch/data_access_boundary_test.dart
+++ b/test/arch/data_access_boundary_test.dart
@@ -15,6 +15,23 @@
 //   comment `// drift-write-ok:` opts out — used only when we need `write`
 //   for a legitimate reason (justified in a PR).
 //
+// Rule 3 — `lib/sources/**` is a data-boundary layer (forward-looking,
+//   anticipates S4.3 integration sources like HealthKit / barcode /
+//   photo-estimate). Feature code must only import the bare façade file
+//   from a source module, never the implementation files inside.
+//   Convention: a façade file's path ends with `_source.dart` (e.g.
+//   `lib/sources/healthkit/healthkit_source.dart`). Any feature import of
+//   a non-façade file under `lib/sources/<name>/` fails. The rule runs
+//   even when `lib/sources/` doesn't exist yet — it simply finds nothing
+//   to flag, keeping the test machinery ready the day a first source
+//   module lands. See CLAUDE.md (data-access boundary, v2.0 contract).
+//
+// Rule 4 — `FoodEntryType` and `Source` are orthogonal — do not conflate.
+//   Feature code (`lib/features/**`) must never reference `Source.` —
+//   features receive `Source`-typed values from repositories, they don't
+//   construct them raw. Tests (`test/**`) may use `Source.` freely. See
+//   CLAUDE.md (canonical enums, v2.0 trust rules).
+//
 // Implementation is deliberately plain: File.readAsStringSync + regex +
 // manual Directory walks. No build_runner reflection, no glob packages.
 // Keep regexes narrow; brittleness is the known risk.
@@ -30,6 +47,7 @@ void main() {
   final projectRoot = _findProjectRoot();
   final featuresDir = Directory(p.join(projectRoot, 'lib', 'features'));
   final reposDir = Directory(p.join(projectRoot, 'lib', 'data', 'repositories'));
+  final sourcesDir = Directory(p.join(projectRoot, 'lib', 'sources'));
 
   group('data access boundary', () {
     test('feature code does not reach into Drift directly', () {
@@ -84,6 +102,98 @@ void main() {
         violations,
         isEmpty,
         reason: 'Feature code must go through repositories. Violations:\n'
+            '${violations.join('\n')}',
+      );
+    });
+
+    test('feature code imports only the lib/sources/<name>/ façade', () {
+      // Forward-looking rule (see Rule 3 at top of file). Convention:
+      // a façade file's path ends with `_source.dart`. Implementation
+      // files inside `lib/sources/<name>/` are off-limits to feature
+      // code — features must depend only on the façade.
+      //
+      // If `lib/sources/` doesn't exist yet this test runs clean (there
+      // is nothing to import); the rule still catches the first
+      // offender the day a source module lands.
+      //
+      // Regex anatomy:
+      //   ^\s*import\s+['"]          — import directive start
+      //   package:liftlog_app/sources/ — our package prefix + sources/
+      //   [^/]+/                     — exactly one subdirectory (module name)
+      //   [^'"]*\.dart               — some file path ending in .dart
+      //   ['"]                       — closing quote
+      final sourcesImport = RegExp(
+        r'''^\s*import\s+['"]package:liftlog_app/sources/([^/]+)/([^'"]*\.dart)['"][^;]*;''',
+      );
+
+      final violations = <String>[];
+      for (final file in _dartFilesIn(featuresDir)) {
+        final relPath = p.relative(file.path, from: projectRoot);
+        final lines = file.readAsStringSync().split('\n');
+        for (var i = 0; i < lines.length; i++) {
+          final rawLine = lines[i];
+          final commentIdx = rawLine.indexOf('//');
+          final codePart =
+              commentIdx >= 0 ? rawLine.substring(0, commentIdx) : rawLine;
+          final match = sourcesImport.firstMatch(codePart);
+          if (match == null) continue;
+          final importedFile = match.group(2)!;
+          // Façade convention: filename ends with `_source.dart`.
+          if (importedFile.endsWith('_source.dart')) continue;
+          violations.add(
+            '$relPath:${i + 1}: feature code must import only the '
+            '<name>_source.dart façade, not ${rawLine.trim()}',
+          );
+        }
+      }
+
+      // `sourcesDir` is informational — the test does not require the
+      // directory to exist. Referenced here so the linter doesn't flag
+      // the local as unused and so a future reader sees the link.
+      assert(sourcesDir.path.endsWith('sources'));
+
+      expect(
+        violations,
+        isEmpty,
+        reason: 'Feature code must import only the <name>_source.dart '
+            'façade from lib/sources/<name>/. Violations:\n'
+            '${violations.join('\n')}',
+      );
+    });
+
+    test('FoodEntryType and Source are orthogonal: features never reference Source.',
+        () {
+      expect(featuresDir.existsSync(), isTrue,
+          reason: 'expected lib/features at ${featuresDir.path}');
+
+      // Plain token match: `Source.` anywhere in feature code. Features
+      // must never construct `Source` values raw — they receive them
+      // from repositories. Tests can freely reference `Source.`; this
+      // rule only scans `lib/features/**`.
+      final sourceToken = RegExp(r'\bSource\.');
+
+      final violations = <String>[];
+      for (final file in _dartFilesIn(featuresDir)) {
+        final relPath = p.relative(file.path, from: projectRoot);
+        final lines = file.readAsStringSync().split('\n');
+        for (var i = 0; i < lines.length; i++) {
+          final rawLine = lines[i];
+          final commentIdx = rawLine.indexOf('//');
+          final codePart =
+              commentIdx >= 0 ? rawLine.substring(0, commentIdx) : rawLine;
+          if (!sourceToken.hasMatch(codePart)) continue;
+          violations.add(
+            '$relPath:${i + 1}: feature code must not reference Source. '
+            'directly (see CLAUDE.md canonical enums): ${rawLine.trim()}',
+          );
+        }
+      }
+
+      expect(
+        violations,
+        isEmpty,
+        reason: 'FoodEntryType and Source are orthogonal. Features must '
+            'not construct Source values raw. Violations:\n'
             '${violations.join('\n')}',
       );
     });

--- a/test/data/exercise_repository_test.dart
+++ b/test/data/exercise_repository_test.dart
@@ -1,0 +1,97 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/data/repositories/exercise_repository.dart';
+
+void main() {
+  late AppDatabase db;
+  late ExerciseRepository repo;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = ExerciseRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  test('listAll returns rows newest-first (createdAt DESC, id DESC tiebreak)',
+      () async {
+    // Distinct createdAt timestamps so primary ordering is unambiguous.
+    await repo.addIfMissing('Squat', source: Source.userEntered);
+    await Future<void>.delayed(const Duration(milliseconds: 2));
+    final middle = await repo.addIfMissing('Bench Press', source: Source.userEntered);
+    await Future<void>.delayed(const Duration(milliseconds: 2));
+    await repo.addIfMissing('Deadlift', source: Source.userEntered);
+
+    final rows = await repo.listAll();
+    expect(rows.map((r) => r.canonicalName).toList(),
+        ['Deadlift', 'Bench Press', 'Squat']);
+    expect(rows[1].id, middle.id);
+  });
+
+  test('findByName: hit returns row; miss returns null', () async {
+    await repo.addIfMissing('Overhead Press', source: Source.userEntered);
+
+    final hit = await repo.findByName('Overhead Press');
+    expect(hit, isNotNull);
+    expect(hit!.canonicalName, 'Overhead Press');
+
+    final miss = await repo.findByName('Nonexistent Lift');
+    expect(miss, isNull);
+  });
+
+  test('findByName is case-sensitive and does not trim whitespace', () async {
+    // Silent canonicalization would mutate what the user sees — trust
+    // rule violation. See repo docstring.
+    await repo.addIfMissing('Bench Press', source: Source.userEntered);
+    expect(await repo.findByName('bench press'), isNull);
+    expect(await repo.findByName('Bench Press '), isNull);
+    expect(await repo.findByName('Bench Press'), isNotNull);
+  });
+
+  test('addIfMissing then findByName round-trip', () async {
+    final row =
+        await repo.addIfMissing('Pull-Up', source: Source.userEntered);
+    expect(row.canonicalName, 'Pull-Up');
+
+    final found = await repo.findByName('Pull-Up');
+    expect(found, isNotNull);
+    expect(found!.id, row.id);
+  });
+
+  test('addIfMissing is idempotent: second call returns the same row', () async {
+    final first = await repo.addIfMissing('Row', source: Source.userEntered);
+    final second = await repo.addIfMissing('Row', source: Source.userEntered);
+    expect(second.id, first.id);
+    expect(second.canonicalName, first.canonicalName);
+
+    final all = await repo.listAll();
+    expect(all, hasLength(1), reason: 'UNIQUE should prevent duplicate rows');
+  });
+
+  test('addIfMissing accepts an optional muscleGroup', () async {
+    final row = await repo.addIfMissing(
+      'Incline Bench',
+      muscleGroup: 'Chest',
+      source: Source.userEntered,
+    );
+    expect(row.muscleGroup, 'Chest');
+
+    // Second call with no muscle group doesn't clear the existing one —
+    // addIfMissing only acts when the row is absent.
+    final again =
+        await repo.addIfMissing('Incline Bench', source: Source.userEntered);
+    expect(again.muscleGroup, 'Chest');
+  });
+
+  test('watchAll emits ordered rows', () async {
+    await repo.addIfMissing('Deadlift', source: Source.userEntered);
+    await Future<void>.delayed(const Duration(milliseconds: 2));
+    await repo.addIfMissing('Squat', source: Source.userEntered);
+
+    final rows = await repo.watchAll().first;
+    expect(rows.map((r) => r.canonicalName).toList(), ['Squat', 'Deadlift']);
+  });
+}

--- a/test/data/persistence_round_trip_test.dart
+++ b/test/data/persistence_round_trip_test.dart
@@ -1,9 +1,18 @@
+// ignore_for_file: depend_on_referenced_packages
+// `sqlite3` is used only here — and only in a test — to stand up a
+// schema-v2 shape on disk so the live AppDatabase's onUpgrade can be
+// exercised. It's a transitive dep via `drift/native.dart` +
+// `sqlite3_flutter_libs` (NativeDatabase uses it under the hood), so
+// no new pub dep is introduced. Adding it to `dev_dependencies` would
+// also work but widens the dependency surface for a single test.
+
 import 'dart:io';
 
 import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart';
 
 import 'package:liftlog_app/data/database.dart';
 import 'package:liftlog_app/data/enums.dart';
@@ -13,6 +22,208 @@ import 'package:liftlog_app/data/repositories/food_entry_repository.dart';
 import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
 
 void main() {
+  group('v2 → v3 migration', () {
+    // Simulates an upgrade from schema v2 (pre-issue #42) to v3:
+    //  - Creates a fresh sqlite file with the v2 table shape via raw SQL
+    //    and sets `PRAGMA user_version = 2` so Drift reads it as v2.
+    //  - Inserts sample rows in each of the 4 entities.
+    //  - Opens AppDatabase (schemaVersion = 3) which fires onUpgrade.
+    //  - Asserts: `source` column added to all 4 tables with default
+    //    `'userEntered'` on existing rows; `exercises` table exists and
+    //    contains exactly the distinct historical `exerciseName` values;
+    //    seeding is idempotent across successive opens.
+    //
+    // Why raw sqlite3 for setup: Drift's own API can't address a
+    // "previous-schema" layout; we have to build the v2 shape by hand
+    // to prove the upgrade path runs. The dependency is transitive
+    // through `drift/native.dart` + `sqlite3_flutter_libs`.
+
+    Directory tempDir() {
+      final dir = Directory.systemTemp.createTempSync('liftlog_migrate_');
+      addTearDown(() {
+        if (dir.existsSync()) dir.deleteSync(recursive: true);
+      });
+      return dir;
+    }
+
+    /// Writes a schema-v2-shaped database to [path]. The schema mirrors
+    /// what existed before issue #42: no `source` column on any table,
+    /// no `exercises` table, no `exercise_id` FK on `exercise_sets`. It
+    /// also inserts three sample rows so we can prove both the column
+    /// default and the seeding pass. PRAGMA user_version is set to 2
+    /// so Drift sees "from = 2" on open and runs the v3 upgrade branch.
+    void seedV2Database(String path) {
+      final raw = sqlite3.open(path);
+      try {
+        raw.execute('PRAGMA foreign_keys = ON');
+        raw.execute('''
+          CREATE TABLE food_entries (
+            id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            timestamp INTEGER NOT NULL,
+            name TEXT NOT NULL DEFAULT '',
+            kcal INTEGER NOT NULL,
+            protein_g REAL NOT NULL,
+            meal_type TEXT NOT NULL,
+            entry_type TEXT NOT NULL,
+            note TEXT NULL
+          )
+        ''');
+        raw.execute('''
+          CREATE TABLE workout_sessions (
+            id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            started_at INTEGER NOT NULL,
+            ended_at INTEGER NULL,
+            note TEXT NULL
+          )
+        ''');
+        raw.execute('''
+          CREATE TABLE exercise_sets (
+            id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            session_id INTEGER NOT NULL REFERENCES workout_sessions (id) ON DELETE CASCADE,
+            exercise_name TEXT NOT NULL,
+            reps INTEGER NOT NULL,
+            weight REAL NOT NULL,
+            weight_unit TEXT NOT NULL,
+            status TEXT NOT NULL,
+            order_index INTEGER NOT NULL
+          )
+        ''');
+        raw.execute('''
+          CREATE TABLE body_weight_logs (
+            id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            timestamp INTEGER NOT NULL,
+            value REAL NOT NULL,
+            unit TEXT NOT NULL
+          )
+        ''');
+        // Drift stores DateTime as int (unix seconds). Values don't
+        // matter for the assertions here — only the row count and the
+        // distinct exerciseName set do.
+        raw.execute(
+          "INSERT INTO food_entries (timestamp, name, kcal, protein_g, meal_type, entry_type) "
+          "VALUES (1000, 'Eggs', 140, 12.0, 'breakfast', 'manual')",
+        );
+        raw.execute(
+          "INSERT INTO body_weight_logs (timestamp, value, unit) "
+          "VALUES (1000, 80.0, 'kg')",
+        );
+        raw.execute(
+          "INSERT INTO workout_sessions (started_at) VALUES (1000)",
+        );
+        raw.execute(
+          "INSERT INTO exercise_sets (session_id, exercise_name, reps, weight, weight_unit, status, order_index) "
+          "VALUES (1, 'Bench Press', 8, 80.0, 'kg', 'completed', 0)",
+        );
+        raw.execute(
+          "INSERT INTO exercise_sets (session_id, exercise_name, reps, weight, weight_unit, status, order_index) "
+          "VALUES (1, 'Bench Press', 7, 82.5, 'kg', 'completed', 1)",
+        );
+        raw.execute(
+          "INSERT INTO exercise_sets (session_id, exercise_name, reps, weight, weight_unit, status, order_index) "
+          "VALUES (1, 'Squat', 5, 100.0, 'kg', 'completed', 2)",
+        );
+        raw.execute('PRAGMA user_version = 2');
+      } finally {
+        raw.close();
+      }
+    }
+
+    test('adds source columns with default "userEntered" on every table',
+        () async {
+      final dir = tempDir();
+      final dbPath = p.join(dir.path, 'liftlog.sqlite');
+      seedV2Database(dbPath);
+
+      // Trigger onUpgrade by opening AppDatabase against the v2 file.
+      final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
+      addTearDown(db.close);
+
+      Future<List<String>> readSource(String table) async {
+        final rows = await db
+            .customSelect('SELECT source FROM $table ORDER BY id ASC')
+            .get();
+        return rows.map((r) => r.read<String>('source')).toList();
+      }
+
+      expect(await readSource('food_entries'), ['userEntered']);
+      expect(await readSource('body_weight_logs'), ['userEntered']);
+      expect(await readSource('workout_sessions'), ['userEntered']);
+      expect(
+        await readSource('exercise_sets'),
+        ['userEntered', 'userEntered', 'userEntered'],
+      );
+    });
+
+    test('creates exercises table and seeds distinct exercise names once',
+        () async {
+      final dir = tempDir();
+      final dbPath = p.join(dir.path, 'liftlog.sqlite');
+      seedV2Database(dbPath);
+
+      final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
+      addTearDown(db.close);
+
+      final rows = await db
+          .customSelect(
+            'SELECT canonical_name FROM exercises ORDER BY canonical_name ASC',
+          )
+          .get();
+      final names =
+          rows.map((r) => r.read<String>('canonical_name')).toList();
+      // V2 sample has "Bench Press" (x2) and "Squat" (x1) → 2 distinct.
+      expect(names, ['Bench Press', 'Squat']);
+
+      // Also confirm `exercise_id` FK column was added (nullable, no
+      // backfill in this PR — see database.dart onUpgrade comment).
+      final setRows = await db
+          .customSelect('SELECT exercise_id FROM exercise_sets ORDER BY id ASC')
+          .get();
+      expect(setRows, hasLength(3));
+      expect(
+        setRows.every((r) => r.read<int?>('exercise_id') == null),
+        isTrue,
+        reason: 'v2→v3 migration does not backfill exercise_id',
+      );
+    });
+
+    test('seeding is idempotent across successive opens', () async {
+      final dir = tempDir();
+      final dbPath = p.join(dir.path, 'liftlog.sqlite');
+      seedV2Database(dbPath);
+
+      // First open: runs onUpgrade + seeds from v2 rows.
+      {
+        final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
+        // Force the connection lazily by touching the DB.
+        await db.customSelect('SELECT 1 AS x').getSingle();
+        await db.close();
+      }
+
+      Future<int> countExercises() async {
+        final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
+        try {
+          final row = await db
+              .customSelect('SELECT COUNT(*) AS c FROM exercises')
+              .getSingle();
+          return row.read<int>('c');
+        } finally {
+          await db.close();
+        }
+      }
+
+      final firstCount = await countExercises();
+      expect(firstCount, 2);
+
+      // Re-open: schemaVersion is now 3 on disk so onUpgrade should
+      // NOT fire again, but even if some future change re-ran the
+      // seeding helper, `INSERT OR IGNORE` + `canonicalName UNIQUE`
+      // guarantees the row count stays constant.
+      final secondCount = await countExercises();
+      expect(secondCount, firstCount,
+          reason: 'seeding must be idempotent under repeated open');
+    });
+  });
+
   test(
       'entries across all 4 entities survive DB close + reopen against same file',
       () async {

--- a/test/features/progress/progress_data_test.dart
+++ b/test/features/progress/progress_data_test.dart
@@ -5,7 +5,7 @@ import 'package:liftlog_app/data/enums.dart';
 import 'package:liftlog_app/features/progress/progress_data.dart';
 
 BodyWeightLog _weight(DateTime t, double v, WeightUnit u) =>
-    BodyWeightLog(id: 1, timestamp: t, value: v, unit: u);
+    BodyWeightLog(id: 1, timestamp: t, value: v, unit: u, source: Source.userEntered);
 
 FoodEntry _food(DateTime t, int kcal) => FoodEntry(
       id: 1,
@@ -16,6 +16,7 @@ FoodEntry _food(DateTime t, int kcal) => FoodEntry(
       mealType: MealType.other,
       entryType: FoodEntryType.manual,
       note: null,
+      source: Source.userEntered,
     );
 
 WorkoutSession _session(int id, DateTime startedAt) => WorkoutSession(
@@ -23,6 +24,7 @@ WorkoutSession _session(int id, DateTime startedAt) => WorkoutSession(
       startedAt: startedAt,
       endedAt: null,
       note: null,
+      source: Source.userEntered,
     );
 
 ExerciseSet _set(int sessionId, WorkoutSetStatus status, {int order = 0}) =>
@@ -35,6 +37,7 @@ ExerciseSet _set(int sessionId, WorkoutSetStatus status, {int order = 0}) =>
       weightUnit: WeightUnit.kg,
       status: status,
       orderIndex: order,
+      source: Source.userEntered,
     );
 
 WorkoutSession _sessionWithEnd(int id, DateTime startedAt, DateTime? endedAt) =>
@@ -43,6 +46,7 @@ WorkoutSession _sessionWithEnd(int id, DateTime startedAt, DateTime? endedAt) =>
       startedAt: startedAt,
       endedAt: endedAt,
       note: null,
+      source: Source.userEntered,
     );
 
 FoodEntry _foodWithProtein(DateTime t, int kcal, double proteinG) => FoodEntry(
@@ -54,6 +58,7 @@ FoodEntry _foodWithProtein(DateTime t, int kcal, double proteinG) => FoodEntry(
       mealType: MealType.other,
       entryType: FoodEntryType.manual,
       note: null,
+      source: Source.userEntered,
     );
 
 void main() {


### PR DESCRIPTION
Closes #42.

## Summary

Schema v3 — additive-only migration from v2. No column drops, no renames, no data transforms except the one-time `exercises` seeding pass.

- **New `Source` enum** (`userEntered`, `savedTemplate`, `healthKit`, `photoEstimate`, `voiceEstimate`, `barcode`, `derived`, `imported`). Stored via `textEnum<Source>()`, `.name` is the storage string.
- **`source` column** added to `food_entries`, `body_weight_logs`, `workout_sessions`, `exercise_sets`. Defaulted to `'userEntered'` so existing rows stay valid and no data transform is needed.
- **First-class `exercises` table** (`canonicalName UNIQUE`, optional `muscleGroup`, `createdAt`). `onUpgrade` seeds it from the distinct historical `exerciseName` values already on `exercise_sets`. The seeding helper uses `InsertMode.insertOrIgnore`, so running it twice produces the same row count as once.
- **Nullable `exercise_id` FK** on `exercise_sets`. Not backfilled in this PR — workout UI still reads `exerciseName` as the authoritative name source. Future adaptive-programming work populates the FK.
- **`ExerciseRepository`** at `lib/data/repositories/exercise_repository.dart` exposes `watchAll` / `listAll` (newest-first by `createdAt DESC`, `id DESC` tiebreak) / `findByName` (case-sensitive, no trim — silent canonicalization is a trust-rule violation) / `addIfMissing` (insert-or-ignore + re-read, idempotent). Wired in `app_providers.dart`.

## Arch-test extensions

Two new rules in `test/arch/data_access_boundary_test.dart`:

1. **`lib/sources/<name>/` façade boundary** (forward-looking for S4.3). Feature code may import only the `<name>_source.dart` façade from a source module, never the implementation files inside. The rule runs today even though `lib/sources/` doesn't exist yet — it flags the first offender the day a source module lands.
2. **`FoodEntryType` / `Source` non-conflation.** `lib/features/**` must not reference `Source.` directly. Features receive `Source`-typed values from repositories; they never construct them raw. Tests may use `Source.` freely — only `lib/features/` is scanned.

Negative-case verified: added `Source.userEntered` to `estimate_badge.dart`, ran the arch test, confirmed it failed with file-and-line pointer, reverted.

## Test plan

- [x] `flutter analyze` — clean, no issues.
- [x] `flutter test` — 162 tests pass (+12 new: 7 repo tests, 3 migration tests, 2 arch rules).
- [x] Arch negative case: feature-code `Source.` reference triggers clear failure; revert restores green.
- [x] `grep -rn 'Source\.' lib/features/` → 0 matches.
- [x] `dart run build_runner build --delete-conflicting-outputs` ran clean against the updated Drift schema.

## Notes

- **Manual backup path** for v2 → v3 already landed in `vault/05 Architecture/Runbooks.md` under "Manual backup path — v2 → v3" (PM confirmed preconditions pre-dispatch).
- **Seeded-from-empty** on the dev machine — the local Drift DB in this workspace has no historical `exercise_sets` rows. The migration tests exercise seeding against synthetic v2 data in a temp sqlite file and confirm the "Bench Press"/"Squat" dedup path plus idempotency across reopens.
- **`sqlite3` transitive dep used in a test only.** `test/data/persistence_round_trip_test.dart` opens a raw sqlite file to stand up the v2 shape so `AppDatabase`'s `onUpgrade` can be driven. No new pub dep — `sqlite3` is already pulled in by `drift/native.dart` + `sqlite3_flutter_libs`. Flagged with an `ignore_for_file: depend_on_referenced_packages` header and explained in the file docstring.
- **No downgrade migration** (per Runbooks).
- **No changes to `pubspec.yaml`, `vault/`, or `CLAUDE.md`** — the v2.0 contract already lists `Source` as a canonical enum.

## Scope-adjacent findings (do NOT fix here)

- `exercise_id` FK on `exercise_sets` is populated by the v2→v3 seeding pass only if we later extend the helper to join by name; today the column stays NULL after migration. A follow-up issue could either (a) join existing sets to newly-seeded exercises on `exerciseName`, or (b) defer until workout UI writes both columns together under a migration. Flagging here so it can be triaged rather than adding scope to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)