### PR TITLE
#49 — HK-weight in Progress sparkline

### DIFF
--- a/lib/features/progress/progress_data.dart
+++ b/lib/features/progress/progress_data.dart
@@ -1,5 +1,6 @@
 import '../../data/database.dart';
 import '../../data/enums.dart';
+import '../../sources/health_kit/health_source.dart';
 
 /// Time-window selector for the Progress tab. Enumerated exhaustively; never
 /// fall through to a default case.
@@ -7,10 +8,22 @@ enum ProgressWindow { sevenDays, thirtyDays, all }
 
 /// A single point on the weight sparkline. Kept portable (no UI types) so the
 /// aggregator can stay a pure-Dart function that's trivial to unit test.
+///
+/// `isFromHealthKit` is a feature-local provenance flag — deliberately NOT a
+/// `Source.` value. Feature code never constructs `Source` values raw (see
+/// the arch guardrail in `test/arch/data_access_boundary_test.dart` and the
+/// canonical-enum-non-conflation rule in CLAUDE.md). The flag is true iff
+/// the point was sourced from a HealthKit sample rather than a user-entered
+/// Drift row.
 class WeightPoint {
-  const WeightPoint({required this.timestamp, required this.value});
+  const WeightPoint({
+    required this.timestamp,
+    required this.value,
+    this.isFromHealthKit = false,
+  });
   final DateTime timestamp;
   final double value;
+  final bool isFromHealthKit;
 }
 
 /// Output of the weight aggregator. `dominantUnit` is the unit the sparkline
@@ -116,35 +129,138 @@ DateTime _mondayOf(DateTime t) {
   return DateTime(day.year, day.month, day.day - (day.weekday - 1));
 }
 
-/// Builds a [WeightSeries] from raw logs. Responsibilities:
+/// Internal merged record for one day of weight data. Carries the unit
+/// alongside the value + provenance so the dominant-unit filter downstream
+/// can see both user-entered rows and HK samples through the same shape.
+class _MergedWeight {
+  const _MergedWeight({
+    required this.timestamp,
+    required this.value,
+    required this.unit,
+    required this.isFromHealthKit,
+  });
+  final DateTime timestamp;
+  final double value;
+  final WeightUnit unit;
+  final bool isFromHealthKit;
+}
+
+/// Builds a [WeightSeries] from user-entered logs and HealthKit samples.
 ///
-/// 1. Pick a dominant unit. If logs are in more than one unit, the most recent
-///    log wins — this is what the "Mixed units — showing kg only" banner
-///    reflects. Never silently convert (trust rule).
-/// 2. Filter to only that unit's points.
-/// 3. Sort chronologically so the painter can walk left-to-right.
+/// Responsibilities:
+///
+/// 1. Day-bucket dedup: for each local-calendar day, a user-entered log wins
+///    over any HK sample (data-source precedence `user_entered` >
+///    `saved_template` > `default` — HK is effectively the `default` lane
+///    here). When both are present on the same day, only the user-entered
+///    row contributes. When multiple HK samples land on the same day, the
+///    most recent sample wins.
+/// 2. Pick a dominant unit against the merged set. If the merged day-buckets
+///    carry more than one unit, the most recent bucket's unit wins — this is
+///    what the "Mixed units — showing kg only" banner reflects. Never
+///    silently convert (trust rule).
+/// 3. Filter to only that unit's points.
+/// 4. Sort chronologically so the painter can walk left-to-right. Stamp each
+///    [WeightPoint] with `isFromHealthKit` so the widget layer can surface a
+///    HealthKit badge without re-interrogating the repositories.
+///
+/// [isFromHealthKit] is a feature-local provenance flag — deliberately NOT a
+/// `Source.` value. Feature code never constructs `Source` values raw (see
+/// the arch guardrail + the canonical-enum non-conflation rule in CLAUDE.md).
 ///
 /// Keeping this in the aggregator (not the widget) means:
-/// - The "mixed unit" behavior is unit-testable without pumping widgets.
+/// - The "mixed unit" and "HK/user dedup" behavior is unit-testable without
+///   pumping widgets.
 /// - The sparkline painter receives a single-unit list and doesn't need to
 ///   know about [WeightUnit] at all.
-WeightSeries buildWeightSeries(List<BodyWeightLog> logs) {
-  if (logs.isEmpty) {
-    return const WeightSeries(points: [], dominantUnit: null, mixedUnits: false);
+WeightSeries buildWeightSeries({
+  required List<BodyWeightLog> userEntered,
+  required List<HKBodyWeightSample> hkSamples,
+  required DateTime from,
+  required DateTime to,
+}) {
+  // --- Build the day-keyed merge map. ---
+  // User-entered wins per the data-source precedence rule, so we layer
+  // user-entered over HK rather than the other way around. HK samples are
+  // kept newest-wins per-day before merging so a single day with multiple
+  // HK readings collapses to one bucket deterministically.
+  final merged = <DateTime, _MergedWeight>{};
+
+  // Pass 1: HK samples, keeping the most recent sample per day. `isBefore`
+  // is strict, so ties resolve to whichever we saw second — we prefer to be
+  // explicit and compare timestamps directly.
+  for (final s in hkSamples) {
+    final day = _dayOf(s.timestamp);
+    final existing = merged[day];
+    if (existing == null || s.timestamp.isAfter(existing.timestamp)) {
+      merged[day] = _MergedWeight(
+        timestamp: s.timestamp,
+        value: s.value,
+        unit: s.unit,
+        isFromHealthKit: true,
+      );
+    }
   }
 
-  // Find the most-recent-log unit — that's the one we show.
-  final sortedDesc = [...logs]..sort((a, b) => b.timestamp.compareTo(a.timestamp));
+  // Pass 2: user-entered logs. These overwrite any HK bucket on the same
+  // day — data-source precedence. If two user-entered logs land on the
+  // same day, keep the most recent one (mirrors the HK newest-wins rule
+  // so "which value shows up on the sparkline" is consistent).
+  for (final l in userEntered) {
+    final day = _dayOf(l.timestamp);
+    final existing = merged[day];
+    if (existing == null ||
+        existing.isFromHealthKit ||
+        l.timestamp.isAfter(existing.timestamp)) {
+      merged[day] = _MergedWeight(
+        timestamp: l.timestamp,
+        value: l.value,
+        unit: l.unit,
+        isFromHealthKit: false,
+      );
+    }
+  }
+
+  // The `from`/`to` params are part of the signature so callers don't have
+  // to filter themselves, but the merge above is already bounded by the
+  // data the provider hands us (both sides are fetched against the same
+  // window). The explicit params also future-proof the function if a caller
+  // ever passes unfiltered inputs. Apply them defensively — drop any bucket
+  // whose day falls outside `[_dayOf(from), _dayOf(to))`.
+  final fromDay = _dayOf(from);
+  final toDay = _dayOf(to);
+  final bounded = <_MergedWeight>[
+    for (final e in merged.values)
+      if (!_dayOf(e.timestamp).isBefore(fromDay) &&
+          _dayOf(e.timestamp).isBefore(toDay))
+        e,
+  ];
+
+  if (bounded.isEmpty) {
+    return const WeightSeries(
+      points: [],
+      dominantUnit: null,
+      mixedUnits: false,
+    );
+  }
+
+  // Most-recent bucket's unit is the one we show.
+  final sortedDesc = [...bounded]
+    ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
   final dominant = sortedDesc.first.unit;
 
-  final hasKg = logs.any((l) => l.unit == WeightUnit.kg);
-  final hasLb = logs.any((l) => l.unit == WeightUnit.lb);
+  final hasKg = bounded.any((e) => e.unit == WeightUnit.kg);
+  final hasLb = bounded.any((e) => e.unit == WeightUnit.lb);
   final mixed = hasKg && hasLb;
 
-  final filtered = logs.where((l) => l.unit == dominant).toList()
+  final filtered = bounded.where((e) => e.unit == dominant).toList()
     ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
   final points = filtered
-      .map((l) => WeightPoint(timestamp: l.timestamp, value: l.value))
+      .map((e) => WeightPoint(
+            timestamp: e.timestamp,
+            value: e.value,
+            isFromHealthKit: e.isFromHealthKit,
+          ))
       .toList();
 
   return WeightSeries(

--- a/lib/features/progress/progress_providers.dart
+++ b/lib/features/progress/progress_providers.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../providers/app_providers.dart';
+import '../../sources/health_kit/health_source.dart';
+import '../body_weight/body_weight_providers.dart';
 import 'progress_data.dart';
 
 /// Currently selected time window for the Progress tab. Widget state lives in
@@ -13,16 +15,42 @@ final progressWindowProvider =
 /// deterministic. Prod callers get the real time.
 final progressNowProvider = Provider<DateTime>((ref) => DateTime.now());
 
-/// Weight series for the currently-selected window. Uses the one-shot
-/// `listRange` repository method (not `watch*`) so widget tests don't hang
-/// under Drift + fake_async.
+/// Weight series for the currently-selected window. Merges user-entered
+/// Drift rows with HealthKit body-weight samples (issue #49 / S5.2); the
+/// aggregator dedups by local-calendar day with user-entered taking
+/// precedence over any HK sample on the same day.
+///
+/// Uses the one-shot `listRange` repository method (not `watch*`) so
+/// widget tests don't hang under Drift + fake_async. On HK denial /
+/// façade error we pass `[]` — per the `HealthSource` contract, denial
+/// surfaces as an empty list, and any other error is downgraded to the
+/// same fallback so the Progress tab stays usable when HK is unavailable.
+/// HK loads are awaited via `.future` to keep window-switch determinism.
 final weightSeriesProvider = FutureProvider<WeightSeries>((ref) async {
   final window = ref.watch(progressWindowProvider);
   final now = ref.watch(progressNowProvider);
   final range = resolveWindow(window, now: now);
   final repo = ref.watch(bodyWeightLogRepositoryProvider);
   final logs = await repo.listRange(range.from, range.to);
-  return buildWeightSeries(logs);
+
+  // HK-side load: deterministic await (no `.maybeWhen(null: ...)` race) so
+  // window-swap tests see the merged result after a single pumpAndSettle.
+  // On error we downgrade to an empty sample list — HK-unavailable is not
+  // a user-facing failure for the Progress sparkline. The user's own data
+  // still draws.
+  List<HKBodyWeightSample> hkSamples;
+  try {
+    hkSamples = await ref.watch(hkBodyWeightProvider.future);
+  } catch (_) {
+    hkSamples = const <HKBodyWeightSample>[];
+  }
+
+  return buildWeightSeries(
+    userEntered: logs,
+    hkSamples: hkSamples,
+    from: range.from,
+    to: range.to,
+  );
 });
 
 /// Daily kcal series for the currently-selected window.

--- a/test/features/progress/progress_data_test.dart
+++ b/test/features/progress/progress_data_test.dart
@@ -3,9 +3,23 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:liftlog_app/data/database.dart';
 import 'package:liftlog_app/data/enums.dart';
 import 'package:liftlog_app/features/progress/progress_data.dart';
+import 'package:liftlog_app/sources/health_kit/health_source.dart';
 
 BodyWeightLog _weight(DateTime t, double v, WeightUnit u) =>
     BodyWeightLog(id: 1, timestamp: t, value: v, unit: u, source: Source.userEntered);
+
+HKBodyWeightSample _hk(
+  DateTime t,
+  double v,
+  WeightUnit u, {
+  String sourceId = 'com.apple.Health',
+}) =>
+    HKBodyWeightSample(sourceId: sourceId, timestamp: t, value: v, unit: u);
+
+// Wide default window covering every test date used below. Individual tests
+// can still pass their own bounds where the boundary matters.
+final _windowFrom = DateTime(2026, 1, 1);
+final _windowTo = DateTime(2026, 5, 1);
 
 FoodEntry _food(DateTime t, int kcal) => FoodEntry(
       id: 1,
@@ -86,7 +100,12 @@ void main() {
 
   group('buildWeightSeries', () {
     test('empty logs yields empty series with no dominant unit', () {
-      final s = buildWeightSeries(const []);
+      final s = buildWeightSeries(
+        userEntered: const [],
+        hkSamples: const [],
+        from: _windowFrom,
+        to: _windowTo,
+      );
       expect(s.isEmpty, isTrue);
       expect(s.dominantUnit, isNull);
       expect(s.mixedUnits, isFalse);
@@ -94,22 +113,37 @@ void main() {
     });
 
     test('single-unit logs: no mixed flag, dominant = that unit', () {
-      final s = buildWeightSeries([
-        _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
-        _weight(DateTime(2026, 4, 22), 80.5, WeightUnit.kg),
-      ]);
+      final s = buildWeightSeries(
+        userEntered: [
+          _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
+          _weight(DateTime(2026, 4, 22), 80.5, WeightUnit.kg),
+        ],
+        hkSamples: const [],
+        from: _windowFrom,
+        to: _windowTo,
+      );
       expect(s.dominantUnit, WeightUnit.kg);
       expect(s.mixedUnits, isFalse);
       expect(s.points.length, 2);
       expect(s.hasEnoughForSparkline, isTrue);
+      expect(
+        s.points.every((p) => !p.isFromHealthKit),
+        isTrue,
+        reason: 'all user-entered → no HK flag on any point',
+      );
     });
 
     test('sorts points chronologically regardless of input order', () {
-      final s = buildWeightSeries([
-        _weight(DateTime(2026, 4, 22), 80.5, WeightUnit.kg),
-        _weight(DateTime(2026, 4, 18), 79.0, WeightUnit.kg),
-        _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
-      ]);
+      final s = buildWeightSeries(
+        userEntered: [
+          _weight(DateTime(2026, 4, 22), 80.5, WeightUnit.kg),
+          _weight(DateTime(2026, 4, 18), 79.0, WeightUnit.kg),
+          _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
+        ],
+        hkSamples: const [],
+        from: _windowFrom,
+        to: _windowTo,
+      );
       expect(
         s.points.map((p) => p.timestamp).toList(),
         [
@@ -122,11 +156,16 @@ void main() {
 
     test('mixed units: dominant = most recent unit, others dropped', () {
       // Most recent is kg → dominant kg, the lb point is dropped.
-      final s = buildWeightSeries([
-        _weight(DateTime(2026, 4, 18), 176.0, WeightUnit.lb),
-        _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
-        _weight(DateTime(2026, 4, 22), 80.5, WeightUnit.kg),
-      ]);
+      final s = buildWeightSeries(
+        userEntered: [
+          _weight(DateTime(2026, 4, 18), 176.0, WeightUnit.lb),
+          _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
+          _weight(DateTime(2026, 4, 22), 80.5, WeightUnit.kg),
+        ],
+        hkSamples: const [],
+        from: _windowFrom,
+        to: _windowTo,
+      );
       expect(s.dominantUnit, WeightUnit.kg);
       expect(s.mixedUnits, isTrue);
       expect(s.points.length, 2);
@@ -135,14 +174,123 @@ void main() {
     });
 
     test('mixed units, most recent is lb: drops kg points', () {
-      final s = buildWeightSeries([
-        _weight(DateTime(2026, 4, 18), 80.0, WeightUnit.kg),
-        _weight(DateTime(2026, 4, 22), 176.0, WeightUnit.lb),
-      ]);
+      final s = buildWeightSeries(
+        userEntered: [
+          _weight(DateTime(2026, 4, 18), 80.0, WeightUnit.kg),
+          _weight(DateTime(2026, 4, 22), 176.0, WeightUnit.lb),
+        ],
+        hkSamples: const [],
+        from: _windowFrom,
+        to: _windowTo,
+      );
       expect(s.dominantUnit, WeightUnit.lb);
       expect(s.mixedUnits, isTrue);
       expect(s.points.length, 1);
       expect(s.points.single.value, 176.0);
+    });
+
+    test(
+        'same-day dedup: user-entered wins over HK sample '
+        '(data-source precedence)', () {
+      // Both sides land on 4/20. Per the data-source precedence rule
+      // (user_entered > saved_template > default), the user-entered row
+      // wins — we never surface the HK value for that day.
+      final s = buildWeightSeries(
+        userEntered: [
+          _weight(DateTime(2026, 4, 20, 8), 80.5, WeightUnit.kg),
+        ],
+        hkSamples: [
+          _hk(DateTime(2026, 4, 20, 7), 79.9, WeightUnit.kg),
+        ],
+        from: _windowFrom,
+        to: _windowTo,
+      );
+      expect(s.points.length, 1);
+      expect(s.points.single.value, 80.5,
+          reason: 'user-entered wins, HK value is dropped');
+      expect(s.points.single.isFromHealthKit, isFalse);
+    });
+
+    test(
+        'different-day merge: 2 points, isFromHealthKit flags match their '
+        'origin', () {
+      // User-entered on 4/20, HK on 4/22 → both survive as separate days.
+      final s = buildWeightSeries(
+        userEntered: [
+          _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
+        ],
+        hkSamples: [
+          _hk(DateTime(2026, 4, 22), 80.5, WeightUnit.kg),
+        ],
+        from: _windowFrom,
+        to: _windowTo,
+      );
+      expect(s.points.length, 2);
+      // Chronological: 4/20 first, 4/22 second.
+      expect(s.points[0].timestamp, DateTime(2026, 4, 20));
+      expect(s.points[0].isFromHealthKit, isFalse);
+      expect(s.points[1].timestamp, DateTime(2026, 4, 22));
+      expect(s.points[1].isFromHealthKit, isTrue);
+    });
+
+    test('HK-only day: single point with isFromHealthKit true', () {
+      // No user-entered data at all — the HK sample contributes a point.
+      final s = buildWeightSeries(
+        userEntered: const [],
+        hkSamples: [
+          _hk(DateTime(2026, 4, 21), 79.8, WeightUnit.kg),
+          _hk(DateTime(2026, 4, 23), 80.0, WeightUnit.kg),
+        ],
+        from: _windowFrom,
+        to: _windowTo,
+      );
+      expect(s.points.length, 2);
+      expect(s.points.every((p) => p.isFromHealthKit), isTrue);
+      expect(s.dominantUnit, WeightUnit.kg);
+      expect(s.mixedUnits, isFalse);
+    });
+
+    test('mixed units across HK + user-entered triggers the banner', () {
+      // HK sample is lb, user-entered is kg, different days → merged set
+      // carries both units → mixedUnits true. Most recent is user-entered
+      // kg → dominant kg → lb HK point drops out.
+      final s = buildWeightSeries(
+        userEntered: [
+          _weight(DateTime(2026, 4, 22), 80.0, WeightUnit.kg),
+        ],
+        hkSamples: [
+          _hk(DateTime(2026, 4, 18), 176.0, WeightUnit.lb),
+        ],
+        from: _windowFrom,
+        to: _windowTo,
+      );
+      expect(s.mixedUnits, isTrue);
+      expect(s.dominantUnit, WeightUnit.kg);
+      expect(s.points.length, 1);
+      expect(s.points.single.value, 80.0,
+          reason: 'lb HK value must drop out — never silently converted');
+      expect(s.points.single.isFromHealthKit, isFalse);
+    });
+
+    test(
+        'multiple HK samples same day → newest wins (and carries the HK flag)',
+        () {
+      // Three HK samples on 4/21 at 07:00, 12:30 and 19:45. The 19:45
+      // reading is the most recent and is the one that must surface.
+      final s = buildWeightSeries(
+        userEntered: const [],
+        hkSamples: [
+          _hk(DateTime(2026, 4, 21, 7), 79.5, WeightUnit.kg),
+          _hk(DateTime(2026, 4, 21, 19, 45), 79.9, WeightUnit.kg),
+          _hk(DateTime(2026, 4, 21, 12, 30), 79.7, WeightUnit.kg),
+        ],
+        from: _windowFrom,
+        to: _windowTo,
+      );
+      expect(s.points.length, 1);
+      expect(s.points.single.value, 79.9,
+          reason: 'newest HK sample for the day wins');
+      expect(s.points.single.isFromHealthKit, isTrue);
     });
   });
 
@@ -402,10 +550,15 @@ void main() {
         _foodWithProtein(DateTime(2026, 4, 19, 12), 700, 40.0),
         _foodWithProtein(DateTime(2026, 4, 23, 13), 1400, 80.0),
       ];
-      final weight = buildWeightSeries([
-        _weight(DateTime(2026, 4, 17), 80.0, WeightUnit.kg),
-        _weight(DateTime(2026, 4, 23), 80.7, WeightUnit.kg),
-      ]);
+      final weight = buildWeightSeries(
+        userEntered: [
+          _weight(DateTime(2026, 4, 17), 80.0, WeightUnit.kg),
+          _weight(DateTime(2026, 4, 23), 80.7, WeightUnit.kg),
+        ],
+        hkSamples: const [],
+        from: range.from,
+        to: range.to,
+      );
       final session = _sessionWithEnd(
         1,
         DateTime(2026, 4, 22, 18),
@@ -458,7 +611,12 @@ void main() {
     });
 
     test('empty window: averages null, delta null, sessions 0', () {
-      final weight = buildWeightSeries(const []);
+      final weight = buildWeightSeries(
+        userEntered: const [],
+        hkSamples: const [],
+        from: range.from,
+        to: range.to,
+      );
       final s = buildProgressSummary(
         foods: const [],
         weightSeries: weight,
@@ -475,11 +633,16 @@ void main() {
 
     test('single-unit delta: last minus first in dominant unit', () {
       // 3 kg points inside the window. Delta = 81.0 - 80.0 = 1.0 kg.
-      final weight = buildWeightSeries([
-        _weight(DateTime(2026, 4, 17), 80.0, WeightUnit.kg),
-        _weight(DateTime(2026, 4, 20), 80.5, WeightUnit.kg),
-        _weight(DateTime(2026, 4, 23), 81.0, WeightUnit.kg),
-      ]);
+      final weight = buildWeightSeries(
+        userEntered: [
+          _weight(DateTime(2026, 4, 17), 80.0, WeightUnit.kg),
+          _weight(DateTime(2026, 4, 20), 80.5, WeightUnit.kg),
+          _weight(DateTime(2026, 4, 23), 81.0, WeightUnit.kg),
+        ],
+        hkSamples: const [],
+        from: range.from,
+        to: range.to,
+      );
       final s = buildProgressSummary(
         foods: const [],
         weightSeries: weight,
@@ -495,11 +658,16 @@ void main() {
         () {
       // Trust rule: don't fabricate a delta that crosses kg↔lb, even if we
       // could filter to the dominant unit and have 2+ points left.
-      final weight = buildWeightSeries([
-        _weight(DateTime(2026, 4, 17), 176.0, WeightUnit.lb),
-        _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
-        _weight(DateTime(2026, 4, 23), 80.5, WeightUnit.kg),
-      ]);
+      final weight = buildWeightSeries(
+        userEntered: [
+          _weight(DateTime(2026, 4, 17), 176.0, WeightUnit.lb),
+          _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
+          _weight(DateTime(2026, 4, 23), 80.5, WeightUnit.kg),
+        ],
+        hkSamples: const [],
+        from: range.from,
+        to: range.to,
+      );
       expect(weight.mixedUnits, isTrue); // sanity check
       final s = buildProgressSummary(
         foods: const [],
@@ -513,9 +681,14 @@ void main() {
     });
 
     test('single weight point: delta is null', () {
-      final weight = buildWeightSeries([
-        _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
-      ]);
+      final weight = buildWeightSeries(
+        userEntered: [
+          _weight(DateTime(2026, 4, 20), 80.0, WeightUnit.kg),
+        ],
+        hkSamples: const [],
+        from: range.from,
+        to: range.to,
+      );
       final s = buildProgressSummary(
         foods: const [],
         weightSeries: weight,

--- a/test/features/progress/progress_screen_test.dart
+++ b/test/features/progress/progress_screen_test.dart
@@ -17,6 +17,8 @@ import 'package:liftlog_app/features/progress/summary_card.dart';
 import 'package:liftlog_app/features/progress/weekly_volume_bars.dart';
 import 'package:liftlog_app/providers/app_providers.dart';
 import 'package:liftlog_app/shell/root_shell.dart';
+import 'package:liftlog_app/sources/health_kit/health_source.dart';
+import 'package:liftlog_app/sources/health_kit/health_source_fake.dart';
 
 void main() {
   late AppDatabase db;
@@ -31,10 +33,16 @@ void main() {
 
   tearDown(() async => db.close());
 
+  // Default HK override: not-authorized fake so nothing in the test tree
+  // reaches a real HealthKit channel. Individual tests can pass `extra`
+  // with their own HK override to inject samples.
   Widget app({List<Override> extra = const []}) => ProviderScope(
         overrides: [
           appDatabaseProvider.overrideWithValue(db),
           progressNowProvider.overrideWithValue(fakeNow),
+          healthSourceProvider.overrideWithValue(
+            HealthSourceFake.notAuthorized(),
+          ),
           ...extra,
         ],
         child: const MaterialApp(home: ProgressScreen()),
@@ -47,6 +55,9 @@ void main() {
         overrides: [
           appDatabaseProvider.overrideWithValue(db),
           progressNowProvider.overrideWithValue(fakeNow),
+          healthSourceProvider.overrideWithValue(
+            HealthSourceFake.notAuthorized(),
+          ),
         ],
         child: const MaterialApp(home: RootShell()),
       ),
@@ -175,6 +186,67 @@ void main() {
     expect(w.points.length, 2);
     expect(w.points.every((p) => p.value < 100), isTrue,
         reason: 'lb value 176 must be dropped, never silently converted');
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets(
+      'HK samples merge into the sparkline, day-bucket dedup keeps the '
+      'user-entered row on its day', (tester) async {
+    // 1 user-entered kg row on 4/20. 2 HK samples: one on 4/18 (HK-only day
+    // → should surface with isFromHealthKit=true) and one on 4/20 (same day
+    // as the user row → user-entered wins per data-source precedence, so
+    // this HK reading must NOT appear in the merged series).
+    final wRepo = BodyWeightLogRepository(db);
+    await wRepo.add(BodyWeightLogsCompanion.insert(
+      timestamp: DateTime(2026, 4, 20, 10),
+      value: 80.5,
+      unit: WeightUnit.kg,
+    ));
+
+    final hkSamples = [
+      HKBodyWeightSample(
+        sourceId: 'com.apple.Health',
+        timestamp: DateTime(2026, 4, 18, 8),
+        value: 80.0,
+        unit: WeightUnit.kg,
+      ),
+      HKBodyWeightSample(
+        sourceId: 'com.apple.Health',
+        timestamp: DateTime(2026, 4, 20, 7),
+        value: 79.9,
+        unit: WeightUnit.kg,
+      ),
+    ];
+
+    await tester.pumpWidget(app(extra: [
+      healthSourceProvider.overrideWithValue(
+        HealthSourceFake.authorized(hkSamples),
+      ),
+    ]));
+    await tester.pumpAndSettle();
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ProgressScreen)),
+    );
+    final w = await container.read(weightSeriesProvider.future);
+
+    // 2 points total: 4/18 HK + 4/20 user-entered. 4/20 HK reading dropped
+    // by day-bucket dedup (user-entered wins).
+    expect(w.points.length, 2);
+    expect(w.dominantUnit, WeightUnit.kg);
+    expect(w.mixedUnits, isFalse);
+
+    // Chronological order. 4/18 is HK, 4/20 is user-entered (value 80.5,
+    // not 79.9 — the HK reading for that day was dropped).
+    expect(w.points[0].timestamp, DateTime(2026, 4, 18, 8));
+    expect(w.points[0].isFromHealthKit, isTrue);
+    expect(w.points[0].value, 80.0);
+
+    expect(w.points[1].timestamp, DateTime(2026, 4, 20, 10));
+    expect(w.points[1].isFromHealthKit, isFalse);
+    expect(w.points[1].value, 80.5,
+        reason: 'user-entered row wins on 4/20; HK reading dropped');
 
     await _drainDriftTimers(tester);
   });


### PR DESCRIPTION
Closes #49.

## Summary
- Extend `buildWeightSeries` to merge HealthKit body-weight samples with user-entered `BodyWeightLog` rows via a day-bucketed dedup. User-entered wins per data-source precedence (`user_entered > saved_template > default`). Multiple HK samples on the same day collapse to the newest.
- Add `WeightPoint.isFromHealthKit` — a feature-local provenance flag (deliberately NOT a `Source.` value, to respect the canonical-enum non-conflation rule + arch guardrail).
- Wire `hkBodyWeightProvider` into `weightSeriesProvider` with `await ref.watch(...future)` for window-switch determinism; HK failures (including denial) downgrade to an empty sample list so the Progress sparkline stays usable when HK is unavailable.

## Acceptance criteria
1. `buildWeightSeries` has the new signature with required `hkSamples`, `from`, `to`. ✔
2. Dedup prefers user-entered over HK per source precedence. ✔
3. `isFromHealthKit` populated correctly on each point. ✔
4. Mixed-unit banner works on the merged set (kg vs lb across user/HK triggers it). ✔
5. Arch test green. ✔
6. `flutter analyze` + `flutter test` green. ✔

## Scope — out (per brief)
- Summary card stays Drift-only (no HK merging into summary metrics).
- Import / writing HK.

## Test plan
- [x] `flutter analyze` — No issues found.
- [x] `flutter test` — 188 tests, all passing.
- [x] Arch guardrail (`test/arch/data_access_boundary_test.dart`) — green; `progress_providers.dart` imports the `_source.dart` façade only, and feature code still never references `Source.`.
- [x] New unit tests: same-day dedup (user-entered wins), different-day merge with HK/user flags, HK-only day, mixed-unit across HK + user-entered triggers banner, multiple HK samples same day → newest wins.
- [x] New widget test: `HealthSourceFake.authorized([...])` injects 2 HK samples merged against 1 user-entered row; asserts 2 merged points, correct `isFromHealthKit` flags, same-day user-entered wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)