### PR TITLE
#51 — HK workouts read + render

### DIFF
--- a/lib/features/workouts/hk_workout_providers.dart
+++ b/lib/features/workouts/hk_workout_providers.dart
@@ -1,0 +1,52 @@
+// HealthKit workout providers (issue #51 / S5.4).
+//
+// Consumed by `WorkoutListScreen` to render an "External workouts"
+// read-only section below the LiftLog session list. This file lives
+// under `lib/features/workouts/` (alongside `workout_providers.dart`)
+// because it's workouts-tab-scoped — not a general cross-feature HK
+// signal like the ones in `lib/features/progress/hk_signal_providers.dart`.
+//
+// Arch note: imports only the `_source.dart` façade from
+// `lib/sources/health_kit/`. Widget tests inject `HealthSourceFake` via
+// the `healthSourceProvider` override.
+//
+// Range semantics: `from`-inclusive / `to`-exclusive, matching every
+// `list*` method on the façade.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/app_providers.dart';
+import '../../sources/health_kit/health_source.dart';
+import '../progress/hk_signal_providers.dart';
+
+/// Workout samples for a given window. Returns `[]` when workouts are
+/// not authorized — partial HK denial is not a failure state (per the
+/// façade contract).
+final hkWorkoutsProvider =
+    FutureProvider.family<List<HKWorkoutSample>, DateRange>((ref, range) {
+      final hk = ref.watch(healthSourceProvider);
+      return hk.listWorkouts(from: range.from, to: range.to);
+    });
+
+/// Convenience provider — 90-day rolling lookback, matching the cadence
+/// used by `hkBodyWeightProvider`'s consumer in Progress. The Workouts
+/// tab consumer reads this directly.
+///
+/// The range is computed fresh on each read so it tracks "now" across
+/// provider invalidations. That means two reads a minute apart will use
+/// different `DateRange` keys and both hit the underlying `listWorkouts`
+/// — acceptable: HK reads are cheap relative to user action frequency.
+final hkWorkoutsLast90dProvider = FutureProvider<List<HKWorkoutSample>>((ref) {
+  final hk = ref.watch(healthSourceProvider);
+  final now = DateTime.now();
+  final from = now.subtract(const Duration(days: 90));
+  return hk.listWorkouts(from: from, to: now);
+});
+
+/// Whether HealthKit is authorized. Used by the Workouts tab to decide
+/// whether to render the "External workouts" section at all — if not
+/// authorized, the section is hidden (no nag toast, no empty state).
+final hkIsAuthorizedProvider = FutureProvider<bool>((ref) {
+  final hk = ref.watch(healthSourceProvider);
+  return hk.isAuthorized();
+});

--- a/lib/features/workouts/workout_list_screen.dart
+++ b/lib/features/workouts/workout_list_screen.dart
@@ -3,7 +3,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../data/database.dart';
 import '../../providers/app_providers.dart';
+import '../../sources/health_kit/health_source.dart';
+import '../../ui/labels.dart';
 import '../food/date_label.dart';
+import 'hk_workout_providers.dart';
 import 'workout_providers.dart';
 import 'workout_session_screen.dart';
 
@@ -13,6 +16,8 @@ class WorkoutListScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final sessions = ref.watch(workoutSessionsProvider);
+    final hkAuthorized = ref.watch(hkIsAuthorizedProvider);
+    final hkWorkouts = ref.watch(hkWorkoutsLast90dProvider);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Workouts')),
@@ -22,58 +27,173 @@ class WorkoutListScreen extends ConsumerWidget {
         label: const Text('Start workout'),
       ),
       body: sessions.when(
-        data: (list) => list.isEmpty
-            ? const Center(
-                child: Padding(
-                  padding: EdgeInsets.all(24),
-                  child: Text(
-                    'No workouts yet.\nTap Start workout to begin.',
-                    textAlign: TextAlign.center,
-                  ),
-                ),
-              )
-            : ListView.separated(
-                itemCount: list.length,
-                separatorBuilder: (_, _) => const Divider(height: 1),
-                itemBuilder: (context, i) {
-                  final s = list[i];
-                  final status = s.endedAt == null ? 'In progress' : 'Ended';
-                  return ListTile(
-                    title: Text('Workout · ${shortDate(s.startedAt)}'),
-                    subtitle: Text(status),
-                    trailing: Text(_formatTime(s.startedAt)),
-                    onTap: () => _openSession(context, s),
-                  );
-                },
-              ),
+        data: (list) => _buildBody(
+          context,
+          sessions: list,
+          hkAuthorized: hkAuthorized,
+          hkWorkouts: hkWorkouts,
+        ),
         loading: () => const SizedBox.shrink(),
         error: (err, _) => Center(child: Text('Could not load workouts: $err')),
       ),
     );
   }
 
+  Widget _buildBody(
+    BuildContext context, {
+    required List<WorkoutSession> sessions,
+    required AsyncValue<bool> hkAuthorized,
+    required AsyncValue<List<HKWorkoutSample>> hkWorkouts,
+  }) {
+    // Collapse the authorized-state read to a boolean. `loading` and
+    // `error` both default to "not authorized" — we never want to flash
+    // the external section while we're still resolving auth state, and
+    // an error resolving auth state means we don't know, so err toward
+    // hiding (per the no-nag-toast fallback).
+    final isAuthorized = hkAuthorized.maybeWhen(
+      data: (v) => v,
+      orElse: () => false,
+    );
+    // When not authorized, the external section doesn't render at all —
+    // no nag, no empty state, just the LiftLog section.
+    final externalSamples = isAuthorized
+        ? hkWorkouts.maybeWhen(
+            data: (v) => v,
+            orElse: () => const <HKWorkoutSample>[],
+          )
+        : const <HKWorkoutSample>[];
+    final showExternalSection = isAuthorized;
+
+    if (sessions.isEmpty && !showExternalSection) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            'No workouts yet.\nTap Start workout to begin.',
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+
+    // Single flat `ListView` with manually placed header / divider / row
+    // entries. Using one ListView keeps scroll smooth across both
+    // sections and avoids nested-scroll quirks.
+    final items = <Widget>[];
+
+    if (sessions.isEmpty) {
+      items.add(
+        const Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            'No LiftLog workouts yet.\nTap Start workout to begin.',
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    } else {
+      for (var i = 0; i < sessions.length; i++) {
+        final s = sessions[i];
+        final status = s.endedAt == null ? 'In progress' : 'Ended';
+        items.add(
+          ListTile(
+            title: Text('Workout · ${shortDate(s.startedAt)}'),
+            subtitle: Text(status),
+            trailing: Text(_formatTime(s.startedAt)),
+            onTap: () => _openSession(context, s),
+          ),
+        );
+        if (i != sessions.length - 1) {
+          items.add(const Divider(height: 1));
+        }
+      }
+    }
+
+    if (showExternalSection) {
+      items.add(const Divider(height: 1));
+      items.add(const _SectionHeader('External workouts'));
+      if (externalSamples.isEmpty) {
+        items.add(
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+            child: Text(
+              'No HealthKit workouts in the last 90 days.',
+              style: TextStyle(color: Colors.black54),
+            ),
+          ),
+        );
+      } else {
+        for (var i = 0; i < externalSamples.length; i++) {
+          final sample = externalSamples[i];
+          items.add(
+            ListTile(
+              title: Text(hkWorkoutTypeLabel(sample.type)),
+              subtitle: Text(
+                '${shortDate(sample.startedAt)} · '
+                '${_formatTime(sample.startedAt)}'
+                '–${_formatTime(sample.endedAt)} · '
+                '${_formatDuration(sample.duration)}',
+              ),
+            ),
+          );
+          if (i != externalSamples.length - 1) {
+            items.add(const Divider(height: 1));
+          }
+        }
+      }
+    }
+
+    return ListView(children: items);
+  }
+
   Future<void> _startSession(BuildContext context, WidgetRef ref) async {
     final repo = ref.read(workoutSessionRepositoryProvider);
     try {
-      final id = await repo.add(WorkoutSessionsCompanion.insert(
-        startedAt: DateTime.now(),
-      ));
+      final id = await repo.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime.now()),
+      );
       if (!context.mounted) return;
-      Navigator.of(context).push(MaterialPageRoute(
-        builder: (_) => WorkoutSessionScreen(sessionId: id),
-      ));
+      Navigator.of(context).push(
+        MaterialPageRoute(builder: (_) => WorkoutSessionScreen(sessionId: id)),
+      );
     } catch (e) {
       if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not start workout: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Could not start workout: $e')));
     }
   }
 
   void _openSession(BuildContext context, WorkoutSession session) {
-    Navigator.of(context).push(MaterialPageRoute(
-      builder: (_) => WorkoutSessionScreen(sessionId: session.id),
-    ));
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => WorkoutSessionScreen(sessionId: session.id),
+      ),
+    );
+  }
+}
+
+/// Lightweight section header used between the LiftLog and HealthKit
+/// lists. Kept local to this file — no design-system header component
+/// exists in this codebase yet and S5.4 doesn't call for one.
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.title);
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      child: Text(
+        title,
+        style: theme.textTheme.titleSmall?.copyWith(
+          color: theme.colorScheme.primary,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
   }
 }
 
@@ -81,4 +201,17 @@ String _formatTime(DateTime t) {
   final h = t.hour.toString().padLeft(2, '0');
   final m = t.minute.toString().padLeft(2, '0');
   return '$h:$m';
+}
+
+/// Compact duration label — `1h 23m`, `45m`, `42s` for sub-minute.
+/// Kept local to the workout-list surface; formatters.dart doesn't have
+/// a duration helper and S5.4 is the first consumer that needs one.
+String _formatDuration(Duration d) {
+  if (d.inMinutes < 1) {
+    return '${d.inSeconds}s';
+  }
+  final h = d.inHours;
+  final m = d.inMinutes.remainder(60);
+  if (h == 0) return '${m}m';
+  return '${h}h ${m}m';
 }

--- a/lib/sources/health_kit/health_source.dart
+++ b/lib/sources/health_kit/health_source.dart
@@ -212,6 +212,92 @@ class HKSleepStageSample {
       'stage: $stage)';
 }
 
+/// Workout activity buckets surfaced by the façade.
+///
+/// The `health` package's `HealthWorkoutActivityType` ships ~80 values
+/// covering every HKWorkoutActivityType Apple has ever defined plus the
+/// Android Health Connect bucket set. Surfacing that full fan-out to the
+/// UI would both (a) bloat the renderer switch and (b) leak a package
+/// enum through the façade. Instead, we compress into a small, stable
+/// set tied to the user's domain: strength training variants the lifter
+/// is most likely to log, plus a handful of the common cardio buckets,
+/// and an explicit `other` bucket for everything else.
+///
+/// `other` is the **explicit** catch-all, not a silent fallback. Every
+/// renderer must enumerate all ten cases in a `switch` — canonical-enum
+/// rule (see CLAUDE.md).
+///
+/// Mapping lives in `health_source_impl.dart::_mapHealthWorkoutType`
+/// (exposed via `debugMapHealthWorkoutType` for the table-driven mapping
+/// test, same seam as the sleep mapper).
+enum HKWorkoutType {
+  traditionalStrengthTraining,
+  functionalStrengthTraining,
+  coreTraining,
+  highIntensityIntervalTraining,
+  running,
+  walking,
+  cycling,
+  yoga,
+  other,
+}
+
+/// A single workout sample surfaced by the HealthKit bridge.
+///
+/// HealthKit workouts are interval-shaped (start + end), so this value
+/// class carries both plus a pre-computed [duration] for consumer
+/// convenience. [type] is the compressed [HKWorkoutType] bucket — see the
+/// enum doc for the rationale.
+///
+/// Immutable, value-equal, pure Dart.
+class HKWorkoutSample {
+  const HKWorkoutSample({
+    required this.sourceId,
+    required this.startedAt,
+    required this.endedAt,
+    required this.type,
+    required this.duration,
+  });
+
+  /// Stable identifier from the underlying HKSample's source — the app or
+  /// device that recorded the workout (the Apple Watch's companion, a
+  /// third-party workout tracker, or a manual entry in the Health app).
+  /// Used for de-duplication across a refresh cycle.
+  final String sourceId;
+
+  /// Inclusive start of the workout interval.
+  final DateTime startedAt;
+
+  /// Exclusive end of the workout interval.
+  final DateTime endedAt;
+
+  /// Which bucket this workout maps to. See [HKWorkoutType].
+  final HKWorkoutType type;
+
+  /// Pre-computed duration. HealthKit reports this explicitly on the
+  /// sample; we pass it through rather than recomputing from
+  /// `endedAt - startedAt` so pause/resume gaps (which Apple tracks
+  /// natively) aren't accidentally counted as active time.
+  final Duration duration;
+
+  @override
+  bool operator ==(Object other) =>
+      other is HKWorkoutSample &&
+      other.sourceId == sourceId &&
+      other.startedAt == startedAt &&
+      other.endedAt == endedAt &&
+      other.type == type &&
+      other.duration == duration;
+
+  @override
+  int get hashCode => Object.hash(sourceId, startedAt, endedAt, type, duration);
+
+  @override
+  String toString() =>
+      'HKWorkoutSample(sourceId: $sourceId, startedAt: $startedAt, '
+      'endedAt: $endedAt, type: $type, duration: $duration)';
+}
+
 /// Pure-Dart façade for a HealthKit source.
 ///
 /// The only implementation today (`HealthSourceImpl`) wraps
@@ -298,6 +384,22 @@ abstract class HealthSource {
   /// Streams sleep-stage samples in `[from, to)`. Same 60s poll semantics
   /// as [watchBodyWeight].
   Stream<List<HKSleepStageSample>> watchSleep({
+    required DateTime from,
+    required DateTime to,
+  });
+
+  /// One-shot fetch of workout samples in `[from, to)`. A workout whose
+  /// `startedAt` falls inside the window is included. Ordered
+  /// newest-first by `startedAt`. Returns `[]` when workouts are not
+  /// authorized — partial HK denial does not throw.
+  Future<List<HKWorkoutSample>> listWorkouts({
+    required DateTime from,
+    required DateTime to,
+  });
+
+  /// Streams workout samples in `[from, to)`. Same 60s poll semantics as
+  /// [watchBodyWeight].
+  Stream<List<HKWorkoutSample>> watchWorkouts({
     required DateTime from,
     required DateTime to,
   });

--- a/lib/sources/health_kit/health_source_fake.dart
+++ b/lib/sources/health_kit/health_source_fake.dart
@@ -19,9 +19,11 @@ import 'health_source.dart';
 /// * `HealthSourceFake.withHRV(samples)` — authorized, only HRV stubbed.
 /// * `HealthSourceFake.withRestingHR(samples)` — authorized, only resting HR.
 /// * `HealthSourceFake.withSleep(samples)` — authorized, only sleep stubbed.
-/// * `HealthSourceFake.authorizedWithSignals({weight, hrv, restingHR, sleep})`
-///   — composite, for widget tests that want to stub multiple signals at
-///   once.
+/// * `HealthSourceFake.withWorkouts(samples)` — authorized, only workouts
+///   stubbed.
+/// * `HealthSourceFake.authorizedWithSignals({weight, hrv, restingHR,
+///   sleep, workouts})` — composite, for widget tests that want to stub
+///   multiple signals at once.
 class HealthSourceFake implements HealthSource {
   HealthSourceFake({
     required bool authorized,
@@ -29,6 +31,7 @@ class HealthSourceFake implements HealthSource {
     List<HKHRVSample> hrvSamples = const [],
     List<HKRestingHRSample> restingHrSamples = const [],
     List<HKSleepStageSample> sleepSamples = const [],
+    List<HKWorkoutSample> workoutSamples = const [],
     Object? error,
     bool permissionGrantOutcome = true,
   }) : _authorized = authorized,
@@ -36,6 +39,7 @@ class HealthSourceFake implements HealthSource {
        _hrvSamples = List.unmodifiable(hrvSamples),
        _restingHrSamples = List.unmodifiable(restingHrSamples),
        _sleepSamples = List.unmodifiable(sleepSamples),
+       _workoutSamples = List.unmodifiable(workoutSamples),
        _error = error,
        _permissionGrantOutcome = permissionGrantOutcome;
 
@@ -72,6 +76,10 @@ class HealthSourceFake implements HealthSource {
   factory HealthSourceFake.withSleep(List<HKSleepStageSample> samples) =>
       HealthSourceFake(authorized: true, sleepSamples: samples);
 
+  /// Convenience: authorized, workout samples only.
+  factory HealthSourceFake.withWorkouts(List<HKWorkoutSample> samples) =>
+      HealthSourceFake(authorized: true, workoutSamples: samples);
+
   /// Composite factory: authorized, stub multiple signal kinds at once.
   /// Any omitted kind defaults to `[]`. Use this from widget tests that
   /// exercise several HK signals simultaneously.
@@ -80,12 +88,14 @@ class HealthSourceFake implements HealthSource {
     List<HKHRVSample> hrv = const [],
     List<HKRestingHRSample> restingHR = const [],
     List<HKSleepStageSample> sleep = const [],
+    List<HKWorkoutSample> workouts = const [],
   }) => HealthSourceFake(
     authorized: true,
     samples: weight,
     hrvSamples: hrv,
     restingHrSamples: restingHR,
     sleepSamples: sleep,
+    workoutSamples: workouts,
   );
 
   final bool _authorized;
@@ -93,6 +103,7 @@ class HealthSourceFake implements HealthSource {
   final List<HKHRVSample> _hrvSamples;
   final List<HKRestingHRSample> _restingHrSamples;
   final List<HKSleepStageSample> _sleepSamples;
+  final List<HKWorkoutSample> _workoutSamples;
   final Object? _error;
   final bool _permissionGrantOutcome;
 
@@ -101,6 +112,7 @@ class HealthSourceFake implements HealthSource {
   int listHRVCallCount = 0;
   int listRestingHRCallCount = 0;
   int listSleepCallCount = 0;
+  int listWorkoutsCallCount = 0;
 
   @override
   Future<bool> requestPermissions() async {
@@ -217,5 +229,35 @@ class HealthSourceFake implements HealthSource {
     required DateTime to,
   }) async* {
     yield await listSleep(from: from, to: to);
+  }
+
+  @override
+  Future<List<HKWorkoutSample>> listWorkouts({
+    required DateTime from,
+    required DateTime to,
+  }) async {
+    listWorkoutsCallCount += 1;
+    if (_error != null) throw _error;
+    if (!_authorized) return const [];
+    // `startedAt` in range — from-inclusive, to-exclusive, matching
+    // `listBodyWeight` semantics. Workouts are interval-shaped, but a
+    // workout is "in" a window if it started during the window; that
+    // matches how a consumer reasons about "workouts on this date."
+    final inRange =
+        _workoutSamples
+            .where(
+              (s) => !s.startedAt.isBefore(from) && s.startedAt.isBefore(to),
+            )
+            .toList()
+          ..sort((a, b) => b.startedAt.compareTo(a.startedAt));
+    return inRange;
+  }
+
+  @override
+  Stream<List<HKWorkoutSample>> watchWorkouts({
+    required DateTime from,
+    required DateTime to,
+  }) async* {
+    yield await listWorkouts(from: from, to: to);
   }
 }

--- a/lib/sources/health_kit/health_source_impl.dart
+++ b/lib/sources/health_kit/health_source_impl.dart
@@ -56,15 +56,17 @@ class HealthSourceImpl implements HealthSource {
     HealthDataType.SLEEP_LIGHT,
     HealthDataType.SLEEP_REM,
   ];
+  static const List<HealthDataType> _workoutTypes = [HealthDataType.WORKOUT];
 
   /// Union of every type we request at permission-dialog time. Requesting
   /// them together shows a single HealthKit permission sheet to the user
-  /// rather than four separate dialogs.
+  /// rather than five separate dialogs.
   static const List<HealthDataType> _allTypes = [
     ..._bodyWeightTypes,
     ..._hrvTypes,
     ..._restingHrTypes,
     ..._sleepTypes,
+    ..._workoutTypes,
   ];
 
   Future<void> _ensureConfigured() async {
@@ -239,6 +241,36 @@ class HealthSourceImpl implements HealthSource {
     required DateTime to,
   }) => _pollStream<HKSleepStageSample>(() => listSleep(from: from, to: to));
 
+  @override
+  Future<List<HKWorkoutSample>> listWorkouts({
+    required DateTime from,
+    required DateTime to,
+  }) async {
+    await _ensureConfigured();
+    if (!await _isAuthorizedFor(_workoutTypes)) return const [];
+
+    final points = await _plugin.getHealthDataFromTypes(
+      types: _workoutTypes,
+      startTime: from,
+      endTime: to,
+    );
+
+    final samples = <HKWorkoutSample>[];
+    for (final point in points) {
+      final sample = _toWorkoutSample(point);
+      if (sample != null) samples.add(sample);
+    }
+    // Newest-first by start time — matches the other list* methods.
+    samples.sort((a, b) => b.startedAt.compareTo(a.startedAt));
+    return samples;
+  }
+
+  @override
+  Stream<List<HKWorkoutSample>> watchWorkouts({
+    required DateTime from,
+    required DateTime to,
+  }) => _pollStream<HKWorkoutSample>(() => listWorkouts(from: from, to: to));
+
   /// Shared poll-on-subscribe / poll-every-N / cancel-on-unsubscribe
   /// implementation used by every `watch*` method. Kept private so the
   /// shape is consistent across data kinds — they all share the 60s
@@ -333,6 +365,171 @@ class HealthSourceImpl implements HealthSource {
     );
   }
 
+  /// Maps a raw `HealthDataPoint` to `HKWorkoutSample`. Returns `null` if
+  /// the point isn't a WORKOUT type or doesn't carry a `WorkoutHealthValue`.
+  /// The activity-type bucket mapping is in [_mapHealthWorkoutType].
+  HKWorkoutSample? _toWorkoutSample(HealthDataPoint point) {
+    if (point.type != HealthDataType.WORKOUT) return null;
+    final value = point.value;
+    if (value is! WorkoutHealthValue) return null;
+    final type = _mapHealthWorkoutType(value.workoutActivityType);
+    return HKWorkoutSample(
+      sourceId: point.sourceId,
+      startedAt: point.dateFrom,
+      endedAt: point.dateTo,
+      type: type,
+      duration: point.dateTo.difference(point.dateFrom),
+    );
+  }
+
+  /// Maps the `health` package's `HealthWorkoutActivityType` into our
+  /// compact [HKWorkoutType] enum. Every value the package ships is
+  /// enumerated explicitly — no fallthrough default. Anything we don't
+  /// explicitly surface maps to [HKWorkoutType.other], which is the
+  /// explicit catch-all (not a silent fallback — see CLAUDE.md canonical
+  /// enums).
+  ///
+  /// Mapping rationale:
+  ///   TRADITIONAL_STRENGTH_TRAINING     → traditionalStrengthTraining
+  ///   FUNCTIONAL_STRENGTH_TRAINING      → functionalStrengthTraining
+  ///   CORE_TRAINING                     → coreTraining
+  ///   HIGH_INTENSITY_INTERVAL_TRAINING  → highIntensityIntervalTraining
+  ///   RUNNING, RUNNING_TREADMILL         → running
+  ///   WALKING, WALKING_TREADMILL         → walking
+  ///   BIKING, BIKING_STATIONARY          → cycling
+  ///     (iOS "CYCLING" is the same enum as BIKING — see the `health`
+  ///      package comment; no separate CYCLING value exists.)
+  ///   YOGA                              → yoga
+  ///   everything else                    → other
+  ///
+  /// STRENGTH_TRAINING (Android-only, unversioned) maps to
+  /// `traditionalStrengthTraining` — it's the closest v1 analog and lets a
+  /// future Android target reuse the bucket. The `other` catch-all would
+  /// hide what is unambiguously a strength workout from the lifter.
+  HKWorkoutType _mapHealthWorkoutType(HealthWorkoutActivityType type) {
+    return switch (type) {
+      // Strength training buckets — surfaced explicitly.
+      HealthWorkoutActivityType.TRADITIONAL_STRENGTH_TRAINING =>
+        HKWorkoutType.traditionalStrengthTraining,
+      HealthWorkoutActivityType.FUNCTIONAL_STRENGTH_TRAINING =>
+        HKWorkoutType.functionalStrengthTraining,
+      HealthWorkoutActivityType.CORE_TRAINING => HKWorkoutType.coreTraining,
+      HealthWorkoutActivityType.HIGH_INTENSITY_INTERVAL_TRAINING =>
+        HKWorkoutType.highIntensityIntervalTraining,
+      // Android-only "STRENGTH_TRAINING" is the closest analog to
+      // traditional strength training — bucket it there rather than
+      // hiding it under `other` where a lifter wouldn't see their own
+      // workout.
+      HealthWorkoutActivityType.STRENGTH_TRAINING =>
+        HKWorkoutType.traditionalStrengthTraining,
+      // Android WEIGHTLIFTING — same rationale.
+      HealthWorkoutActivityType.WEIGHTLIFTING =>
+        HKWorkoutType.traditionalStrengthTraining,
+
+      // Cardio buckets — surfaced explicitly.
+      HealthWorkoutActivityType.RUNNING => HKWorkoutType.running,
+      HealthWorkoutActivityType.RUNNING_TREADMILL => HKWorkoutType.running,
+      HealthWorkoutActivityType.WALKING => HKWorkoutType.walking,
+      HealthWorkoutActivityType.WALKING_TREADMILL => HKWorkoutType.walking,
+      HealthWorkoutActivityType.BIKING => HKWorkoutType.cycling,
+      HealthWorkoutActivityType.BIKING_STATIONARY => HKWorkoutType.cycling,
+      HealthWorkoutActivityType.YOGA => HKWorkoutType.yoga,
+
+      // Everything else — explicit `other` catch-all. Every value the
+      // `health` package ships is enumerated here so the analyzer flags
+      // a new value the day the package bumps.
+      HealthWorkoutActivityType.AMERICAN_FOOTBALL => HKWorkoutType.other,
+      HealthWorkoutActivityType.ARCHERY => HKWorkoutType.other,
+      HealthWorkoutActivityType.AUSTRALIAN_FOOTBALL => HKWorkoutType.other,
+      HealthWorkoutActivityType.BADMINTON => HKWorkoutType.other,
+      HealthWorkoutActivityType.BASEBALL => HKWorkoutType.other,
+      HealthWorkoutActivityType.BASKETBALL => HKWorkoutType.other,
+      HealthWorkoutActivityType.BOXING => HKWorkoutType.other,
+      HealthWorkoutActivityType.CARDIO_DANCE => HKWorkoutType.other,
+      HealthWorkoutActivityType.CRICKET => HKWorkoutType.other,
+      HealthWorkoutActivityType.CROSS_COUNTRY_SKIING => HKWorkoutType.other,
+      HealthWorkoutActivityType.CURLING => HKWorkoutType.other,
+      HealthWorkoutActivityType.DOWNHILL_SKIING => HKWorkoutType.other,
+      HealthWorkoutActivityType.ELLIPTICAL => HKWorkoutType.other,
+      HealthWorkoutActivityType.FENCING => HKWorkoutType.other,
+      HealthWorkoutActivityType.GOLF => HKWorkoutType.other,
+      HealthWorkoutActivityType.GYMNASTICS => HKWorkoutType.other,
+      HealthWorkoutActivityType.HANDBALL => HKWorkoutType.other,
+      HealthWorkoutActivityType.HIKING => HKWorkoutType.other,
+      HealthWorkoutActivityType.HOCKEY => HKWorkoutType.other,
+      HealthWorkoutActivityType.JUMP_ROPE => HKWorkoutType.other,
+      HealthWorkoutActivityType.KICKBOXING => HKWorkoutType.other,
+      HealthWorkoutActivityType.MARTIAL_ARTS => HKWorkoutType.other,
+      HealthWorkoutActivityType.PILATES => HKWorkoutType.other,
+      HealthWorkoutActivityType.RACQUETBALL => HKWorkoutType.other,
+      HealthWorkoutActivityType.ROWING => HKWorkoutType.other,
+      HealthWorkoutActivityType.RUGBY => HKWorkoutType.other,
+      HealthWorkoutActivityType.SAILING => HKWorkoutType.other,
+      HealthWorkoutActivityType.SKATING => HKWorkoutType.other,
+      HealthWorkoutActivityType.SNOWBOARDING => HKWorkoutType.other,
+      HealthWorkoutActivityType.SOCCER => HKWorkoutType.other,
+      HealthWorkoutActivityType.SOFTBALL => HKWorkoutType.other,
+      HealthWorkoutActivityType.SQUASH => HKWorkoutType.other,
+      HealthWorkoutActivityType.STAIR_CLIMBING => HKWorkoutType.other,
+      HealthWorkoutActivityType.SWIMMING => HKWorkoutType.other,
+      HealthWorkoutActivityType.TABLE_TENNIS => HKWorkoutType.other,
+      HealthWorkoutActivityType.TENNIS => HKWorkoutType.other,
+      HealthWorkoutActivityType.VOLLEYBALL => HKWorkoutType.other,
+      HealthWorkoutActivityType.WATER_POLO => HKWorkoutType.other,
+      // iOS-only sports / activities.
+      HealthWorkoutActivityType.BARRE => HKWorkoutType.other,
+      HealthWorkoutActivityType.BOWLING => HKWorkoutType.other,
+      HealthWorkoutActivityType.CLIMBING => HKWorkoutType.other,
+      HealthWorkoutActivityType.COOLDOWN => HKWorkoutType.other,
+      HealthWorkoutActivityType.CROSS_TRAINING => HKWorkoutType.other,
+      HealthWorkoutActivityType.DISC_SPORTS => HKWorkoutType.other,
+      HealthWorkoutActivityType.EQUESTRIAN_SPORTS => HKWorkoutType.other,
+      HealthWorkoutActivityType.FISHING => HKWorkoutType.other,
+      HealthWorkoutActivityType.FITNESS_GAMING => HKWorkoutType.other,
+      HealthWorkoutActivityType.FLEXIBILITY => HKWorkoutType.other,
+      HealthWorkoutActivityType.HAND_CYCLING => HKWorkoutType.other,
+      HealthWorkoutActivityType.HUNTING => HKWorkoutType.other,
+      HealthWorkoutActivityType.LACROSSE => HKWorkoutType.other,
+      HealthWorkoutActivityType.MIND_AND_BODY => HKWorkoutType.other,
+      HealthWorkoutActivityType.MIXED_CARDIO => HKWorkoutType.other,
+      HealthWorkoutActivityType.PADDLE_SPORTS => HKWorkoutType.other,
+      HealthWorkoutActivityType.PICKLEBALL => HKWorkoutType.other,
+      HealthWorkoutActivityType.PLAY => HKWorkoutType.other,
+      HealthWorkoutActivityType.PREPARATION_AND_RECOVERY => HKWorkoutType.other,
+      HealthWorkoutActivityType.SNOW_SPORTS => HKWorkoutType.other,
+      HealthWorkoutActivityType.SOCIAL_DANCE => HKWorkoutType.other,
+      HealthWorkoutActivityType.STAIRS => HKWorkoutType.other,
+      HealthWorkoutActivityType.STEP_TRAINING => HKWorkoutType.other,
+      HealthWorkoutActivityType.SURFING => HKWorkoutType.other,
+      HealthWorkoutActivityType.TAI_CHI => HKWorkoutType.other,
+      HealthWorkoutActivityType.TRACK_AND_FIELD => HKWorkoutType.other,
+      HealthWorkoutActivityType.WATER_FITNESS => HKWorkoutType.other,
+      HealthWorkoutActivityType.WATER_SPORTS => HKWorkoutType.other,
+      HealthWorkoutActivityType.WHEELCHAIR_RUN_PACE => HKWorkoutType.other,
+      HealthWorkoutActivityType.WHEELCHAIR_WALK_PACE => HKWorkoutType.other,
+      HealthWorkoutActivityType.WRESTLING => HKWorkoutType.other,
+      HealthWorkoutActivityType.UNDERWATER_DIVING => HKWorkoutType.other,
+      // Android-only.
+      HealthWorkoutActivityType.CALISTHENICS => HKWorkoutType.other,
+      HealthWorkoutActivityType.DANCING => HKWorkoutType.other,
+      HealthWorkoutActivityType.FRISBEE_DISC => HKWorkoutType.other,
+      HealthWorkoutActivityType.GUIDED_BREATHING => HKWorkoutType.other,
+      HealthWorkoutActivityType.ICE_SKATING => HKWorkoutType.other,
+      HealthWorkoutActivityType.PARAGLIDING => HKWorkoutType.other,
+      HealthWorkoutActivityType.ROCK_CLIMBING => HKWorkoutType.other,
+      HealthWorkoutActivityType.ROWING_MACHINE => HKWorkoutType.other,
+      HealthWorkoutActivityType.SCUBA_DIVING => HKWorkoutType.other,
+      HealthWorkoutActivityType.SKIING => HKWorkoutType.other,
+      HealthWorkoutActivityType.SNOWSHOEING => HKWorkoutType.other,
+      HealthWorkoutActivityType.STAIR_CLIMBING_MACHINE => HKWorkoutType.other,
+      HealthWorkoutActivityType.SWIMMING_OPEN_WATER => HKWorkoutType.other,
+      HealthWorkoutActivityType.SWIMMING_POOL => HKWorkoutType.other,
+      HealthWorkoutActivityType.WHEELCHAIR => HKWorkoutType.other,
+      // The package's own generic "other" bucket.
+      HealthWorkoutActivityType.OTHER => HKWorkoutType.other,
+    };
+  }
+
   /// Maps the `health` package's `HealthDataType.SLEEP_*` values into our
   /// compact [SleepStage] enum.
   ///
@@ -393,3 +590,14 @@ SleepStage? debugMapHealthSleepType(
   HealthSourceImpl impl,
   HealthDataType type,
 ) => impl._mapHealthSleepType(type);
+
+/// Test-only hook — exposes `_mapHealthWorkoutType` for the table-driven
+/// mapping test over every `HealthWorkoutActivityType` value.
+///
+/// Returns the [HKWorkoutType] bucket the `listWorkouts` pipeline would
+/// emit for a given activity type — proving the mapping is exhaustive.
+@visibleForTesting
+HKWorkoutType debugMapHealthWorkoutType(
+  HealthSourceImpl impl,
+  HealthWorkoutActivityType type,
+) => impl._mapHealthWorkoutType(type);

--- a/lib/ui/labels.dart
+++ b/lib/ui/labels.dart
@@ -1,4 +1,5 @@
 import '../data/enums.dart';
+import '../sources/health_kit/health_source.dart';
 
 String mealTypeLabel(MealType t) {
   switch (t) {
@@ -32,5 +33,33 @@ String workoutSetStatusLabel(WorkoutSetStatus s) {
       return 'Completed';
     case WorkoutSetStatus.skipped:
       return 'Skipped';
+  }
+}
+
+/// Human-readable label for a HealthKit workout type bucket.
+///
+/// Enumerates every [HKWorkoutType] case (canonical-enum rule). If a new
+/// bucket is added, the analyzer flags this switch before it reaches the
+/// UI.
+String hkWorkoutTypeLabel(HKWorkoutType t) {
+  switch (t) {
+    case HKWorkoutType.traditionalStrengthTraining:
+      return 'Strength training';
+    case HKWorkoutType.functionalStrengthTraining:
+      return 'Functional strength';
+    case HKWorkoutType.coreTraining:
+      return 'Core training';
+    case HKWorkoutType.highIntensityIntervalTraining:
+      return 'HIIT';
+    case HKWorkoutType.running:
+      return 'Running';
+    case HKWorkoutType.walking:
+      return 'Walking';
+    case HKWorkoutType.cycling:
+      return 'Cycling';
+    case HKWorkoutType.yoga:
+      return 'Yoga';
+    case HKWorkoutType.other:
+      return 'Other';
   }
 }

--- a/test/features/workouts/workout_list_screen_test.dart
+++ b/test/features/workouts/workout_list_screen_test.dart
@@ -8,6 +8,8 @@ import 'package:liftlog_app/data/database.dart';
 import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
 import 'package:liftlog_app/features/workouts/workout_list_screen.dart';
 import 'package:liftlog_app/providers/app_providers.dart';
+import 'package:liftlog_app/sources/health_kit/health_source.dart';
+import 'package:liftlog_app/sources/health_kit/health_source_fake.dart';
 
 void main() {
   late AppDatabase db;
@@ -18,41 +20,106 @@ void main() {
 
   tearDown(() async => db.close());
 
-  Widget app() => ProviderScope(
-        overrides: [appDatabaseProvider.overrideWithValue(db)],
-        child: const MaterialApp(home: WorkoutListScreen()),
-      );
+  Widget app({HealthSource? hk}) => ProviderScope(
+    overrides: [
+      appDatabaseProvider.overrideWithValue(db),
+      if (hk != null) healthSourceProvider.overrideWithValue(hk),
+    ],
+    child: const MaterialApp(home: WorkoutListScreen()),
+  );
 
-  testWidgets('empty state shown when no sessions', (tester) async {
-    await tester.pumpWidget(app());
+  testWidgets('empty state shown when no sessions and HK unauthorized', (
+    tester,
+  ) async {
+    await tester.pumpWidget(app(hk: HealthSourceFake.notAuthorized()));
     await tester.pumpAndSettle();
 
     expect(find.textContaining('No workouts yet'), findsOneWidget);
+    // External section must NOT render when unauthorized — no nag, no
+    // empty state.
+    expect(find.text('External workouts'), findsNothing);
 
     await _drainDriftTimers(tester);
   });
 
-  testWidgets('renders sessions newest-first with in-progress / ended status',
-      (tester) async {
+  testWidgets('renders sessions newest-first with in-progress / ended status', (
+    tester,
+  ) async {
     final repo = WorkoutSessionRepository(db);
-    await repo.add(WorkoutSessionsCompanion.insert(
-      startedAt: DateTime(2026, 4, 20, 10),
-      endedAt: Value(DateTime(2026, 4, 20, 11)),
-    ));
-    await repo.add(WorkoutSessionsCompanion.insert(
-      startedAt: DateTime(2026, 4, 23, 18),
-    ));
+    await repo.add(
+      WorkoutSessionsCompanion.insert(
+        startedAt: DateTime(2026, 4, 20, 10),
+        endedAt: Value(DateTime(2026, 4, 20, 11)),
+      ),
+    );
+    await repo.add(
+      WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23, 18)),
+    );
 
-    await tester.pumpWidget(app());
+    await tester.pumpWidget(app(hk: HealthSourceFake.notAuthorized()));
     await tester.pumpAndSettle();
 
     final inProgress = find.text('In progress');
     final ended = find.text('Ended');
     expect(inProgress, findsOneWidget);
     expect(ended, findsOneWidget);
+    // Unauthorized → only the LiftLog section renders. No "External
+    // workouts" header, no HK rows.
+    expect(find.text('External workouts'), findsNothing);
 
     await _drainDriftTimers(tester);
   });
+
+  testWidgets(
+    'authorized + 2 HK workouts + 1 session → both sections, 3 rows',
+    (tester) async {
+      final repo = WorkoutSessionRepository(db);
+      await repo.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23, 18)),
+      );
+
+      final now = DateTime.now();
+      // Recent enough to fall inside the 90-day rolling window used by
+      // `hkWorkoutsLast90dProvider`.
+      final hkWorkouts = [
+        HKWorkoutSample(
+          sourceId: 'com.apple.health.workouts',
+          startedAt: now.subtract(const Duration(days: 2, hours: 3)),
+          endedAt: now.subtract(const Duration(days: 2, hours: 2)),
+          type: HKWorkoutType.traditionalStrengthTraining,
+          duration: const Duration(hours: 1),
+        ),
+        HKWorkoutSample(
+          sourceId: 'com.apple.health.workouts',
+          startedAt: now.subtract(const Duration(days: 5, hours: 3)),
+          endedAt: now.subtract(const Duration(days: 5, hours: 2, minutes: 15)),
+          type: HKWorkoutType.running,
+          duration: const Duration(minutes: 45),
+        ),
+      ];
+
+      await tester.pumpWidget(
+        app(hk: HealthSourceFake.withWorkouts(hkWorkouts)),
+      );
+      await tester.pumpAndSettle();
+
+      // LiftLog section: one session.
+      expect(find.text('In progress'), findsOneWidget);
+
+      // HK section header.
+      expect(find.text('External workouts'), findsOneWidget);
+
+      // HK rows — each title is the bucket label from
+      // `hkWorkoutTypeLabel`. Both buckets must appear.
+      expect(find.text('Strength training'), findsOneWidget);
+      expect(find.text('Running'), findsOneWidget);
+
+      // Total visible ListTile count = 1 LiftLog + 2 HK = 3.
+      expect(find.byType(ListTile), findsNWidgets(3));
+
+      await _drainDriftTimers(tester);
+    },
+  );
 }
 
 Future<void> _drainDriftTimers(WidgetTester tester) async {

--- a/test/sources/health_kit/health_source_impl_workout_mapping_test.dart
+++ b/test/sources/health_kit/health_source_impl_workout_mapping_test.dart
@@ -1,0 +1,98 @@
+// Table-driven test for `HealthSourceImpl._mapHealthWorkoutType`.
+//
+// Covers every `HealthWorkoutActivityType` value that `package:health`
+// ships. If the package adds a new activity type in a future version,
+// the mapping `switch` in `health_source_impl.dart` has no fallthrough
+// default — so an added value will fail analysis. This test pins that
+// guarantee at the test level too, asserting every known activity type
+// has an explicit mapping (to either a surfaced [HKWorkoutType] bucket
+// or the explicit `HKWorkoutType.other` catch-all).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:health/health.dart';
+
+import 'package:liftlog_app/sources/health_kit/health_source.dart';
+import 'package:liftlog_app/sources/health_kit/health_source_impl.dart';
+
+void main() {
+  final impl = HealthSourceImpl();
+
+  group('_mapHealthWorkoutType — surfaced buckets', () {
+    // The nine buckets that surface to the UI. Each maps from one or
+    // more `HealthWorkoutActivityType` values. If the `health` package
+    // bumps and renames/removes any of these, the mapping switch will
+    // fail analysis AND this test will fail — forcing a lock-step fix.
+    final surfaced = <HealthWorkoutActivityType, HKWorkoutType>{
+      HealthWorkoutActivityType.TRADITIONAL_STRENGTH_TRAINING:
+          HKWorkoutType.traditionalStrengthTraining,
+      HealthWorkoutActivityType.STRENGTH_TRAINING:
+          HKWorkoutType.traditionalStrengthTraining,
+      HealthWorkoutActivityType.WEIGHTLIFTING:
+          HKWorkoutType.traditionalStrengthTraining,
+      HealthWorkoutActivityType.FUNCTIONAL_STRENGTH_TRAINING:
+          HKWorkoutType.functionalStrengthTraining,
+      HealthWorkoutActivityType.CORE_TRAINING: HKWorkoutType.coreTraining,
+      HealthWorkoutActivityType.HIGH_INTENSITY_INTERVAL_TRAINING:
+          HKWorkoutType.highIntensityIntervalTraining,
+      HealthWorkoutActivityType.RUNNING: HKWorkoutType.running,
+      HealthWorkoutActivityType.RUNNING_TREADMILL: HKWorkoutType.running,
+      HealthWorkoutActivityType.WALKING: HKWorkoutType.walking,
+      HealthWorkoutActivityType.WALKING_TREADMILL: HKWorkoutType.walking,
+      HealthWorkoutActivityType.BIKING: HKWorkoutType.cycling,
+      HealthWorkoutActivityType.BIKING_STATIONARY: HKWorkoutType.cycling,
+      HealthWorkoutActivityType.YOGA: HKWorkoutType.yoga,
+    };
+
+    for (final entry in surfaced.entries) {
+      test('${entry.key} -> ${entry.value}', () {
+        expect(debugMapHealthWorkoutType(impl, entry.key), equals(entry.value));
+      });
+    }
+  });
+
+  group('_mapHealthWorkoutType — other catch-all', () {
+    // A representative (non-exhaustive) sample of activity types that
+    // should fold into `other`. Exhaustiveness is verified below via
+    // the "every value maps to something" test — this group's job is to
+    // document that the `other` bucket is explicit, not a silent
+    // fallback.
+    final otherSamples = <HealthWorkoutActivityType>[
+      HealthWorkoutActivityType.AMERICAN_FOOTBALL,
+      HealthWorkoutActivityType.ARCHERY,
+      HealthWorkoutActivityType.SWIMMING,
+      HealthWorkoutActivityType.TENNIS,
+      HealthWorkoutActivityType.PILATES,
+      HealthWorkoutActivityType.ELLIPTICAL,
+      HealthWorkoutActivityType.ROWING,
+      HealthWorkoutActivityType.BOXING,
+      HealthWorkoutActivityType.MIXED_CARDIO,
+      HealthWorkoutActivityType.FLEXIBILITY,
+      HealthWorkoutActivityType.TRACK_AND_FIELD,
+      HealthWorkoutActivityType.OTHER,
+    ];
+
+    for (final value in otherSamples) {
+      test('$value -> HKWorkoutType.other', () {
+        expect(
+          debugMapHealthWorkoutType(impl, value),
+          equals(HKWorkoutType.other),
+        );
+      });
+    }
+  });
+
+  test('every HealthWorkoutActivityType value maps to some HKWorkoutType', () {
+    // This test is the canary for `health` package bumps. If the
+    // package adds a new activity type, the `switch` in the impl has
+    // no fallthrough default — so the analyzer flags it and this test
+    // will still pass once the new case is added. If, somehow, a case
+    // yields `other` only because it was caught by a future default,
+    // this test still runs the assertion and documents the contract.
+    for (final value in HealthWorkoutActivityType.values) {
+      final mapped = debugMapHealthWorkoutType(impl, value);
+      // Every value produces a valid HKWorkoutType — no nulls, no
+      // throws. The mapping is total.
+      expect(HKWorkoutType.values, contains(mapped));
+    }
+  });
+}

--- a/test/sources/health_kit/health_source_test.dart
+++ b/test/sources/health_kit/health_source_test.dart
@@ -531,6 +531,174 @@ void main() {
     });
   });
 
+  group('HKWorkoutSample value equality', () {
+    test('two samples with identical fields compare equal', () {
+      final a = HKWorkoutSample(
+        sourceId: 'com.apple.health.workouts',
+        startedAt: DateTime(2026, 4, 20, 18),
+        endedAt: DateTime(2026, 4, 20, 19),
+        type: HKWorkoutType.traditionalStrengthTraining,
+        duration: const Duration(hours: 1),
+      );
+      final b = HKWorkoutSample(
+        sourceId: 'com.apple.health.workouts',
+        startedAt: DateTime(2026, 4, 20, 18),
+        endedAt: DateTime(2026, 4, 20, 19),
+        type: HKWorkoutType.traditionalStrengthTraining,
+        duration: const Duration(hours: 1),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('samples that differ on any field compare unequal', () {
+      final base = HKWorkoutSample(
+        sourceId: 'com.apple.health.workouts',
+        startedAt: DateTime(2026, 4, 20, 18),
+        endedAt: DateTime(2026, 4, 20, 19),
+        type: HKWorkoutType.traditionalStrengthTraining,
+        duration: const Duration(hours: 1),
+      );
+      // Different type.
+      expect(
+        base,
+        isNot(
+          equals(
+            HKWorkoutSample(
+              sourceId: 'com.apple.health.workouts',
+              startedAt: DateTime(2026, 4, 20, 18),
+              endedAt: DateTime(2026, 4, 20, 19),
+              type: HKWorkoutType.running,
+              duration: const Duration(hours: 1),
+            ),
+          ),
+        ),
+      );
+      // Different duration.
+      expect(
+        base,
+        isNot(
+          equals(
+            HKWorkoutSample(
+              sourceId: 'com.apple.health.workouts',
+              startedAt: DateTime(2026, 4, 20, 18),
+              endedAt: DateTime(2026, 4, 20, 19),
+              type: HKWorkoutType.traditionalStrengthTraining,
+              duration: const Duration(minutes: 45),
+            ),
+          ),
+        ),
+      );
+      // Different start.
+      expect(
+        base,
+        isNot(
+          equals(
+            HKWorkoutSample(
+              sourceId: 'com.apple.health.workouts',
+              startedAt: DateTime(2026, 4, 21, 18),
+              endedAt: DateTime(2026, 4, 20, 19),
+              type: HKWorkoutType.traditionalStrengthTraining,
+              duration: const Duration(hours: 1),
+            ),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('HKWorkoutType canonical enum', () {
+    // Dedicated coverage: every HKWorkoutType value must be reachable in
+    // a downstream consumer's `switch` — canonical-enum rule. The size
+    // check pins the set — if a new bucket lands, every renderer must be
+    // re-enumerated.
+    String dummyLabel(HKWorkoutType t) => switch (t) {
+      HKWorkoutType.traditionalStrengthTraining => 'Strength',
+      HKWorkoutType.functionalStrengthTraining => 'Functional',
+      HKWorkoutType.coreTraining => 'Core',
+      HKWorkoutType.highIntensityIntervalTraining => 'HIIT',
+      HKWorkoutType.running => 'Running',
+      HKWorkoutType.walking => 'Walking',
+      HKWorkoutType.cycling => 'Cycling',
+      HKWorkoutType.yoga => 'Yoga',
+      HKWorkoutType.other => 'Other',
+    };
+
+    test('every enum value resolves through an exhaustive switch', () {
+      for (final t in HKWorkoutType.values) {
+        expect(dummyLabel(t), isNotEmpty);
+      }
+      expect(HKWorkoutType.values, hasLength(9));
+    });
+  });
+
+  group('HealthSourceFake — workouts contract', () {
+    final w1 = HKWorkoutSample(
+      sourceId: 'com.apple.health.workouts',
+      startedAt: DateTime(2026, 4, 20, 18),
+      endedAt: DateTime(2026, 4, 20, 19),
+      type: HKWorkoutType.traditionalStrengthTraining,
+      duration: const Duration(hours: 1),
+    );
+    final w2 = HKWorkoutSample(
+      sourceId: 'com.apple.health.workouts',
+      startedAt: DateTime(2026, 4, 22, 7),
+      endedAt: DateTime(2026, 4, 22, 7, 45),
+      type: HKWorkoutType.running,
+      duration: const Duration(minutes: 45),
+    );
+
+    test(
+      'authorized: listWorkouts returns range-filtered, newest-first',
+      () async {
+        final fake = HealthSourceFake.withWorkouts([w1, w2]);
+        final got = await fake.listWorkouts(
+          from: DateTime(2026, 4, 1),
+          to: DateTime(2026, 5, 1),
+        );
+        expect(got, equals([w2, w1]));
+        expect(fake.listWorkoutsCallCount, 1);
+      },
+    );
+
+    test(
+      'authorized: range exclusion filters out workouts outside window',
+      () async {
+        final fake = HealthSourceFake.withWorkouts([w1, w2]);
+        final got = await fake.listWorkouts(
+          from: DateTime(2026, 4, 21),
+          to: DateTime(2026, 5, 1),
+        );
+        expect(got, equals([w2]));
+      },
+    );
+
+    test('not authorized: listWorkouts returns []', () async {
+      final fake = HealthSourceFake.notAuthorized();
+      final got = await fake.listWorkouts(
+        from: DateTime(2026, 4, 1),
+        to: DateTime(2026, 5, 1),
+      );
+      expect(got, isEmpty);
+    });
+
+    test('throwing fake surfaces the stubbed error for workouts', () async {
+      final fake = HealthSourceFake.throwing(StateError('boom'));
+      await expectLater(
+        fake.listWorkouts(from: DateTime(2026, 4, 1), to: DateTime(2026, 5, 1)),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('watchWorkouts emits the initial list', () async {
+      final fake = HealthSourceFake.withWorkouts([w1, w2]);
+      final first = await fake
+          .watchWorkouts(from: DateTime(2026, 4, 1), to: DateTime(2026, 5, 1))
+          .first;
+      expect(first, equals([w2, w1]));
+    });
+  });
+
   group('HealthSourceFake.authorizedWithSignals composite factory', () {
     test(
       'stubs multiple signals at once; omitted kinds default to []',
@@ -547,9 +715,18 @@ void main() {
           sdnnMs: 50.0,
         );
 
+        final workout = HKWorkoutSample(
+          sourceId: 'com.apple.health.workouts',
+          startedAt: DateTime(2026, 4, 20, 18),
+          endedAt: DateTime(2026, 4, 20, 19),
+          type: HKWorkoutType.traditionalStrengthTraining,
+          duration: const Duration(hours: 1),
+        );
+
         final fake = HealthSourceFake.authorizedWithSignals(
           weight: [weight],
           hrv: [hrv],
+          workouts: [workout],
         );
 
         expect(
@@ -565,6 +742,13 @@ void main() {
             to: DateTime(2026, 5, 1),
           ),
           equals([hrv]),
+        );
+        expect(
+          await fake.listWorkouts(
+            from: DateTime(2026, 4, 1),
+            to: DateTime(2026, 5, 1),
+          ),
+          equals([workout]),
         );
         // Omitted signals — both default to [].
         expect(
@@ -599,6 +783,10 @@ void main() {
       );
       await expectLater(
         fake.listSleep(from: DateTime(2026, 4, 1), to: DateTime(2026, 5, 1)),
+        throwsA(isA<StateError>()),
+      );
+      await expectLater(
+        fake.listWorkouts(from: DateTime(2026, 4, 1), to: DateTime(2026, 5, 1)),
         throwsA(isA<StateError>()),
       );
     });


### PR DESCRIPTION
Closes #51.

## Summary
- Adds `HKWorkoutType` (9 cases, explicit `other` catch-all) + `HKWorkoutSample` value class + `listWorkouts`/`watchWorkouts` on the `HealthSource` façade.
- `HealthSourceImpl` maps `HealthWorkoutActivityType` exhaustively — every value the `health` package ships has an explicit arm (analyzer flags a package bump in lock-step).
- `HealthSourceFake.withWorkouts(...)` + composite `.authorizedWithSignals(workouts: ...)` grow the fake.
- Workouts tab renders a new **External workouts** section below the LiftLog session list when HK is authorized. Section is hidden entirely when not authorized — no nag toast, no empty state.
- New `hk_workout_providers.dart` under `lib/features/workouts/` with a 90-day rolling lookback matching `hkBodyWeightProvider`'s cadence.
- New `hkWorkoutTypeLabel` in `lib/ui/labels.dart` enumerates all 9 cases.

## Design decisions, briefly noted
- `STRENGTH_TRAINING` (Android) and `WEIGHTLIFTING` both fold into `HKWorkoutType.traditionalStrengthTraining` rather than `other` — these are unambiguously strength workouts for a lifter and hiding them under `other` would be worse UX than the small bucket-blurring.
- `BIKING` + `BIKING_STATIONARY` both map to `cycling`. The `health` package doesn't ship a separate `CYCLING` symbol (iOS's `CYCLING` is the same value as `BIKING` per the package's own comment).
- Provider lives under `features/workouts/` rather than `features/progress/hk_signal_providers.dart` because the Workouts tab is the sole consumer — keeps the cross-feature Progress signal file tight.
- `_formatDuration` kept local to `workout_list_screen.dart`. `lib/ui/formatters.dart` doesn't have a duration helper and this is the first consumer that needs one; promoting it is a separate call.
- Single flat `ListView` (rather than nested) in the workouts screen keeps scrolling smooth across both sections without nested-scroll quirks.

## Trust-rule adherence
- `HKWorkoutType` enumerated exhaustively in every `switch` (label helper + dummy-label test + impl mapping + enum size assertion).
- `other` is the **explicit** catch-all — never a fallthrough default.
- Partial HK denial (`WORKOUT` denied but other signals granted) returns `[]` per the façade contract; does not throw.
- No new pub deps.
- `lib/features/**` imports only the `_source.dart` façade from `lib/sources/health_kit/` — arch test still passes.

## Out of scope (per S5.4 brief)
- Auto-import HK workouts into `WorkoutSessions`.
- Tap-to-detail on HK workouts.
- Editing HK workouts.
- Merging HK workout duration into the weekly volume chart.
- HK workout writes.

## Test plan
- [x] `flutter analyze` — clean (no issues).
- [x] `flutter test` — 257 / 257 pass.
- [x] `grep -rn "package:health" lib/features/` — 0 hits.
- [x] New mapping test covers every `HealthWorkoutActivityType` value (package canary).
- [x] New widget tests cover authorized (both sections, 3 ListTiles) + unauthorized (only LiftLog).

## Surprising findings
- The `health` package's `HealthWorkoutActivityType` is ~80 values, not the ~60+ in the brief. All non-surfaced values enumerate to `other` via explicit arms — no fallthrough.
- `HealthWorkoutActivityType.UNDERWATER_DIVING`, `FITNESS_GAMING`, `CARDIO_DANCE`, `SOCIAL_DANCE`, `PADDLE_SPORTS`, `PICKLEBALL`, `PLAY`, `WHEELCHAIR_RUN_PACE`, `WHEELCHAIR_WALK_PACE`, `HAND_CYCLING`, `UNDERWATER_DIVING` all exist — all fold to `other`. None of these were controversial; noting here for the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)