### PR TITLE
#52 — Routines model (schema v4)

### DIFF
--- a/docs/export-format.md
+++ b/docs/export-format.md
@@ -13,13 +13,15 @@ The format is designed to be machine-readable first. snake_case keys match the D
   "meta": {
     "format_version": "1",
     "app_version": "1.0.0+1",
-    "schema_version": 2,
+    "schema_version": 4,
     "exported_at": "2026-04-24T09:14:00.000Z",
     "counts": {
       "food_entries": 42,
       "body_weight_logs": 18,
       "workout_sessions": 6,
-      "exercise_sets": 71
+      "exercise_sets": 71,
+      "routines": 3,
+      "routine_exercises": 12
     },
     "note": "All arrays below are user-entered rows exactly as stored. Daily totals, weight deltas, weekly workout volumes, and other summaries are derived by the app at read time and intentionally not included."
   },
@@ -62,6 +64,27 @@ The format is designed to be machine-readable first. snake_case keys match the D
       "status": "completed",
       "order_index": 0
     }
+  ],
+  "routines": [
+    {
+      "id": 1,
+      "name": "Push A",
+      "notes": null,
+      "created_at": "2026-04-20T12:00:00.000Z",
+      "source": "userEntered"
+    }
+  ],
+  "routine_exercises": [
+    {
+      "id": 1,
+      "routine_id": 1,
+      "exercise_id": 4,
+      "order_index": 0,
+      "target_sets": 4,
+      "target_reps": 8,
+      "target_weight": 80.0,
+      "target_weight_unit": "kg"
+    }
   ]
 }
 ```
@@ -75,6 +98,33 @@ The format is designed to be machine-readable first. snake_case keys match the D
 - **Numbers** are JSON numbers. `kcal`, `reps`, `order_index`, `id`, `session_id`, `schema_version` are integers; `protein_g`, `weight`, `value` are doubles. No locale formatting, no quoted numbers.
 - **Array ordering**: every entity array is sorted by `id` ascending in Dart before serialization. Deterministic across runs: two consecutive exports of the same DB with the same `exported_at` produce byte-identical output.
 - **No other keys.** Any future field requires a `format_version` bump and a matching spec update in this file.
+
+### `routines`
+
+Reusable workout templates (schema v4, issue #52). A routine is a named lineup of exercises a user can later spin up into a concrete `WorkoutSession`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | int | Primary key. |
+| `name` | string | Required. |
+| `notes` | string \| null | Free-form; `null` serializes as JSON `null`. |
+| `created_at` | ISO 8601 UTC string | Same timestamp convention as the other entities. |
+| `source` | enum string | `Source.name`. See [enum reference](#enum-reference). |
+
+### `routine_exercises`
+
+Line items on a routine (schema v4, issue #52). Each row pairs a routine with an exercise and optional per-exercise targets.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | int | Primary key. |
+| `routine_id` | int | FK → `routines.id`. `ON DELETE CASCADE`. |
+| `exercise_id` | int | FK → `exercises.id`. The `exercises` catalog is not itself exported today (it's seeded from `exercise_sets.exercise_name`), so routine_exercises imports assume the destination DB already has the matching exercise row — same pattern as the `exercise_sets` → `workout_sessions` contract. |
+| `order_index` | int | Authoritative ordering within the routine. |
+| `target_sets` | int \| null | |
+| `target_reps` | int \| null | |
+| `target_weight` | double \| null | |
+| `target_weight_unit` | enum string \| null | `WeightUnit.name`; `null` if the routine doesn't prescribe a weight (bodyweight or reps-only). |
 
 ## Enum reference
 
@@ -110,6 +160,18 @@ Every enum value is listed here. The serialized string is the Dart `.name`.
 | `WeightUnit.kg` | `"kg"` |
 | `WeightUnit.lb` | `"lb"` |
 
+### `Source`
+| Value | Serialized |
+|---|---|
+| `Source.userEntered` | `"userEntered"` |
+| `Source.savedTemplate` | `"savedTemplate"` |
+| `Source.healthKit` | `"healthKit"` |
+| `Source.photoEstimate` | `"photoEstimate"` |
+| `Source.voiceEstimate` | `"voiceEstimate"` |
+| `Source.barcode` | `"barcode"` |
+| `Source.derived` | `"derived"` |
+| `Source.imported` | `"imported"` |
+
 ## Not included
 
 The export contains only the rows you typed. These **are** always in the app but **are not** in the export file:
@@ -124,7 +186,7 @@ If any of those ever start appearing in the export, that's a regression — ever
 
 ## Stability
 
-- `format_version` bumps **whenever this shape changes** — new entity, new field, renamed key, changed serialization. The value is a plain string (`"1"`, `"2"`, …); tooling can string-compare.
+- `format_version` bumps **when a breaking shape change lands** — a removed entity, a renamed key, a changed serialization of an existing field, or any change that would make an older importer read the file wrong. **Additive snake_case keys do not require a bump:** old importers ignore unknown keys, new importers treat missing keys as empty / null. That's the rule that let the S5.1 `source` column addition and the S5.5 `routines` / `routine_exercises` sections both ship at `format_version: "1"`.
 - `schema_version` tracks the Drift DB schema (`AppDatabase.schemaVersion`). It changes independently of `format_version`: a schema migration that doesn't surface new user-visible columns does not require a `format_version` bump.
 - `app_version` is informational. It matches the `pubspec.yaml` version at build time.
 

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -47,8 +47,7 @@ class ExerciseSets extends Table {
   // Nullable FK to the first-class `Exercises` table (schema v3). Populated
   // by the v2→v3 seeding pass and by future adaptive-programming work.
   // UI still reads `exerciseName` as the authoritative name source for now.
-  IntColumn get exerciseId =>
-      integer().nullable().references(Exercises, #id)();
+  IntColumn get exerciseId => integer().nullable().references(Exercises, #id)();
   TextColumn get source =>
       textEnum<Source>().withDefault(const Constant('userEntered'))();
 }
@@ -78,75 +77,134 @@ class Exercises extends Table {
   DateTimeColumn get createdAt => dateTime()();
 }
 
-@DriftDatabase(tables: [
-  FoodEntries,
-  WorkoutSessions,
-  ExerciseSets,
-  BodyWeightLogs,
-  Exercises,
-])
+/// Routine — a reusable workout template (schema v4, issue #52).
+///
+/// A routine names a lineup of exercises (and optional per-exercise
+/// target sets/reps/weight) that the user can later spin up into a
+/// concrete `WorkoutSession`. Sprint 5 lands the data layer only — no
+/// UI renders routines yet, and "start workout from routine" is
+/// deferred. The model is shaped so future adaptive-programming work
+/// (E7) can read routine definitions without schema churn.
+///
+/// `source` follows the v2.0 trust rule that every entity declares its
+/// provenance. Defaulted to `'userEntered'` so the v3→v4 migration can
+/// add the column without a data backfill (no existing rows on a fresh
+/// table anyway, but keeping the pattern consistent with every other
+/// entity).
+class Routines extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get name => text()();
+  TextColumn get notes => text().nullable()();
+  DateTimeColumn get createdAt => dateTime()();
+  TextColumn get source =>
+      textEnum<Source>().withDefault(const Constant('userEntered'))();
+}
+
+/// Line items on a routine (schema v4, issue #52).
+///
+/// Each row links a routine to an exercise with an explicit
+/// `orderIndex` (the `RoutineRepository.reorderExercises` transactional
+/// rewrite preserves this as the authoritative ordering). Target
+/// columns are nullable because a routine can prescribe as much or as
+/// little detail as the user wants — a bodyweight routine might leave
+/// `targetWeight` / `targetWeightUnit` null, and a free-form one might
+/// leave every target null. `routineId` uses `ON DELETE CASCADE` so
+/// deleting a routine removes its lineup automatically (enforced by
+/// `PRAGMA foreign_keys = ON` in `beforeOpen`).
+class RoutineExercises extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  IntColumn get routineId =>
+      integer().references(Routines, #id, onDelete: KeyAction.cascade)();
+  IntColumn get exerciseId => integer().references(Exercises, #id)();
+  IntColumn get orderIndex => integer()();
+  IntColumn get targetSets => integer().nullable()();
+  IntColumn get targetReps => integer().nullable()();
+  RealColumn get targetWeight => real().nullable()();
+  TextColumn get targetWeightUnit => textEnum<WeightUnit>().nullable()();
+}
+
+@DriftDatabase(
+  tables: [
+    FoodEntries,
+    WorkoutSessions,
+    ExerciseSets,
+    BodyWeightLogs,
+    Exercises,
+    Routines,
+    RoutineExercises,
+  ],
+)
 class AppDatabase extends _$AppDatabase {
   AppDatabase() : super(_openConnection());
 
   AppDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 3;
+  int get schemaVersion => 4;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
-        onCreate: (m) => m.createAll(),
-        onUpgrade: (m, from, to) async {
-          // When advancing schemaVersion: document the manual backup path
-          // in vault/05 Architecture/Runbooks.md before releasing the migration.
-          if (from < 2) {
-            await m.addColumn(foodEntries, foodEntries.name);
-          }
-          if (from < 3) {
-            // Additive-only — no drops, no renames, no transforms beyond
-            // the one-time exercise seeding (idempotent via UNIQUE).
-            //
-            // 1. Provenance columns on every entity.
-            await m.addColumn(foodEntries, foodEntries.source);
-            await m.addColumn(bodyWeightLogs, bodyWeightLogs.source);
-            await m.addColumn(workoutSessions, workoutSessions.source);
-            await m.addColumn(exerciseSets, exerciseSets.source);
-            // 2. First-class `exercises` table.
-            await m.createTable(exercises);
-            // 3. Nullable FK from exercise_sets → exercises (no backfill
-            //    in this PR; UI still reads `exerciseName`).
-            await m.addColumn(exerciseSets, exerciseSets.exerciseId);
-            // 4. Seed exercises from the distinct historical names.
-            await _seedExercisesFromHistory();
-          }
-        },
-        beforeOpen: (details) async {
-          await customStatement('PRAGMA foreign_keys = ON');
-          // Backfill `exercise_sets.exercise_id` from the `exercises` table.
-          //
-          // Why: the v2→v3 migration (issue #42) seeded `exercises` from the
-          // distinct historical `exerciseName` values and added a nullable
-          // `exercise_id` FK on `exercise_sets`, but did NOT link existing
-          // sets to their seeded exercise row. This statement closes that
-          // carryover (issue #47) so historical sets are addressable by id
-          // for future adaptive-programming features.
-          //
-          // Idempotency: the `WHERE exercise_id IS NULL` guard makes every
-          // subsequent open a no-op — rows already linked stay linked, rows
-          // that still lack a matching `exercises` entry (e.g. a set whose
-          // name was deleted from `exercises`) stay null. Safe to run on
-          // every boot.
-          //
-          // Trust rule: this populates a nullable FK that was introduced
-          // specifically to enable this link — restoration of intent, not
-          // silent mutation of user-visible totals or units.
-          await customStatement('''
+    onCreate: (m) => m.createAll(),
+    onUpgrade: (m, from, to) async {
+      // When advancing schemaVersion: document the manual backup path
+      // in vault/05 Architecture/Runbooks.md before releasing the migration.
+      if (from < 2) {
+        await m.addColumn(foodEntries, foodEntries.name);
+      }
+      if (from < 3) {
+        // Additive-only — no drops, no renames, no transforms beyond
+        // the one-time exercise seeding (idempotent via UNIQUE).
+        //
+        // 1. Provenance columns on every entity.
+        await m.addColumn(foodEntries, foodEntries.source);
+        await m.addColumn(bodyWeightLogs, bodyWeightLogs.source);
+        await m.addColumn(workoutSessions, workoutSessions.source);
+        await m.addColumn(exerciseSets, exerciseSets.source);
+        // 2. First-class `exercises` table.
+        await m.createTable(exercises);
+        // 3. Nullable FK from exercise_sets → exercises (no backfill
+        //    in this PR; UI still reads `exerciseName`).
+        await m.addColumn(exerciseSets, exerciseSets.exerciseId);
+        // 4. Seed exercises from the distinct historical names.
+        await _seedExercisesFromHistory();
+      }
+      if (from < 4) {
+        // Additive-only — two brand-new tables with no data transform
+        // on existing tables. Backup path documented in Runbooks
+        // ("Manual backup path — v3 → v4") per the platform-risk
+        // guardrail. `routines.source` has a default ('userEntered'),
+        // but there are no existing rows to backfill anyway.
+        await m.createTable(routines);
+        await m.createTable(routineExercises);
+      }
+    },
+    beforeOpen: (details) async {
+      await customStatement('PRAGMA foreign_keys = ON');
+      // Backfill `exercise_sets.exercise_id` from the `exercises` table.
+      //
+      // Why: the v2→v3 migration (issue #42) seeded `exercises` from the
+      // distinct historical `exerciseName` values and added a nullable
+      // `exercise_id` FK on `exercise_sets`, but did NOT link existing
+      // sets to their seeded exercise row. This statement closes that
+      // carryover (issue #47) so historical sets are addressable by id
+      // for future adaptive-programming features.
+      //
+      // Idempotency: the `WHERE exercise_id IS NULL` guard makes every
+      // subsequent open a no-op — rows already linked stay linked, rows
+      // that still lack a matching `exercises` entry (e.g. a set whose
+      // name was deleted from `exercises`) stay null. Safe to run on
+      // every boot.
+      //
+      // Trust rule: this populates a nullable FK that was introduced
+      // specifically to enable this link — restoration of intent, not
+      // silent mutation of user-visible totals or units.
+      await customStatement('''
             UPDATE exercise_sets
                SET exercise_id = (SELECT id FROM exercises WHERE canonical_name = exercise_sets.exercise_name)
              WHERE exercise_id IS NULL
           ''');
-        },
-      );
+    },
+  );
 
   /// Seeds `exercises` with the distinct `exercise_name` values already
   /// present in `exercise_sets`. Idempotent: the `canonicalName UNIQUE`
@@ -160,10 +218,7 @@ class AppDatabase extends _$AppDatabase {
     for (final row in rows) {
       final name = row.read<String>('exercise_name');
       await into(exercises).insert(
-        ExercisesCompanion.insert(
-          canonicalName: name,
-          createdAt: now,
-        ),
+        ExercisesCompanion.insert(canonicalName: name, createdAt: now),
         mode: InsertMode.insertOrIgnore,
       );
     }

--- a/lib/data/database.g.dart
+++ b/lib/data/database.g.dart
@@ -2201,6 +2201,902 @@ class BodyWeightLogsCompanion extends UpdateCompanion<BodyWeightLog> {
   }
 }
 
+class $RoutinesTable extends Routines with TableInfo<$RoutinesTable, Routine> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $RoutinesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _notesMeta = const VerificationMeta('notes');
+  @override
+  late final GeneratedColumn<String> notes = GeneratedColumn<String>(
+    'notes',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<Source, String> source =
+      GeneratedColumn<String>(
+        'source',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        defaultValue: const Constant('userEntered'),
+      ).withConverter<Source>($RoutinesTable.$convertersource);
+  @override
+  List<GeneratedColumn> get $columns => [id, name, notes, createdAt, source];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'routines';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<Routine> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('notes')) {
+      context.handle(
+        _notesMeta,
+        notes.isAcceptableOrUnknown(data['notes']!, _notesMeta),
+      );
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  Routine map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Routine(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      )!,
+      notes: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}notes'],
+      ),
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      source: $RoutinesTable.$convertersource.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}source'],
+        )!,
+      ),
+    );
+  }
+
+  @override
+  $RoutinesTable createAlias(String alias) {
+    return $RoutinesTable(attachedDatabase, alias);
+  }
+
+  static JsonTypeConverter2<Source, String, String> $convertersource =
+      const EnumNameConverter<Source>(Source.values);
+}
+
+class Routine extends DataClass implements Insertable<Routine> {
+  final int id;
+  final String name;
+  final String? notes;
+  final DateTime createdAt;
+  final Source source;
+  const Routine({
+    required this.id,
+    required this.name,
+    this.notes,
+    required this.createdAt,
+    required this.source,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['name'] = Variable<String>(name);
+    if (!nullToAbsent || notes != null) {
+      map['notes'] = Variable<String>(notes);
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    {
+      map['source'] = Variable<String>(
+        $RoutinesTable.$convertersource.toSql(source),
+      );
+    }
+    return map;
+  }
+
+  RoutinesCompanion toCompanion(bool nullToAbsent) {
+    return RoutinesCompanion(
+      id: Value(id),
+      name: Value(name),
+      notes: notes == null && nullToAbsent
+          ? const Value.absent()
+          : Value(notes),
+      createdAt: Value(createdAt),
+      source: Value(source),
+    );
+  }
+
+  factory Routine.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return Routine(
+      id: serializer.fromJson<int>(json['id']),
+      name: serializer.fromJson<String>(json['name']),
+      notes: serializer.fromJson<String?>(json['notes']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      source: $RoutinesTable.$convertersource.fromJson(
+        serializer.fromJson<String>(json['source']),
+      ),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'name': serializer.toJson<String>(name),
+      'notes': serializer.toJson<String?>(notes),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'source': serializer.toJson<String>(
+        $RoutinesTable.$convertersource.toJson(source),
+      ),
+    };
+  }
+
+  Routine copyWith({
+    int? id,
+    String? name,
+    Value<String?> notes = const Value.absent(),
+    DateTime? createdAt,
+    Source? source,
+  }) => Routine(
+    id: id ?? this.id,
+    name: name ?? this.name,
+    notes: notes.present ? notes.value : this.notes,
+    createdAt: createdAt ?? this.createdAt,
+    source: source ?? this.source,
+  );
+  Routine copyWithCompanion(RoutinesCompanion data) {
+    return Routine(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      notes: data.notes.present ? data.notes.value : this.notes,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      source: data.source.present ? data.source.value : this.source,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('Routine(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('notes: $notes, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('source: $source')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, name, notes, createdAt, source);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Routine &&
+          other.id == this.id &&
+          other.name == this.name &&
+          other.notes == this.notes &&
+          other.createdAt == this.createdAt &&
+          other.source == this.source);
+}
+
+class RoutinesCompanion extends UpdateCompanion<Routine> {
+  final Value<int> id;
+  final Value<String> name;
+  final Value<String?> notes;
+  final Value<DateTime> createdAt;
+  final Value<Source> source;
+  const RoutinesCompanion({
+    this.id = const Value.absent(),
+    this.name = const Value.absent(),
+    this.notes = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.source = const Value.absent(),
+  });
+  RoutinesCompanion.insert({
+    this.id = const Value.absent(),
+    required String name,
+    this.notes = const Value.absent(),
+    required DateTime createdAt,
+    this.source = const Value.absent(),
+  }) : name = Value(name),
+       createdAt = Value(createdAt);
+  static Insertable<Routine> custom({
+    Expression<int>? id,
+    Expression<String>? name,
+    Expression<String>? notes,
+    Expression<DateTime>? createdAt,
+    Expression<String>? source,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (name != null) 'name': name,
+      if (notes != null) 'notes': notes,
+      if (createdAt != null) 'created_at': createdAt,
+      if (source != null) 'source': source,
+    });
+  }
+
+  RoutinesCompanion copyWith({
+    Value<int>? id,
+    Value<String>? name,
+    Value<String?>? notes,
+    Value<DateTime>? createdAt,
+    Value<Source>? source,
+  }) {
+    return RoutinesCompanion(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      notes: notes ?? this.notes,
+      createdAt: createdAt ?? this.createdAt,
+      source: source ?? this.source,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (notes.present) {
+      map['notes'] = Variable<String>(notes.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (source.present) {
+      map['source'] = Variable<String>(
+        $RoutinesTable.$convertersource.toSql(source.value),
+      );
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RoutinesCompanion(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('notes: $notes, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('source: $source')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $RoutineExercisesTable extends RoutineExercises
+    with TableInfo<$RoutineExercisesTable, RoutineExercise> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $RoutineExercisesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _routineIdMeta = const VerificationMeta(
+    'routineId',
+  );
+  @override
+  late final GeneratedColumn<int> routineId = GeneratedColumn<int>(
+    'routine_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES routines (id) ON DELETE CASCADE',
+    ),
+  );
+  static const VerificationMeta _exerciseIdMeta = const VerificationMeta(
+    'exerciseId',
+  );
+  @override
+  late final GeneratedColumn<int> exerciseId = GeneratedColumn<int>(
+    'exercise_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES exercises (id)',
+    ),
+  );
+  static const VerificationMeta _orderIndexMeta = const VerificationMeta(
+    'orderIndex',
+  );
+  @override
+  late final GeneratedColumn<int> orderIndex = GeneratedColumn<int>(
+    'order_index',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _targetSetsMeta = const VerificationMeta(
+    'targetSets',
+  );
+  @override
+  late final GeneratedColumn<int> targetSets = GeneratedColumn<int>(
+    'target_sets',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _targetRepsMeta = const VerificationMeta(
+    'targetReps',
+  );
+  @override
+  late final GeneratedColumn<int> targetReps = GeneratedColumn<int>(
+    'target_reps',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _targetWeightMeta = const VerificationMeta(
+    'targetWeight',
+  );
+  @override
+  late final GeneratedColumn<double> targetWeight = GeneratedColumn<double>(
+    'target_weight',
+    aliasedName,
+    true,
+    type: DriftSqlType.double,
+    requiredDuringInsert: false,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<WeightUnit?, String>
+  targetWeightUnit =
+      GeneratedColumn<String>(
+        'target_weight_unit',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      ).withConverter<WeightUnit?>(
+        $RoutineExercisesTable.$convertertargetWeightUnitn,
+      );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    routineId,
+    exerciseId,
+    orderIndex,
+    targetSets,
+    targetReps,
+    targetWeight,
+    targetWeightUnit,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'routine_exercises';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<RoutineExercise> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('routine_id')) {
+      context.handle(
+        _routineIdMeta,
+        routineId.isAcceptableOrUnknown(data['routine_id']!, _routineIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_routineIdMeta);
+    }
+    if (data.containsKey('exercise_id')) {
+      context.handle(
+        _exerciseIdMeta,
+        exerciseId.isAcceptableOrUnknown(data['exercise_id']!, _exerciseIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_exerciseIdMeta);
+    }
+    if (data.containsKey('order_index')) {
+      context.handle(
+        _orderIndexMeta,
+        orderIndex.isAcceptableOrUnknown(data['order_index']!, _orderIndexMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_orderIndexMeta);
+    }
+    if (data.containsKey('target_sets')) {
+      context.handle(
+        _targetSetsMeta,
+        targetSets.isAcceptableOrUnknown(data['target_sets']!, _targetSetsMeta),
+      );
+    }
+    if (data.containsKey('target_reps')) {
+      context.handle(
+        _targetRepsMeta,
+        targetReps.isAcceptableOrUnknown(data['target_reps']!, _targetRepsMeta),
+      );
+    }
+    if (data.containsKey('target_weight')) {
+      context.handle(
+        _targetWeightMeta,
+        targetWeight.isAcceptableOrUnknown(
+          data['target_weight']!,
+          _targetWeightMeta,
+        ),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  RoutineExercise map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return RoutineExercise(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      routineId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}routine_id'],
+      )!,
+      exerciseId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}exercise_id'],
+      )!,
+      orderIndex: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}order_index'],
+      )!,
+      targetSets: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}target_sets'],
+      ),
+      targetReps: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}target_reps'],
+      ),
+      targetWeight: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}target_weight'],
+      ),
+      targetWeightUnit: $RoutineExercisesTable.$convertertargetWeightUnitn
+          .fromSql(
+            attachedDatabase.typeMapping.read(
+              DriftSqlType.string,
+              data['${effectivePrefix}target_weight_unit'],
+            ),
+          ),
+    );
+  }
+
+  @override
+  $RoutineExercisesTable createAlias(String alias) {
+    return $RoutineExercisesTable(attachedDatabase, alias);
+  }
+
+  static JsonTypeConverter2<WeightUnit, String, String>
+  $convertertargetWeightUnit = const EnumNameConverter<WeightUnit>(
+    WeightUnit.values,
+  );
+  static JsonTypeConverter2<WeightUnit?, String?, String?>
+  $convertertargetWeightUnitn = JsonTypeConverter2.asNullable(
+    $convertertargetWeightUnit,
+  );
+}
+
+class RoutineExercise extends DataClass implements Insertable<RoutineExercise> {
+  final int id;
+  final int routineId;
+  final int exerciseId;
+  final int orderIndex;
+  final int? targetSets;
+  final int? targetReps;
+  final double? targetWeight;
+  final WeightUnit? targetWeightUnit;
+  const RoutineExercise({
+    required this.id,
+    required this.routineId,
+    required this.exerciseId,
+    required this.orderIndex,
+    this.targetSets,
+    this.targetReps,
+    this.targetWeight,
+    this.targetWeightUnit,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['routine_id'] = Variable<int>(routineId);
+    map['exercise_id'] = Variable<int>(exerciseId);
+    map['order_index'] = Variable<int>(orderIndex);
+    if (!nullToAbsent || targetSets != null) {
+      map['target_sets'] = Variable<int>(targetSets);
+    }
+    if (!nullToAbsent || targetReps != null) {
+      map['target_reps'] = Variable<int>(targetReps);
+    }
+    if (!nullToAbsent || targetWeight != null) {
+      map['target_weight'] = Variable<double>(targetWeight);
+    }
+    if (!nullToAbsent || targetWeightUnit != null) {
+      map['target_weight_unit'] = Variable<String>(
+        $RoutineExercisesTable.$convertertargetWeightUnitn.toSql(
+          targetWeightUnit,
+        ),
+      );
+    }
+    return map;
+  }
+
+  RoutineExercisesCompanion toCompanion(bool nullToAbsent) {
+    return RoutineExercisesCompanion(
+      id: Value(id),
+      routineId: Value(routineId),
+      exerciseId: Value(exerciseId),
+      orderIndex: Value(orderIndex),
+      targetSets: targetSets == null && nullToAbsent
+          ? const Value.absent()
+          : Value(targetSets),
+      targetReps: targetReps == null && nullToAbsent
+          ? const Value.absent()
+          : Value(targetReps),
+      targetWeight: targetWeight == null && nullToAbsent
+          ? const Value.absent()
+          : Value(targetWeight),
+      targetWeightUnit: targetWeightUnit == null && nullToAbsent
+          ? const Value.absent()
+          : Value(targetWeightUnit),
+    );
+  }
+
+  factory RoutineExercise.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return RoutineExercise(
+      id: serializer.fromJson<int>(json['id']),
+      routineId: serializer.fromJson<int>(json['routineId']),
+      exerciseId: serializer.fromJson<int>(json['exerciseId']),
+      orderIndex: serializer.fromJson<int>(json['orderIndex']),
+      targetSets: serializer.fromJson<int?>(json['targetSets']),
+      targetReps: serializer.fromJson<int?>(json['targetReps']),
+      targetWeight: serializer.fromJson<double?>(json['targetWeight']),
+      targetWeightUnit: $RoutineExercisesTable.$convertertargetWeightUnitn
+          .fromJson(serializer.fromJson<String?>(json['targetWeightUnit'])),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'routineId': serializer.toJson<int>(routineId),
+      'exerciseId': serializer.toJson<int>(exerciseId),
+      'orderIndex': serializer.toJson<int>(orderIndex),
+      'targetSets': serializer.toJson<int?>(targetSets),
+      'targetReps': serializer.toJson<int?>(targetReps),
+      'targetWeight': serializer.toJson<double?>(targetWeight),
+      'targetWeightUnit': serializer.toJson<String?>(
+        $RoutineExercisesTable.$convertertargetWeightUnitn.toJson(
+          targetWeightUnit,
+        ),
+      ),
+    };
+  }
+
+  RoutineExercise copyWith({
+    int? id,
+    int? routineId,
+    int? exerciseId,
+    int? orderIndex,
+    Value<int?> targetSets = const Value.absent(),
+    Value<int?> targetReps = const Value.absent(),
+    Value<double?> targetWeight = const Value.absent(),
+    Value<WeightUnit?> targetWeightUnit = const Value.absent(),
+  }) => RoutineExercise(
+    id: id ?? this.id,
+    routineId: routineId ?? this.routineId,
+    exerciseId: exerciseId ?? this.exerciseId,
+    orderIndex: orderIndex ?? this.orderIndex,
+    targetSets: targetSets.present ? targetSets.value : this.targetSets,
+    targetReps: targetReps.present ? targetReps.value : this.targetReps,
+    targetWeight: targetWeight.present ? targetWeight.value : this.targetWeight,
+    targetWeightUnit: targetWeightUnit.present
+        ? targetWeightUnit.value
+        : this.targetWeightUnit,
+  );
+  RoutineExercise copyWithCompanion(RoutineExercisesCompanion data) {
+    return RoutineExercise(
+      id: data.id.present ? data.id.value : this.id,
+      routineId: data.routineId.present ? data.routineId.value : this.routineId,
+      exerciseId: data.exerciseId.present
+          ? data.exerciseId.value
+          : this.exerciseId,
+      orderIndex: data.orderIndex.present
+          ? data.orderIndex.value
+          : this.orderIndex,
+      targetSets: data.targetSets.present
+          ? data.targetSets.value
+          : this.targetSets,
+      targetReps: data.targetReps.present
+          ? data.targetReps.value
+          : this.targetReps,
+      targetWeight: data.targetWeight.present
+          ? data.targetWeight.value
+          : this.targetWeight,
+      targetWeightUnit: data.targetWeightUnit.present
+          ? data.targetWeightUnit.value
+          : this.targetWeightUnit,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RoutineExercise(')
+          ..write('id: $id, ')
+          ..write('routineId: $routineId, ')
+          ..write('exerciseId: $exerciseId, ')
+          ..write('orderIndex: $orderIndex, ')
+          ..write('targetSets: $targetSets, ')
+          ..write('targetReps: $targetReps, ')
+          ..write('targetWeight: $targetWeight, ')
+          ..write('targetWeightUnit: $targetWeightUnit')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    routineId,
+    exerciseId,
+    orderIndex,
+    targetSets,
+    targetReps,
+    targetWeight,
+    targetWeightUnit,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is RoutineExercise &&
+          other.id == this.id &&
+          other.routineId == this.routineId &&
+          other.exerciseId == this.exerciseId &&
+          other.orderIndex == this.orderIndex &&
+          other.targetSets == this.targetSets &&
+          other.targetReps == this.targetReps &&
+          other.targetWeight == this.targetWeight &&
+          other.targetWeightUnit == this.targetWeightUnit);
+}
+
+class RoutineExercisesCompanion extends UpdateCompanion<RoutineExercise> {
+  final Value<int> id;
+  final Value<int> routineId;
+  final Value<int> exerciseId;
+  final Value<int> orderIndex;
+  final Value<int?> targetSets;
+  final Value<int?> targetReps;
+  final Value<double?> targetWeight;
+  final Value<WeightUnit?> targetWeightUnit;
+  const RoutineExercisesCompanion({
+    this.id = const Value.absent(),
+    this.routineId = const Value.absent(),
+    this.exerciseId = const Value.absent(),
+    this.orderIndex = const Value.absent(),
+    this.targetSets = const Value.absent(),
+    this.targetReps = const Value.absent(),
+    this.targetWeight = const Value.absent(),
+    this.targetWeightUnit = const Value.absent(),
+  });
+  RoutineExercisesCompanion.insert({
+    this.id = const Value.absent(),
+    required int routineId,
+    required int exerciseId,
+    required int orderIndex,
+    this.targetSets = const Value.absent(),
+    this.targetReps = const Value.absent(),
+    this.targetWeight = const Value.absent(),
+    this.targetWeightUnit = const Value.absent(),
+  }) : routineId = Value(routineId),
+       exerciseId = Value(exerciseId),
+       orderIndex = Value(orderIndex);
+  static Insertable<RoutineExercise> custom({
+    Expression<int>? id,
+    Expression<int>? routineId,
+    Expression<int>? exerciseId,
+    Expression<int>? orderIndex,
+    Expression<int>? targetSets,
+    Expression<int>? targetReps,
+    Expression<double>? targetWeight,
+    Expression<String>? targetWeightUnit,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (routineId != null) 'routine_id': routineId,
+      if (exerciseId != null) 'exercise_id': exerciseId,
+      if (orderIndex != null) 'order_index': orderIndex,
+      if (targetSets != null) 'target_sets': targetSets,
+      if (targetReps != null) 'target_reps': targetReps,
+      if (targetWeight != null) 'target_weight': targetWeight,
+      if (targetWeightUnit != null) 'target_weight_unit': targetWeightUnit,
+    });
+  }
+
+  RoutineExercisesCompanion copyWith({
+    Value<int>? id,
+    Value<int>? routineId,
+    Value<int>? exerciseId,
+    Value<int>? orderIndex,
+    Value<int?>? targetSets,
+    Value<int?>? targetReps,
+    Value<double?>? targetWeight,
+    Value<WeightUnit?>? targetWeightUnit,
+  }) {
+    return RoutineExercisesCompanion(
+      id: id ?? this.id,
+      routineId: routineId ?? this.routineId,
+      exerciseId: exerciseId ?? this.exerciseId,
+      orderIndex: orderIndex ?? this.orderIndex,
+      targetSets: targetSets ?? this.targetSets,
+      targetReps: targetReps ?? this.targetReps,
+      targetWeight: targetWeight ?? this.targetWeight,
+      targetWeightUnit: targetWeightUnit ?? this.targetWeightUnit,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (routineId.present) {
+      map['routine_id'] = Variable<int>(routineId.value);
+    }
+    if (exerciseId.present) {
+      map['exercise_id'] = Variable<int>(exerciseId.value);
+    }
+    if (orderIndex.present) {
+      map['order_index'] = Variable<int>(orderIndex.value);
+    }
+    if (targetSets.present) {
+      map['target_sets'] = Variable<int>(targetSets.value);
+    }
+    if (targetReps.present) {
+      map['target_reps'] = Variable<int>(targetReps.value);
+    }
+    if (targetWeight.present) {
+      map['target_weight'] = Variable<double>(targetWeight.value);
+    }
+    if (targetWeightUnit.present) {
+      map['target_weight_unit'] = Variable<String>(
+        $RoutineExercisesTable.$convertertargetWeightUnitn.toSql(
+          targetWeightUnit.value,
+        ),
+      );
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('RoutineExercisesCompanion(')
+          ..write('id: $id, ')
+          ..write('routineId: $routineId, ')
+          ..write('exerciseId: $exerciseId, ')
+          ..write('orderIndex: $orderIndex, ')
+          ..write('targetSets: $targetSets, ')
+          ..write('targetReps: $targetReps, ')
+          ..write('targetWeight: $targetWeight, ')
+          ..write('targetWeightUnit: $targetWeightUnit')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -2211,6 +3107,10 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $ExercisesTable exercises = $ExercisesTable(this);
   late final $ExerciseSetsTable exerciseSets = $ExerciseSetsTable(this);
   late final $BodyWeightLogsTable bodyWeightLogs = $BodyWeightLogsTable(this);
+  late final $RoutinesTable routines = $RoutinesTable(this);
+  late final $RoutineExercisesTable routineExercises = $RoutineExercisesTable(
+    this,
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -2221,6 +3121,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     exercises,
     exerciseSets,
     bodyWeightLogs,
+    routines,
+    routineExercises,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
@@ -2230,6 +3132,13 @@ abstract class _$AppDatabase extends GeneratedDatabase {
         limitUpdateKind: UpdateKind.delete,
       ),
       result: [TableUpdate('exercise_sets', kind: UpdateKind.delete)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'routines',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('routine_exercises', kind: UpdateKind.delete)],
     ),
   ]);
 }
@@ -2849,6 +3758,29 @@ final class $$ExercisesTableReferences
       manager.$state.copyWith(prefetchedData: cache),
     );
   }
+
+  static MultiTypedResultKey<$RoutineExercisesTable, List<RoutineExercise>>
+  _routineExercisesRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+    db.routineExercises,
+    aliasName: $_aliasNameGenerator(
+      db.exercises.id,
+      db.routineExercises.exerciseId,
+    ),
+  );
+
+  $$RoutineExercisesTableProcessedTableManager get routineExercisesRefs {
+    final manager = $$RoutineExercisesTableTableManager(
+      $_db,
+      $_db.routineExercises,
+    ).filter((f) => f.exerciseId.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(
+      _routineExercisesRefsTable($_db),
+    );
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
 }
 
 class $$ExercisesTableFilterComposer
@@ -2896,6 +3828,31 @@ class $$ExercisesTableFilterComposer
           }) => $$ExerciseSetsTableFilterComposer(
             $db: $db,
             $table: $db.exerciseSets,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+
+  Expression<bool> routineExercisesRefs(
+    Expression<bool> Function($$RoutineExercisesTableFilterComposer f) f,
+  ) {
+    final $$RoutineExercisesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.routineExercises,
+      getReferencedColumn: (t) => t.exerciseId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$RoutineExercisesTableFilterComposer(
+            $db: $db,
+            $table: $db.routineExercises,
             $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
             joinBuilder: joinBuilder,
             $removeJoinBuilderFromRootComposer:
@@ -2985,6 +3942,31 @@ class $$ExercisesTableAnnotationComposer
     );
     return f(composer);
   }
+
+  Expression<T> routineExercisesRefs<T extends Object>(
+    Expression<T> Function($$RoutineExercisesTableAnnotationComposer a) f,
+  ) {
+    final $$RoutineExercisesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.routineExercises,
+      getReferencedColumn: (t) => t.exerciseId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$RoutineExercisesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.routineExercises,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
 }
 
 class $$ExercisesTableTableManager
@@ -3000,7 +3982,10 @@ class $$ExercisesTableTableManager
           $$ExercisesTableUpdateCompanionBuilder,
           (Exercise, $$ExercisesTableReferences),
           Exercise,
-          PrefetchHooks Function({bool exerciseSetsRefs})
+          PrefetchHooks Function({
+            bool exerciseSetsRefs,
+            bool routineExercisesRefs,
+          })
         > {
   $$ExercisesTableTableManager(_$AppDatabase db, $ExercisesTable table)
     : super(
@@ -3045,36 +4030,63 @@ class $$ExercisesTableTableManager
                 ),
               )
               .toList(),
-          prefetchHooksCallback: ({exerciseSetsRefs = false}) {
-            return PrefetchHooks(
-              db: db,
-              explicitlyWatchedTables: [if (exerciseSetsRefs) db.exerciseSets],
-              addJoins: null,
-              getPrefetchedDataCallback: (items) async {
-                return [
-                  if (exerciseSetsRefs)
-                    await $_getPrefetchedData<
-                      Exercise,
-                      $ExercisesTable,
-                      ExerciseSet
-                    >(
-                      currentTable: table,
-                      referencedTable: $$ExercisesTableReferences
-                          ._exerciseSetsRefsTable(db),
-                      managerFromTypedResult: (p0) =>
-                          $$ExercisesTableReferences(
-                            db,
-                            table,
-                            p0,
-                          ).exerciseSetsRefs,
-                      referencedItemsForCurrentItem: (item, referencedItems) =>
-                          referencedItems.where((e) => e.exerciseId == item.id),
-                      typedResults: items,
-                    ),
-                ];
+          prefetchHooksCallback:
+              ({exerciseSetsRefs = false, routineExercisesRefs = false}) {
+                return PrefetchHooks(
+                  db: db,
+                  explicitlyWatchedTables: [
+                    if (exerciseSetsRefs) db.exerciseSets,
+                    if (routineExercisesRefs) db.routineExercises,
+                  ],
+                  addJoins: null,
+                  getPrefetchedDataCallback: (items) async {
+                    return [
+                      if (exerciseSetsRefs)
+                        await $_getPrefetchedData<
+                          Exercise,
+                          $ExercisesTable,
+                          ExerciseSet
+                        >(
+                          currentTable: table,
+                          referencedTable: $$ExercisesTableReferences
+                              ._exerciseSetsRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$ExercisesTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).exerciseSetsRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.exerciseId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
+                      if (routineExercisesRefs)
+                        await $_getPrefetchedData<
+                          Exercise,
+                          $ExercisesTable,
+                          RoutineExercise
+                        >(
+                          currentTable: table,
+                          referencedTable: $$ExercisesTableReferences
+                              ._routineExercisesRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$ExercisesTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).routineExercisesRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.exerciseId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
+                    ];
+                  },
+                );
               },
-            );
-          },
         ),
       );
 }
@@ -3091,7 +4103,7 @@ typedef $$ExercisesTableProcessedTableManager =
       $$ExercisesTableUpdateCompanionBuilder,
       (Exercise, $$ExercisesTableReferences),
       Exercise,
-      PrefetchHooks Function({bool exerciseSetsRefs})
+      PrefetchHooks Function({bool exerciseSetsRefs, bool routineExercisesRefs})
     >;
 typedef $$ExerciseSetsTableCreateCompanionBuilder =
     ExerciseSetsCompanion Function({
@@ -3797,6 +4809,789 @@ typedef $$BodyWeightLogsTableProcessedTableManager =
       BodyWeightLog,
       PrefetchHooks Function()
     >;
+typedef $$RoutinesTableCreateCompanionBuilder =
+    RoutinesCompanion Function({
+      Value<int> id,
+      required String name,
+      Value<String?> notes,
+      required DateTime createdAt,
+      Value<Source> source,
+    });
+typedef $$RoutinesTableUpdateCompanionBuilder =
+    RoutinesCompanion Function({
+      Value<int> id,
+      Value<String> name,
+      Value<String?> notes,
+      Value<DateTime> createdAt,
+      Value<Source> source,
+    });
+
+final class $$RoutinesTableReferences
+    extends BaseReferences<_$AppDatabase, $RoutinesTable, Routine> {
+  $$RoutinesTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<$RoutineExercisesTable, List<RoutineExercise>>
+  _routineExercisesRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+    db.routineExercises,
+    aliasName: $_aliasNameGenerator(
+      db.routines.id,
+      db.routineExercises.routineId,
+    ),
+  );
+
+  $$RoutineExercisesTableProcessedTableManager get routineExercisesRefs {
+    final manager = $$RoutineExercisesTableTableManager(
+      $_db,
+      $_db.routineExercises,
+    ).filter((f) => f.routineId.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(
+      _routineExercisesRefsTable($_db),
+    );
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
+
+class $$RoutinesTableFilterComposer
+    extends Composer<_$AppDatabase, $RoutinesTable> {
+  $$RoutinesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get notes => $composableBuilder(
+    column: $table.notes,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<Source, Source, String> get source =>
+      $composableBuilder(
+        column: $table.source,
+        builder: (column) => ColumnWithTypeConverterFilters(column),
+      );
+
+  Expression<bool> routineExercisesRefs(
+    Expression<bool> Function($$RoutineExercisesTableFilterComposer f) f,
+  ) {
+    final $$RoutineExercisesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.routineExercises,
+      getReferencedColumn: (t) => t.routineId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$RoutineExercisesTableFilterComposer(
+            $db: $db,
+            $table: $db.routineExercises,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$RoutinesTableOrderingComposer
+    extends Composer<_$AppDatabase, $RoutinesTable> {
+  $$RoutinesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get notes => $composableBuilder(
+    column: $table.notes,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get source => $composableBuilder(
+    column: $table.source,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$RoutinesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $RoutinesTable> {
+  $$RoutinesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get name =>
+      $composableBuilder(column: $table.name, builder: (column) => column);
+
+  GeneratedColumn<String> get notes =>
+      $composableBuilder(column: $table.notes, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<Source, String> get source =>
+      $composableBuilder(column: $table.source, builder: (column) => column);
+
+  Expression<T> routineExercisesRefs<T extends Object>(
+    Expression<T> Function($$RoutineExercisesTableAnnotationComposer a) f,
+  ) {
+    final $$RoutineExercisesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.routineExercises,
+      getReferencedColumn: (t) => t.routineId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$RoutineExercisesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.routineExercises,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$RoutinesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $RoutinesTable,
+          Routine,
+          $$RoutinesTableFilterComposer,
+          $$RoutinesTableOrderingComposer,
+          $$RoutinesTableAnnotationComposer,
+          $$RoutinesTableCreateCompanionBuilder,
+          $$RoutinesTableUpdateCompanionBuilder,
+          (Routine, $$RoutinesTableReferences),
+          Routine,
+          PrefetchHooks Function({bool routineExercisesRefs})
+        > {
+  $$RoutinesTableTableManager(_$AppDatabase db, $RoutinesTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$RoutinesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$RoutinesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$RoutinesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> name = const Value.absent(),
+                Value<String?> notes = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<Source> source = const Value.absent(),
+              }) => RoutinesCompanion(
+                id: id,
+                name: name,
+                notes: notes,
+                createdAt: createdAt,
+                source: source,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String name,
+                Value<String?> notes = const Value.absent(),
+                required DateTime createdAt,
+                Value<Source> source = const Value.absent(),
+              }) => RoutinesCompanion.insert(
+                id: id,
+                name: name,
+                notes: notes,
+                createdAt: createdAt,
+                source: source,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$RoutinesTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({routineExercisesRefs = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [
+                if (routineExercisesRefs) db.routineExercises,
+              ],
+              addJoins: null,
+              getPrefetchedDataCallback: (items) async {
+                return [
+                  if (routineExercisesRefs)
+                    await $_getPrefetchedData<
+                      Routine,
+                      $RoutinesTable,
+                      RoutineExercise
+                    >(
+                      currentTable: table,
+                      referencedTable: $$RoutinesTableReferences
+                          ._routineExercisesRefsTable(db),
+                      managerFromTypedResult: (p0) => $$RoutinesTableReferences(
+                        db,
+                        table,
+                        p0,
+                      ).routineExercisesRefs,
+                      referencedItemsForCurrentItem: (item, referencedItems) =>
+                          referencedItems.where((e) => e.routineId == item.id),
+                      typedResults: items,
+                    ),
+                ];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$RoutinesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $RoutinesTable,
+      Routine,
+      $$RoutinesTableFilterComposer,
+      $$RoutinesTableOrderingComposer,
+      $$RoutinesTableAnnotationComposer,
+      $$RoutinesTableCreateCompanionBuilder,
+      $$RoutinesTableUpdateCompanionBuilder,
+      (Routine, $$RoutinesTableReferences),
+      Routine,
+      PrefetchHooks Function({bool routineExercisesRefs})
+    >;
+typedef $$RoutineExercisesTableCreateCompanionBuilder =
+    RoutineExercisesCompanion Function({
+      Value<int> id,
+      required int routineId,
+      required int exerciseId,
+      required int orderIndex,
+      Value<int?> targetSets,
+      Value<int?> targetReps,
+      Value<double?> targetWeight,
+      Value<WeightUnit?> targetWeightUnit,
+    });
+typedef $$RoutineExercisesTableUpdateCompanionBuilder =
+    RoutineExercisesCompanion Function({
+      Value<int> id,
+      Value<int> routineId,
+      Value<int> exerciseId,
+      Value<int> orderIndex,
+      Value<int?> targetSets,
+      Value<int?> targetReps,
+      Value<double?> targetWeight,
+      Value<WeightUnit?> targetWeightUnit,
+    });
+
+final class $$RoutineExercisesTableReferences
+    extends
+        BaseReferences<_$AppDatabase, $RoutineExercisesTable, RoutineExercise> {
+  $$RoutineExercisesTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static $RoutinesTable _routineIdTable(_$AppDatabase db) =>
+      db.routines.createAlias(
+        $_aliasNameGenerator(db.routineExercises.routineId, db.routines.id),
+      );
+
+  $$RoutinesTableProcessedTableManager get routineId {
+    final $_column = $_itemColumn<int>('routine_id')!;
+
+    final manager = $$RoutinesTableTableManager(
+      $_db,
+      $_db.routines,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_routineIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static $ExercisesTable _exerciseIdTable(_$AppDatabase db) =>
+      db.exercises.createAlias(
+        $_aliasNameGenerator(db.routineExercises.exerciseId, db.exercises.id),
+      );
+
+  $$ExercisesTableProcessedTableManager get exerciseId {
+    final $_column = $_itemColumn<int>('exercise_id')!;
+
+    final manager = $$ExercisesTableTableManager(
+      $_db,
+      $_db.exercises,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_exerciseIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$RoutineExercisesTableFilterComposer
+    extends Composer<_$AppDatabase, $RoutineExercisesTable> {
+  $$RoutineExercisesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get orderIndex => $composableBuilder(
+    column: $table.orderIndex,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get targetSets => $composableBuilder(
+    column: $table.targetSets,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get targetReps => $composableBuilder(
+    column: $table.targetReps,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get targetWeight => $composableBuilder(
+    column: $table.targetWeight,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<WeightUnit?, WeightUnit, String>
+  get targetWeightUnit => $composableBuilder(
+    column: $table.targetWeightUnit,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  $$RoutinesTableFilterComposer get routineId {
+    final $$RoutinesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.routineId,
+      referencedTable: $db.routines,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$RoutinesTableFilterComposer(
+            $db: $db,
+            $table: $db.routines,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$ExercisesTableFilterComposer get exerciseId {
+    final $$ExercisesTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.exerciseId,
+      referencedTable: $db.exercises,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ExercisesTableFilterComposer(
+            $db: $db,
+            $table: $db.exercises,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$RoutineExercisesTableOrderingComposer
+    extends Composer<_$AppDatabase, $RoutineExercisesTable> {
+  $$RoutineExercisesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get orderIndex => $composableBuilder(
+    column: $table.orderIndex,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get targetSets => $composableBuilder(
+    column: $table.targetSets,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get targetReps => $composableBuilder(
+    column: $table.targetReps,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get targetWeight => $composableBuilder(
+    column: $table.targetWeight,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get targetWeightUnit => $composableBuilder(
+    column: $table.targetWeightUnit,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$RoutinesTableOrderingComposer get routineId {
+    final $$RoutinesTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.routineId,
+      referencedTable: $db.routines,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$RoutinesTableOrderingComposer(
+            $db: $db,
+            $table: $db.routines,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$ExercisesTableOrderingComposer get exerciseId {
+    final $$ExercisesTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.exerciseId,
+      referencedTable: $db.exercises,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ExercisesTableOrderingComposer(
+            $db: $db,
+            $table: $db.exercises,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$RoutineExercisesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $RoutineExercisesTable> {
+  $$RoutineExercisesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<int> get orderIndex => $composableBuilder(
+    column: $table.orderIndex,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get targetSets => $composableBuilder(
+    column: $table.targetSets,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get targetReps => $composableBuilder(
+    column: $table.targetReps,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<double> get targetWeight => $composableBuilder(
+    column: $table.targetWeight,
+    builder: (column) => column,
+  );
+
+  GeneratedColumnWithTypeConverter<WeightUnit?, String> get targetWeightUnit =>
+      $composableBuilder(
+        column: $table.targetWeightUnit,
+        builder: (column) => column,
+      );
+
+  $$RoutinesTableAnnotationComposer get routineId {
+    final $$RoutinesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.routineId,
+      referencedTable: $db.routines,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$RoutinesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.routines,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$ExercisesTableAnnotationComposer get exerciseId {
+    final $$ExercisesTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.exerciseId,
+      referencedTable: $db.exercises,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$ExercisesTableAnnotationComposer(
+            $db: $db,
+            $table: $db.exercises,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$RoutineExercisesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $RoutineExercisesTable,
+          RoutineExercise,
+          $$RoutineExercisesTableFilterComposer,
+          $$RoutineExercisesTableOrderingComposer,
+          $$RoutineExercisesTableAnnotationComposer,
+          $$RoutineExercisesTableCreateCompanionBuilder,
+          $$RoutineExercisesTableUpdateCompanionBuilder,
+          (RoutineExercise, $$RoutineExercisesTableReferences),
+          RoutineExercise,
+          PrefetchHooks Function({bool routineId, bool exerciseId})
+        > {
+  $$RoutineExercisesTableTableManager(
+    _$AppDatabase db,
+    $RoutineExercisesTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$RoutineExercisesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$RoutineExercisesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$RoutineExercisesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<int> routineId = const Value.absent(),
+                Value<int> exerciseId = const Value.absent(),
+                Value<int> orderIndex = const Value.absent(),
+                Value<int?> targetSets = const Value.absent(),
+                Value<int?> targetReps = const Value.absent(),
+                Value<double?> targetWeight = const Value.absent(),
+                Value<WeightUnit?> targetWeightUnit = const Value.absent(),
+              }) => RoutineExercisesCompanion(
+                id: id,
+                routineId: routineId,
+                exerciseId: exerciseId,
+                orderIndex: orderIndex,
+                targetSets: targetSets,
+                targetReps: targetReps,
+                targetWeight: targetWeight,
+                targetWeightUnit: targetWeightUnit,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required int routineId,
+                required int exerciseId,
+                required int orderIndex,
+                Value<int?> targetSets = const Value.absent(),
+                Value<int?> targetReps = const Value.absent(),
+                Value<double?> targetWeight = const Value.absent(),
+                Value<WeightUnit?> targetWeightUnit = const Value.absent(),
+              }) => RoutineExercisesCompanion.insert(
+                id: id,
+                routineId: routineId,
+                exerciseId: exerciseId,
+                orderIndex: orderIndex,
+                targetSets: targetSets,
+                targetReps: targetReps,
+                targetWeight: targetWeight,
+                targetWeightUnit: targetWeightUnit,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$RoutineExercisesTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({routineId = false, exerciseId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (routineId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.routineId,
+                                referencedTable:
+                                    $$RoutineExercisesTableReferences
+                                        ._routineIdTable(db),
+                                referencedColumn:
+                                    $$RoutineExercisesTableReferences
+                                        ._routineIdTable(db)
+                                        .id,
+                              )
+                              as T;
+                    }
+                    if (exerciseId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.exerciseId,
+                                referencedTable:
+                                    $$RoutineExercisesTableReferences
+                                        ._exerciseIdTable(db),
+                                referencedColumn:
+                                    $$RoutineExercisesTableReferences
+                                        ._exerciseIdTable(db)
+                                        .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$RoutineExercisesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $RoutineExercisesTable,
+      RoutineExercise,
+      $$RoutineExercisesTableFilterComposer,
+      $$RoutineExercisesTableOrderingComposer,
+      $$RoutineExercisesTableAnnotationComposer,
+      $$RoutineExercisesTableCreateCompanionBuilder,
+      $$RoutineExercisesTableUpdateCompanionBuilder,
+      (RoutineExercise, $$RoutineExercisesTableReferences),
+      RoutineExercise,
+      PrefetchHooks Function({bool routineId, bool exerciseId})
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -3811,4 +5606,8 @@ class $AppDatabaseManager {
       $$ExerciseSetsTableTableManager(_db, _db.exerciseSets);
   $$BodyWeightLogsTableTableManager get bodyWeightLogs =>
       $$BodyWeightLogsTableTableManager(_db, _db.bodyWeightLogs);
+  $$RoutinesTableTableManager get routines =>
+      $$RoutinesTableTableManager(_db, _db.routines);
+  $$RoutineExercisesTableTableManager get routineExercises =>
+      $$RoutineExercisesTableTableManager(_db, _db.routineExercises);
 }

--- a/lib/data/enums.dart
+++ b/lib/data/enums.dart
@@ -33,3 +33,23 @@ enum Source {
   derived,
   imported,
 }
+
+/// Resolves a Drift-stored `source` string back into a [Source] enum.
+///
+/// Lives here (not in a feature file) because the arch guardrail forbids
+/// `lib/features/**` from referencing `Source.` directly (CLAUDE.md
+/// canonical enums — `FoodEntryType` and `Source` are orthogonal).
+/// Feature code (e.g. the import service) calls this helper so it
+/// receives a `Source`-typed value without constructing one raw.
+///
+/// Throws an `ArgumentError` on an unknown string — callers are
+/// expected to catch and translate that into their own malformed-row
+/// signalling so an unknown `source` value fails loudly rather than
+/// silently defaulting. Trust rule: no silent fallbacks.
+Source parseSourceName(String name) {
+  try {
+    return Source.values.byName(name);
+  } catch (_) {
+    throw ArgumentError.value(name, 'source', 'unknown Source value');
+  }
+}

--- a/lib/data/repositories/routine_repository.dart
+++ b/lib/data/repositories/routine_repository.dart
@@ -1,0 +1,135 @@
+import 'package:drift/drift.dart';
+
+import '../database.dart';
+
+/// Access to the `Routines` + `RoutineExercises` tables (schema v4 —
+/// issue #52).
+///
+/// A routine is a reusable workout template: a named lineup of
+/// exercises with optional per-exercise target sets/reps/weight.
+/// Sprint 5 lands the data layer only — no UI reads or writes routines
+/// yet, so this repository's surface is deliberately minimal: full
+/// CRUD on both tables, a transactional reorder helper, and the usual
+/// `watch*` / `list*` pair per the v2.0 trust rules (every watcher
+/// pairs with a one-shot so widget tests avoid Drift + fake_async
+/// hangs).
+///
+/// FK note: `RoutineExercises.routineId` is `ON DELETE CASCADE`, so
+/// `delete(routineId)` removes the routine's lineup automatically.
+/// The cascade is enforced at the SQLite layer via
+/// `PRAGMA foreign_keys = ON` in `AppDatabase.beforeOpen`. Unrelated
+/// `ExerciseSet` rows — from real workout sessions — are untouched.
+class RoutineRepository {
+  RoutineRepository(this._db);
+
+  final AppDatabase _db;
+
+  /// Inserts [routine] and returns the new row's `id`.
+  Future<int> add(RoutinesCompanion routine) =>
+      _db.into(_db.routines).insert(routine);
+
+  /// Writes every column of [routine] including any nullable columns
+  /// that are being cleared (e.g. `notes: null`). We use `replace`
+  /// rather than `update(...).write(...)` because `write` serializes
+  /// with `nullToAbsent: true` and would silently preserve cleared
+  /// nullables — a trust-rule violation ("no silent mutation"). See
+  /// the arch guardrail in `test/arch/data_access_boundary_test.dart`.
+  /// `replace` applies its own `whereSamePrimaryKey` so the caller
+  /// must not add one.
+  Future<void> update(Routine routine) async {
+    await _db.update(_db.routines).replace(routine);
+  }
+
+  /// Deletes the routine with [routineId]. `RoutineExercises` rows
+  /// referencing this routine are removed by SQLite's
+  /// `ON DELETE CASCADE`. Unrelated `ExerciseSet` rows are untouched.
+  Future<int> delete(int routineId) =>
+      (_db.delete(_db.routines)..where((t) => t.id.equals(routineId))).go();
+
+  /// Every routine, newest-first by `createdAt` with `id DESC` as the
+  /// tie-breaker (mirrors `ExerciseRepository.listAll` / `watchAll`).
+  Future<List<Routine>> listAll() =>
+      (_db.select(_db.routines)..orderBy([
+            (t) => OrderingTerm.desc(t.createdAt),
+            (t) => OrderingTerm.desc(t.id),
+          ]))
+          .get();
+
+  /// Streaming counterpart to [listAll]. Widget tests should prefer
+  /// [listAll] to avoid the Drift + fake_async hang.
+  Stream<List<Routine>> watchAll() =>
+      (_db.select(_db.routines)..orderBy([
+            (t) => OrderingTerm.desc(t.createdAt),
+            (t) => OrderingTerm.desc(t.id),
+          ]))
+          .watch();
+
+  /// Returns the routine with [id], or `null` if no row matches.
+  Future<Routine?> findById(int id) => (_db.select(
+    _db.routines,
+  )..where((t) => t.id.equals(id))).getSingleOrNull();
+
+  /// Every line item for [routineId], ordered by `orderIndex` ascending.
+  Future<List<RoutineExercise>> listExercises(int routineId) =>
+      (_db.select(_db.routineExercises)
+            ..where((t) => t.routineId.equals(routineId))
+            ..orderBy([(t) => OrderingTerm.asc(t.orderIndex)]))
+          .get();
+
+  /// Streaming counterpart to [listExercises].
+  Stream<List<RoutineExercise>> watchExercises(int routineId) =>
+      (_db.select(_db.routineExercises)
+            ..where((t) => t.routineId.equals(routineId))
+            ..orderBy([(t) => OrderingTerm.asc(t.orderIndex)]))
+          .watch();
+
+  /// Every line item across every routine, ordered by `id` ascending
+  /// for deterministic output. Added for the data-export flow (issue
+  /// #52) which needs a flat dump of all rows; [listExercises] is
+  /// scoped to a single routine.
+  Future<List<RoutineExercise>> listAllExercises() => (_db.select(
+    _db.routineExercises,
+  )..orderBy([(t) => OrderingTerm.asc(t.id)])).get();
+
+  /// Inserts a new line item and returns the new row's `id`.
+  Future<int> addExercise(RoutineExercisesCompanion exercise) =>
+      _db.into(_db.routineExercises).insert(exercise);
+
+  /// Rewrites `orderIndex` on every row in [exerciseIds] for the
+  /// routine [routineId], in the order the caller supplied. The update
+  /// runs inside a single Drift transaction so a partial reorder is
+  /// never committed.
+  ///
+  /// Semantics: [exerciseIds] is the caller's desired ordering — the
+  /// row whose id is `exerciseIds[0]` gets `orderIndex = 0`,
+  /// `exerciseIds[1]` gets `orderIndex = 1`, etc. Callers are
+  /// responsible for passing every id belonging to the routine
+  /// exactly once; this method does not validate that. Ids not
+  /// belonging to [routineId] are skipped (the per-row update matches
+  /// on both `id` and `routineId` so stray ids don't mutate rows on
+  /// another routine).
+  Future<void> reorderExercises(int routineId, List<int> exerciseIds) async {
+    // Read-then-replace loop: fetch each target row, rewrite its
+    // `orderIndex`, and pass the full row back through `replace()`.
+    // This keeps us on the trust-rule compliant `replace` path (no
+    // silent null-preservation from `write(..., nullToAbsent: true)`)
+    // while still being transactional — a partial reorder can never
+    // land. Rows whose id doesn't belong to [routineId] are skipped
+    // by the `getSingleOrNull` guard.
+    await _db.transaction(() async {
+      for (var i = 0; i < exerciseIds.length; i++) {
+        final row =
+            await (_db.select(_db.routineExercises)..where(
+                  (t) =>
+                      t.id.equals(exerciseIds[i]) &
+                      t.routineId.equals(routineId),
+                ))
+                .getSingleOrNull();
+        if (row == null) continue;
+        await _db
+            .update(_db.routineExercises)
+            .replace(row.copyWith(orderIndex: i));
+      }
+    });
+  }
+}

--- a/lib/features/export/export_service.dart
+++ b/lib/features/export/export_service.dart
@@ -25,6 +25,7 @@ import '../../data/database.dart';
 import '../../data/repositories/body_weight_log_repository.dart';
 import '../../data/repositories/exercise_set_repository.dart';
 import '../../data/repositories/food_entry_repository.dart';
+import '../../data/repositories/routine_repository.dart';
 import '../../data/repositories/workout_session_repository.dart';
 
 /// Current export format version. Bump when the JSON shape changes.
@@ -60,14 +61,21 @@ Future<String> buildExportJson({
   final weightRepo = BodyWeightLogRepository(db);
   final sessionRepo = WorkoutSessionRepository(db);
   final setRepo = ExerciseSetRepository(db);
+  final routineRepo = RoutineRepository(db);
 
-  // Fan out all four reads in parallel. None of them depend on each
-  // other so there's no ordering concern here.
+  // Fan out all reads in parallel. None of them depend on each other
+  // so there's no ordering concern here. Routines + routine_exercises
+  // (schema v4, issue #52) appended to the list — the `format_version`
+  // stays at '1' because the new keys are additive snake_case fields
+  // that old importers safely ignore (same reasoning as the S5.1
+  // `source` column addition on the four original entities).
   final results = await Future.wait<List<Object>>([
     foodRepo.listAll(),
     weightRepo.listAll(),
     sessionRepo.listAll(),
     setRepo.listAll(),
+    routineRepo.listAll(),
+    routineRepo.listAllExercises(),
   ]);
 
   // Each repo's `listAll` orders by timestamp descending (or similar);
@@ -82,6 +90,10 @@ Future<String> buildExportJson({
     ..sort((a, b) => a.id.compareTo(b.id));
   final exerciseSets = [...results[3] as List<ExerciseSet>]
     ..sort((a, b) => a.id.compareTo(b.id));
+  final routines = [...results[4] as List<Routine>]
+    ..sort((a, b) => a.id.compareTo(b.id));
+  final routineExercises = [...results[5] as List<RoutineExercise>]
+    ..sort((a, b) => a.id.compareTo(b.id));
 
   final payload = <String, Object?>{
     'meta': <String, Object?>{
@@ -94,6 +106,8 @@ Future<String> buildExportJson({
         'body_weight_logs': bodyWeightLogs.length,
         'workout_sessions': workoutSessions.length,
         'exercise_sets': exerciseSets.length,
+        'routines': routines.length,
+        'routine_exercises': routineExercises.length,
       },
       'note':
           'All arrays below are user-entered rows exactly as stored. '
@@ -105,28 +119,30 @@ Future<String> buildExportJson({
     'body_weight_logs': bodyWeightLogs.map(_bodyWeightLogToJson).toList(),
     'workout_sessions': workoutSessions.map(_workoutSessionToJson).toList(),
     'exercise_sets': exerciseSets.map(_exerciseSetToJson).toList(),
+    'routines': routines.map(_routineToJson).toList(),
+    'routine_exercises': routineExercises.map(_routineExerciseToJson).toList(),
   };
 
   return jsonEncode(payload);
 }
 
 Map<String, Object?> _foodEntryToJson(FoodEntry e) => <String, Object?>{
-      'id': e.id,
-      'timestamp': e.timestamp.toUtc().toIso8601String(),
-      'name': e.name,
-      'kcal': e.kcal,
-      'protein_g': e.proteinG,
-      'meal_type': e.mealType.name,
-      'entry_type': e.entryType.name,
-      'note': e.note,
-    };
+  'id': e.id,
+  'timestamp': e.timestamp.toUtc().toIso8601String(),
+  'name': e.name,
+  'kcal': e.kcal,
+  'protein_g': e.proteinG,
+  'meal_type': e.mealType.name,
+  'entry_type': e.entryType.name,
+  'note': e.note,
+};
 
 Map<String, Object?> _bodyWeightLogToJson(BodyWeightLog e) => <String, Object?>{
-      'id': e.id,
-      'timestamp': e.timestamp.toUtc().toIso8601String(),
-      'value': e.value,
-      'unit': e.unit.name,
-    };
+  'id': e.id,
+  'timestamp': e.timestamp.toUtc().toIso8601String(),
+  'value': e.value,
+  'unit': e.unit.name,
+};
 
 Map<String, Object?> _workoutSessionToJson(WorkoutSession s) =>
     <String, Object?>{
@@ -139,12 +155,35 @@ Map<String, Object?> _workoutSessionToJson(WorkoutSession s) =>
     };
 
 Map<String, Object?> _exerciseSetToJson(ExerciseSet s) => <String, Object?>{
-      'id': s.id,
-      'session_id': s.sessionId,
-      'exercise_name': s.exerciseName,
-      'reps': s.reps,
-      'weight': s.weight,
-      'weight_unit': s.weightUnit.name,
-      'status': s.status.name,
-      'order_index': s.orderIndex,
+  'id': s.id,
+  'session_id': s.sessionId,
+  'exercise_name': s.exerciseName,
+  'reps': s.reps,
+  'weight': s.weight,
+  'weight_unit': s.weightUnit.name,
+  'status': s.status.name,
+  'order_index': s.orderIndex,
+};
+
+Map<String, Object?> _routineToJson(Routine r) => <String, Object?>{
+  'id': r.id,
+  'name': r.name,
+  'notes': r.notes,
+  'created_at': r.createdAt.toUtc().toIso8601String(),
+  'source': r.source.name,
+};
+
+Map<String, Object?> _routineExerciseToJson(RoutineExercise e) =>
+    <String, Object?>{
+      'id': e.id,
+      'routine_id': e.routineId,
+      'exercise_id': e.exerciseId,
+      'order_index': e.orderIndex,
+      'target_sets': e.targetSets,
+      'target_reps': e.targetReps,
+      'target_weight': e.targetWeight,
+      // Nullable enum — `null` stays `null` through jsonEncode; the key
+      // is always present so parsers can rely on `row['target_weight_unit']`
+      // rather than a `containsKey` check.
+      'target_weight_unit': e.targetWeightUnit?.name,
     };

--- a/lib/features/export/import_service.dart
+++ b/lib/features/export/import_service.dart
@@ -35,6 +35,7 @@ import '../../data/enums.dart';
 import '../../data/repositories/body_weight_log_repository.dart';
 import '../../data/repositories/exercise_set_repository.dart';
 import '../../data/repositories/food_entry_repository.dart';
+import '../../data/repositories/routine_repository.dart';
 import '../../data/repositories/workout_session_repository.dart';
 import 'export_service.dart';
 
@@ -176,18 +177,24 @@ class _ParsedPayload {
     required this.bodyWeightLogs,
     required this.workoutSessions,
     required this.exerciseSets,
+    required this.routines,
+    required this.routineExercises,
   });
 
   final List<FoodEntriesCompanion> foodEntries;
   final List<BodyWeightLogsCompanion> bodyWeightLogs;
   final List<WorkoutSessionsCompanion> workoutSessions;
   final List<ExerciseSetsCompanion> exerciseSets;
+  final List<RoutinesCompanion> routines;
+  final List<RoutineExercisesCompanion> routineExercises;
 
   int get totalRows =>
       foodEntries.length +
       bodyWeightLogs.length +
       workoutSessions.length +
-      exerciseSets.length;
+      exerciseSets.length +
+      routines.length +
+      routineExercises.length;
 }
 
 _ParseOutcome _parseAndValidate(String jsonPayload) {
@@ -226,16 +233,26 @@ _ParseOutcome _parseAndValidate(String jsonPayload) {
 
   // Each entity array is optional (empty DB exports as empty list); but
   // if present it must be a List<Map>. We also tolerate the key being
-  // absent — treat as empty.
+  // absent — treat as empty. `routines` / `routine_exercises` were
+  // added in schema v4 (issue #52) — older export files won't have the
+  // keys, so the tolerant "missing → empty" behavior is what makes the
+  // `format_version` bump unnecessary (pre-v4 payloads remain valid).
   final List<FoodEntriesCompanion> foodEntries;
   final List<BodyWeightLogsCompanion> bodyWeightLogs;
   final List<WorkoutSessionsCompanion> workoutSessions;
   final List<ExerciseSetsCompanion> exerciseSets;
+  final List<RoutinesCompanion> routines;
+  final List<RoutineExercisesCompanion> routineExercises;
   try {
     foodEntries = _parseList(raw['food_entries'], _parseFoodEntry);
     bodyWeightLogs = _parseList(raw['body_weight_logs'], _parseBodyWeightLog);
     workoutSessions = _parseList(raw['workout_sessions'], _parseWorkoutSession);
     exerciseSets = _parseList(raw['exercise_sets'], _parseExerciseSet);
+    routines = _parseList(raw['routines'], _parseRoutine);
+    routineExercises = _parseList(
+      raw['routine_exercises'],
+      _parseRoutineExercise,
+    );
   } on _MalformedRow catch (e) {
     return _ParseFailure(ImportMalformed(reason: e.reason));
   }
@@ -246,6 +263,8 @@ _ParseOutcome _parseAndValidate(String jsonPayload) {
       bodyWeightLogs: bodyWeightLogs,
       workoutSessions: workoutSessions,
       exerciseSets: exerciseSets,
+      routines: routines,
+      routineExercises: routineExercises,
     ),
   );
 }
@@ -337,6 +356,63 @@ WorkoutSessionsCompanion _parseWorkoutSession(Map<String, dynamic> row) {
   );
 }
 
+RoutinesCompanion _parseRoutine(Map<String, dynamic> row) {
+  final id = _int(row, 'id', 'routines');
+  final name = _string(row, 'name', 'routines');
+  final notes = _nullableString(row, 'notes', 'routines');
+  final createdAt = _dateTime(row, 'created_at', 'routines');
+  final sourceRaw = _string(row, 'source', 'routines');
+  // `parseSourceName` lives in `lib/data/enums.dart` so the arch
+  // guardrail (features never reference `Source.` directly) holds.
+  // Translates the thrown `ArgumentError` into the malformed-row
+  // contract this file already uses for every other enum mismatch.
+  final Source source;
+  try {
+    source = parseSourceName(sourceRaw);
+  } on ArgumentError {
+    throw _MalformedRow('routines.source: unknown enum value "$sourceRaw"');
+  }
+
+  return RoutinesCompanion.insert(
+    id: Value(id),
+    name: name,
+    notes: Value(notes),
+    createdAt: createdAt,
+    source: Value(source),
+  );
+}
+
+RoutineExercisesCompanion _parseRoutineExercise(Map<String, dynamic> row) {
+  final id = _int(row, 'id', 'routine_exercises');
+  final routineId = _int(row, 'routine_id', 'routine_exercises');
+  final exerciseId = _int(row, 'exercise_id', 'routine_exercises');
+  final orderIndex = _int(row, 'order_index', 'routine_exercises');
+  final targetSets = _nullableInt(row, 'target_sets', 'routine_exercises');
+  final targetReps = _nullableInt(row, 'target_reps', 'routine_exercises');
+  final targetWeight = _nullableDouble(
+    row,
+    'target_weight',
+    'routine_exercises',
+  );
+  final targetWeightUnit = _nullableEnum<WeightUnit>(
+    row,
+    'target_weight_unit',
+    'routine_exercises',
+    WeightUnit.values,
+  );
+
+  return RoutineExercisesCompanion.insert(
+    id: Value(id),
+    routineId: routineId,
+    exerciseId: exerciseId,
+    orderIndex: orderIndex,
+    targetSets: Value(targetSets),
+    targetReps: Value(targetReps),
+    targetWeight: Value(targetWeight),
+    targetWeightUnit: Value(targetWeightUnit),
+  );
+}
+
 ExerciseSetsCompanion _parseExerciseSet(Map<String, dynamic> row) {
   final id = _int(row, 'id', 'exercise_sets');
   final sessionId = _int(row, 'session_id', 'exercise_sets');
@@ -388,6 +464,25 @@ String _string(Map<String, dynamic> row, String key, String entity) {
   final v = row[key];
   if (v is String) return v;
   throw _MalformedRow('$entity.$key: expected string, got ${v.runtimeType}');
+}
+
+int? _nullableInt(Map<String, dynamic> row, String key, String entity) {
+  final v = row[key];
+  if (v == null) return null;
+  if (v is int) return v;
+  throw _MalformedRow(
+    '$entity.$key: expected int or null, got ${v.runtimeType}',
+  );
+}
+
+double? _nullableDouble(Map<String, dynamic> row, String key, String entity) {
+  final v = row[key];
+  if (v == null) return null;
+  if (v is double) return v;
+  if (v is int) return v.toDouble();
+  throw _MalformedRow(
+    '$entity.$key: expected number or null, got ${v.runtimeType}',
+  );
 }
 
 String? _nullableString(Map<String, dynamic> row, String key, String entity) {
@@ -451,16 +546,34 @@ T _enum<T extends Enum>(
   }
 }
 
+/// Nullable companion of [_enum]. Accepts `null` (or a missing key) and
+/// returns `null`; otherwise resolves like [_enum]. Unknown non-null
+/// strings still fail loudly — the `null` tolerance is only for
+/// genuinely optional enum columns (e.g. `routine_exercises.target_weight_unit`).
+T? _nullableEnum<T extends Enum>(
+  Map<String, dynamic> row,
+  String key,
+  String entity,
+  List<T> values,
+) {
+  final v = row[key];
+  if (v == null) return null;
+  return _enum<T>(row, key, entity, values);
+}
+
 Future<int> _totalRowCount(AppDatabase db) async {
   final foods = FoodEntryRepository(db);
   final weights = BodyWeightLogRepository(db);
   final sessions = WorkoutSessionRepository(db);
   final sets = ExerciseSetRepository(db);
+  final routines = RoutineRepository(db);
   final results = await Future.wait<int>([
     foods.listAll().then((l) => l.length),
     weights.listAll().then((l) => l.length),
     sessions.listAll().then((l) => l.length),
     sets.listAll().then((l) => l.length),
+    routines.listAll().then((l) => l.length),
+    routines.listAllExercises().then((l) => l.length),
   ]);
   return results.fold<int>(0, (a, b) => a + b);
 }
@@ -479,6 +592,7 @@ Future<void> _wipeAll(AppDatabase db) async {
   final weights = BodyWeightLogRepository(db);
   final sessions = WorkoutSessionRepository(db);
   final sets = ExerciseSetRepository(db);
+  final routines = RoutineRepository(db);
 
   // Child first (exercise_sets). Cascade would also handle this via the
   // sessions' `onDelete: cascade`, but being explicit keeps the step
@@ -495,6 +609,12 @@ Future<void> _wipeAll(AppDatabase db) async {
   for (final f in await foods.listAll()) {
     await foods.delete(f.id);
   }
+  // Routines cascade to routine_exercises, so deleting the parent is
+  // sufficient. We still iterate the parent list explicitly so the
+  // order is visible and matches the pattern above.
+  for (final r in await routines.listAll()) {
+    await routines.delete(r.id);
+  }
 }
 
 /// Inserts all rows in FK-forward order (parents before children so
@@ -507,10 +627,16 @@ Future<void> _insertAll(AppDatabase db, _ParsedPayload payload) async {
   final weights = BodyWeightLogRepository(db);
   final sessions = WorkoutSessionRepository(db);
   final sets = ExerciseSetRepository(db);
+  final routines = RoutineRepository(db);
 
   // food_entries and body_weight_logs have no FK dependencies — order
   // among these two is arbitrary. workout_sessions must precede
-  // exercise_sets.
+  // exercise_sets. `routine_exercises` FK-references both `routines`
+  // (parent) and `exercises` (sibling table whose rows are populated
+  // by historical seeding, not by this import flow — round-tripping
+  // routines currently requires the destination DB to already have
+  // the exercise catalog, which mirrors how workout_sessions +
+  // exercise_sets share the session-parent contract).
   for (final row in payload.foodEntries) {
     await foods.add(row);
   }
@@ -522,5 +648,11 @@ Future<void> _insertAll(AppDatabase db, _ParsedPayload payload) async {
   }
   for (final row in payload.exerciseSets) {
     await sets.add(row);
+  }
+  for (final row in payload.routines) {
+    await routines.add(row);
+  }
+  for (final row in payload.routineExercises) {
+    await routines.addExercise(row);
   }
 }

--- a/lib/providers/app_providers.dart
+++ b/lib/providers/app_providers.dart
@@ -5,6 +5,7 @@ import '../data/repositories/body_weight_log_repository.dart';
 import '../data/repositories/exercise_repository.dart';
 import '../data/repositories/exercise_set_repository.dart';
 import '../data/repositories/food_entry_repository.dart';
+import '../data/repositories/routine_repository.dart';
 import '../data/repositories/workout_session_repository.dart';
 import '../sources/health_kit/health_source.dart';
 import '../sources/health_kit/health_source_impl.dart';
@@ -37,6 +38,10 @@ final bodyWeightLogRepositoryProvider = Provider<BodyWeightLogRepository>((
 
 final exerciseRepositoryProvider = Provider<ExerciseRepository>((ref) {
   return ExerciseRepository(ref.watch(appDatabaseProvider));
+});
+
+final routineRepositoryProvider = Provider<RoutineRepository>((ref) {
+  return RoutineRepository(ref.watch(appDatabaseProvider));
 });
 
 /// HealthKit façade provider (issue #43).

--- a/test/data/persistence_round_trip_test.dart
+++ b/test/data/persistence_round_trip_test.dart
@@ -107,9 +107,7 @@ void main() {
           "INSERT INTO body_weight_logs (timestamp, value, unit) "
           "VALUES (1000, 80.0, 'kg')",
         );
-        raw.execute(
-          "INSERT INTO workout_sessions (started_at) VALUES (1000)",
-        );
+        raw.execute("INSERT INTO workout_sessions (started_at) VALUES (1000)");
         raw.execute(
           "INSERT INTO exercise_sets (session_id, exercise_name, reps, weight, weight_unit, status, order_index) "
           "VALUES (1, 'Bench Press', 8, 80.0, 'kg', 'completed', 0)",
@@ -128,73 +126,79 @@ void main() {
       }
     }
 
-    test('adds source columns with default "userEntered" on every table',
-        () async {
-      final dir = tempDir();
-      final dbPath = p.join(dir.path, 'liftlog.sqlite');
-      seedV2Database(dbPath);
+    test(
+      'adds source columns with default "userEntered" on every table',
+      () async {
+        final dir = tempDir();
+        final dbPath = p.join(dir.path, 'liftlog.sqlite');
+        seedV2Database(dbPath);
 
-      // Trigger onUpgrade by opening AppDatabase against the v2 file.
-      final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
-      addTearDown(db.close);
+        // Trigger onUpgrade by opening AppDatabase against the v2 file.
+        final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
+        addTearDown(db.close);
 
-      Future<List<String>> readSource(String table) async {
+        Future<List<String>> readSource(String table) async {
+          final rows = await db
+              .customSelect('SELECT source FROM $table ORDER BY id ASC')
+              .get();
+          return rows.map((r) => r.read<String>('source')).toList();
+        }
+
+        expect(await readSource('food_entries'), ['userEntered']);
+        expect(await readSource('body_weight_logs'), ['userEntered']);
+        expect(await readSource('workout_sessions'), ['userEntered']);
+        expect(await readSource('exercise_sets'), [
+          'userEntered',
+          'userEntered',
+          'userEntered',
+        ]);
+      },
+    );
+
+    test(
+      'creates exercises table and seeds distinct exercise names once',
+      () async {
+        final dir = tempDir();
+        final dbPath = p.join(dir.path, 'liftlog.sqlite');
+        seedV2Database(dbPath);
+
+        final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
+        addTearDown(db.close);
+
         final rows = await db
-            .customSelect('SELECT source FROM $table ORDER BY id ASC')
+            .customSelect(
+              'SELECT canonical_name FROM exercises ORDER BY canonical_name ASC',
+            )
             .get();
-        return rows.map((r) => r.read<String>('source')).toList();
-      }
+        final names = rows
+            .map((r) => r.read<String>('canonical_name'))
+            .toList();
+        // V2 sample has "Bench Press" (x2) and "Squat" (x1) → 2 distinct.
+        expect(names, ['Bench Press', 'Squat']);
 
-      expect(await readSource('food_entries'), ['userEntered']);
-      expect(await readSource('body_weight_logs'), ['userEntered']);
-      expect(await readSource('workout_sessions'), ['userEntered']);
-      expect(
-        await readSource('exercise_sets'),
-        ['userEntered', 'userEntered', 'userEntered'],
-      );
-    });
-
-    test('creates exercises table and seeds distinct exercise names once',
-        () async {
-      final dir = tempDir();
-      final dbPath = p.join(dir.path, 'liftlog.sqlite');
-      seedV2Database(dbPath);
-
-      final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
-      addTearDown(db.close);
-
-      final rows = await db
-          .customSelect(
-            'SELECT canonical_name FROM exercises ORDER BY canonical_name ASC',
-          )
-          .get();
-      final names =
-          rows.map((r) => r.read<String>('canonical_name')).toList();
-      // V2 sample has "Bench Press" (x2) and "Squat" (x1) → 2 distinct.
-      expect(names, ['Bench Press', 'Squat']);
-
-      // Confirm `exercise_id` FK column was added AND backfilled by the
-      // `beforeOpen` pass (issue #47). Historical sets are now linked to
-      // their seeded `exercises` row by matching `exercise_name` →
-      // `canonical_name`.
-      final setRows = await db
-          .customSelect(
-            'SELECT exercise_name, exercise_id FROM exercise_sets ORDER BY id ASC',
-          )
-          .get();
-      expect(setRows, hasLength(3));
-      expect(
-        setRows.every((r) => r.read<int?>('exercise_id') != null),
-        isTrue,
-        reason: 'beforeOpen backfill must populate every matchable set',
-      );
-      // Both "Bench Press" rows should map to the same exercise id.
-      final benchIds = setRows
-          .where((r) => r.read<String>('exercise_name') == 'Bench Press')
-          .map((r) => r.read<int>('exercise_id'))
-          .toSet();
-      expect(benchIds, hasLength(1));
-    });
+        // Confirm `exercise_id` FK column was added AND backfilled by the
+        // `beforeOpen` pass (issue #47). Historical sets are now linked to
+        // their seeded `exercises` row by matching `exercise_name` →
+        // `canonical_name`.
+        final setRows = await db
+            .customSelect(
+              'SELECT exercise_name, exercise_id FROM exercise_sets ORDER BY id ASC',
+            )
+            .get();
+        expect(setRows, hasLength(3));
+        expect(
+          setRows.every((r) => r.read<int?>('exercise_id') != null),
+          isTrue,
+          reason: 'beforeOpen backfill must populate every matchable set',
+        );
+        // Both "Bench Press" rows should map to the same exercise id.
+        final benchIds = setRows
+            .where((r) => r.read<String>('exercise_name') == 'Bench Press')
+            .map((r) => r.read<int>('exercise_id'))
+            .toSet();
+        expect(benchIds, hasLength(1));
+      },
+    );
 
     test('seeding is idempotent across successive opens', () async {
       final dir = tempDir();
@@ -229,8 +233,323 @@ void main() {
       // seeding helper, `INSERT OR IGNORE` + `canonicalName UNIQUE`
       // guarantees the row count stays constant.
       final secondCount = await countExercises();
-      expect(secondCount, firstCount,
-          reason: 'seeding must be idempotent under repeated open');
+      expect(
+        secondCount,
+        firstCount,
+        reason: 'seeding must be idempotent under repeated open',
+      );
+    });
+  });
+
+  group('v3 → v4 migration', () {
+    // Simulates an upgrade from schema v3 (post-issue #42) to v4:
+    //  - Creates a fresh sqlite file with the v3 table shape via raw SQL
+    //    and sets `PRAGMA user_version = 3` so Drift reads it as v3.
+    //  - Inserts sample rows across the five v3 entities.
+    //  - Opens AppDatabase (schemaVersion = 4) which fires onUpgrade.
+    //  - Asserts: existing rows survive untouched; the two new tables
+    //    (`routines`, `routine_exercises`) exist and are empty; new
+    //    inserts work; cascade delete on routine removes child rows.
+    //
+    // Same raw-sqlite3 setup rationale as the v2→v3 group above: Drift
+    // can't address a "previous-schema" layout from its own API, so we
+    // build the v3 shape by hand.
+
+    Directory tempDir() {
+      final dir = Directory.systemTemp.createTempSync('liftlog_migrate_v4_');
+      addTearDown(() {
+        if (dir.existsSync()) dir.deleteSync(recursive: true);
+      });
+      return dir;
+    }
+
+    /// Writes a schema-v3-shaped database to [path]. Mirrors the shape
+    /// `AppDatabase` had immediately after the v2→v3 migration landed:
+    /// provenance column on every entity, first-class `exercises`
+    /// table, nullable `exercise_id` FK on `exercise_sets`. No
+    /// `routines` / `routine_exercises` tables yet. PRAGMA user_version
+    /// is set to 3 so Drift sees "from = 3" on open.
+    void seedV3Database(String path) {
+      final raw = sqlite3.open(path);
+      try {
+        raw.execute('PRAGMA foreign_keys = ON');
+        raw.execute('''
+          CREATE TABLE food_entries (
+            id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            timestamp INTEGER NOT NULL,
+            name TEXT NOT NULL DEFAULT '',
+            kcal INTEGER NOT NULL,
+            protein_g REAL NOT NULL,
+            meal_type TEXT NOT NULL,
+            entry_type TEXT NOT NULL,
+            note TEXT NULL,
+            source TEXT NOT NULL DEFAULT 'userEntered'
+          )
+        ''');
+        raw.execute('''
+          CREATE TABLE workout_sessions (
+            id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            started_at INTEGER NOT NULL,
+            ended_at INTEGER NULL,
+            note TEXT NULL,
+            source TEXT NOT NULL DEFAULT 'userEntered'
+          )
+        ''');
+        raw.execute('''
+          CREATE TABLE exercises (
+            id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            canonical_name TEXT NOT NULL UNIQUE,
+            muscle_group TEXT NULL,
+            created_at INTEGER NOT NULL
+          )
+        ''');
+        raw.execute('''
+          CREATE TABLE exercise_sets (
+            id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            session_id INTEGER NOT NULL REFERENCES workout_sessions (id) ON DELETE CASCADE,
+            exercise_name TEXT NOT NULL,
+            reps INTEGER NOT NULL,
+            weight REAL NOT NULL,
+            weight_unit TEXT NOT NULL,
+            status TEXT NOT NULL,
+            order_index INTEGER NOT NULL,
+            exercise_id INTEGER NULL REFERENCES exercises (id),
+            source TEXT NOT NULL DEFAULT 'userEntered'
+          )
+        ''');
+        raw.execute('''
+          CREATE TABLE body_weight_logs (
+            id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+            timestamp INTEGER NOT NULL,
+            value REAL NOT NULL,
+            unit TEXT NOT NULL,
+            source TEXT NOT NULL DEFAULT 'userEntered'
+          )
+        ''');
+        raw.execute(
+          "INSERT INTO food_entries (timestamp, name, kcal, protein_g, meal_type, entry_type) "
+          "VALUES (1000, 'Eggs', 140, 12.0, 'breakfast', 'manual')",
+        );
+        raw.execute(
+          "INSERT INTO body_weight_logs (timestamp, value, unit) "
+          "VALUES (1000, 80.0, 'kg')",
+        );
+        raw.execute("INSERT INTO workout_sessions (started_at) VALUES (1000)");
+        raw.execute(
+          "INSERT INTO exercises (canonical_name, created_at) VALUES ('Bench Press', 1000)",
+        );
+        // One set explicitly linked to the seeded exercise so we can
+        // prove the v3 exercise_id value survives the upgrade.
+        raw.execute(
+          "INSERT INTO exercise_sets (session_id, exercise_name, reps, weight, weight_unit, status, order_index, exercise_id) "
+          "VALUES (1, 'Bench Press', 8, 80.0, 'kg', 'completed', 0, 1)",
+        );
+        raw.execute('PRAGMA user_version = 3');
+      } finally {
+        raw.close();
+      }
+    }
+
+    test('existing rows across v3 entities survive the upgrade intact', () async {
+      final dir = tempDir();
+      final dbPath = p.join(dir.path, 'liftlog.sqlite');
+      seedV3Database(dbPath);
+
+      final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
+      addTearDown(db.close);
+
+      final foods = await db
+          .customSelect(
+            'SELECT id, name, kcal, protein_g, meal_type, entry_type, source '
+            'FROM food_entries ORDER BY id ASC',
+          )
+          .get();
+      expect(foods, hasLength(1));
+      expect(foods.single.read<String>('name'), 'Eggs');
+      expect(foods.single.read<int>('kcal'), 140);
+      expect(foods.single.read<double>('protein_g'), 12.0);
+      expect(foods.single.read<String>('meal_type'), 'breakfast');
+      expect(foods.single.read<String>('entry_type'), 'manual');
+      expect(foods.single.read<String>('source'), 'userEntered');
+
+      final weights = await db
+          .customSelect(
+            'SELECT value, unit, source FROM body_weight_logs ORDER BY id ASC',
+          )
+          .get();
+      expect(weights, hasLength(1));
+      expect(weights.single.read<double>('value'), 80.0);
+      expect(weights.single.read<String>('unit'), 'kg');
+      expect(weights.single.read<String>('source'), 'userEntered');
+
+      final sessions = await db
+          .customSelect(
+            'SELECT id, started_at, source FROM workout_sessions ORDER BY id ASC',
+          )
+          .get();
+      expect(sessions, hasLength(1));
+      expect(sessions.single.read<String>('source'), 'userEntered');
+
+      final exercises = await db
+          .customSelect('SELECT canonical_name FROM exercises ORDER BY id ASC')
+          .get();
+      expect(exercises.map((r) => r.read<String>('canonical_name')).toList(), [
+        'Bench Press',
+      ]);
+
+      final sets = await db
+          .customSelect(
+            'SELECT exercise_name, reps, weight, weight_unit, status, order_index, '
+            'exercise_id, source FROM exercise_sets ORDER BY id ASC',
+          )
+          .get();
+      expect(sets, hasLength(1));
+      final setRow = sets.single;
+      expect(setRow.read<String>('exercise_name'), 'Bench Press');
+      expect(setRow.read<int>('reps'), 8);
+      expect(setRow.read<double>('weight'), 80.0);
+      expect(setRow.read<String>('weight_unit'), 'kg');
+      expect(setRow.read<String>('status'), 'completed');
+      expect(setRow.read<int>('order_index'), 0);
+      expect(
+        setRow.read<int?>('exercise_id'),
+        1,
+        reason: 'v3 exercise_id linkage must survive the upgrade',
+      );
+      expect(setRow.read<String>('source'), 'userEntered');
+    });
+
+    test(
+      'routines and routine_exercises tables exist and start empty',
+      () async {
+        final dir = tempDir();
+        final dbPath = p.join(dir.path, 'liftlog.sqlite');
+        seedV3Database(dbPath);
+
+        final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
+        addTearDown(db.close);
+
+        final routines = await db
+            .customSelect('SELECT COUNT(*) AS c FROM routines')
+            .getSingle();
+        expect(routines.read<int>('c'), 0);
+
+        final routineExercises = await db
+            .customSelect('SELECT COUNT(*) AS c FROM routine_exercises')
+            .getSingle();
+        expect(routineExercises.read<int>('c'), 0);
+      },
+    );
+
+    test(
+      'can insert into routines + routine_exercises after upgrade',
+      () async {
+        final dir = tempDir();
+        final dbPath = p.join(dir.path, 'liftlog.sqlite');
+        seedV3Database(dbPath);
+
+        final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
+        addTearDown(db.close);
+
+        final routineId = await db
+            .into(db.routines)
+            .insert(
+              RoutinesCompanion.insert(
+                name: 'Push A',
+                createdAt: DateTime(2026, 4, 20, 12),
+              ),
+            );
+        expect(routineId, isPositive);
+
+        // Reference the `exercises.id = 1` seeded row above.
+        final reId = await db
+            .into(db.routineExercises)
+            .insert(
+              RoutineExercisesCompanion.insert(
+                routineId: routineId,
+                exerciseId: 1,
+                orderIndex: 0,
+                targetSets: const Value(4),
+                targetReps: const Value(8),
+                targetWeight: const Value(80.0),
+                targetWeightUnit: const Value(WeightUnit.kg),
+              ),
+            );
+        expect(reId, isPositive);
+
+        // The FK must have resolved — a bogus exercise_id should fail.
+        expect(
+          () => db
+              .into(db.routineExercises)
+              .insert(
+                RoutineExercisesCompanion.insert(
+                  routineId: routineId,
+                  exerciseId: 9999,
+                  orderIndex: 1,
+                ),
+              ),
+          throwsA(anything),
+          reason: 'FK to exercises.id must be enforced after migration',
+        );
+      },
+    );
+
+    test('deleting a routine cascades to its routine_exercises rows', () async {
+      final dir = tempDir();
+      final dbPath = p.join(dir.path, 'liftlog.sqlite');
+      seedV3Database(dbPath);
+
+      final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
+      addTearDown(db.close);
+
+      final routineId = await db
+          .into(db.routines)
+          .insert(
+            RoutinesCompanion.insert(
+              name: 'Push A',
+              createdAt: DateTime(2026, 4, 20, 12),
+            ),
+          );
+      await db
+          .into(db.routineExercises)
+          .insert(
+            RoutineExercisesCompanion.insert(
+              routineId: routineId,
+              exerciseId: 1,
+              orderIndex: 0,
+            ),
+          );
+      await db
+          .into(db.routineExercises)
+          .insert(
+            RoutineExercisesCompanion.insert(
+              routineId: routineId,
+              exerciseId: 1,
+              orderIndex: 1,
+            ),
+          );
+
+      final before = await db
+          .customSelect(
+            'SELECT COUNT(*) AS c FROM routine_exercises WHERE routine_id = ?',
+            variables: [Variable<int>(routineId)],
+          )
+          .getSingle();
+      expect(before.read<int>('c'), 2);
+
+      await (db.delete(db.routines)..where((t) => t.id.equals(routineId))).go();
+
+      final after = await db
+          .customSelect(
+            'SELECT COUNT(*) AS c FROM routine_exercises WHERE routine_id = ?',
+            variables: [Variable<int>(routineId)],
+          )
+          .getSingle();
+      expect(
+        after.read<int>('c'),
+        0,
+        reason: 'ON DELETE CASCADE must remove the lineup',
+      );
     });
   });
 
@@ -260,13 +579,17 @@ void main() {
     }) async {
       final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
       try {
-        final sessionId = await db.into(db.workoutSessions).insert(
+        final sessionId = await db
+            .into(db.workoutSessions)
+            .insert(
               WorkoutSessionsCompanion.insert(
                 startedAt: DateTime(2026, 4, 23, 9),
               ),
             );
         for (var i = 0; i < setNames.length; i++) {
-          await db.into(db.exerciseSets).insert(
+          await db
+              .into(db.exerciseSets)
+              .insert(
                 ExerciseSetsCompanion.insert(
                   sessionId: sessionId,
                   exerciseName: setNames[i],
@@ -279,7 +602,9 @@ void main() {
               );
         }
         for (final name in exerciseCanonicalNames) {
-          await db.into(db.exercises).insert(
+          await db
+              .into(db.exercises)
+              .insert(
                 ExercisesCompanion.insert(
                   canonicalName: name,
                   createdAt: DateTime(2026, 4, 23, 8),
@@ -291,16 +616,13 @@ void main() {
         // this handle when it was first opened, so without this the
         // sets would already be linked and the backfill assertion
         // below would tautologically pass.
-        await db.customStatement(
-          'UPDATE exercise_sets SET exercise_id = NULL',
-        );
+        await db.customStatement('UPDATE exercise_sets SET exercise_id = NULL');
       } finally {
         await db.close();
       }
     }
 
-    test('populates exercise_id for every matchable set on re-open',
-        () async {
+    test('populates exercise_id for every matchable set on re-open', () async {
       final dir = tempDir();
       final dbPath = p.join(dir.path, 'liftlog.sqlite');
 
@@ -335,9 +657,7 @@ void main() {
       expect(benchIds, hasLength(1));
 
       final squatId = rows
-          .firstWhere(
-            (r) => r.read<String>('exercise_name') == 'Squat',
-          )
+          .firstWhere((r) => r.read<String>('exercise_name') == 'Squat')
           .read<int>('exercise_id');
       expect(benchIds.single, isNot(squatId));
 
@@ -356,8 +676,7 @@ void main() {
       expect(await canonicalFor(squatId), 'Squat');
     });
 
-    test('leaves exercise_id null when no matching exercise exists',
-        () async {
+    test('leaves exercise_id null when no matching exercise exists', () async {
       final dir = tempDir();
       final dbPath = p.join(dir.path, 'liftlog.sqlite');
 
@@ -374,159 +693,186 @@ void main() {
           .customSelect('SELECT exercise_id FROM exercise_sets')
           .get();
       expect(rows, hasLength(1));
-      expect(rows.single.read<int?>('exercise_id'), isNull,
-          reason: 'no matching exercise → exercise_id must stay null');
-    });
-
-    test('is idempotent: second re-open does not mutate row contents',
-        () async {
-      final dir = tempDir();
-      final dbPath = p.join(dir.path, 'liftlog.sqlite');
-
-      await seedV3DatabaseWithNullExerciseIds(
-        dbPath: dbPath,
-        setNames: const ['Bench Press', 'Squat'],
-        exerciseCanonicalNames: const ['Bench Press', 'Squat'],
+      expect(
+        rows.single.read<int?>('exercise_id'),
+        isNull,
+        reason: 'no matching exercise → exercise_id must stay null',
       );
-
-      Future<List<Map<String, Object?>>> snapshot() async {
-        final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
-        try {
-          final rows = await db
-              .customSelect(
-                'SELECT id, session_id, exercise_name, reps, weight, '
-                'weight_unit, status, order_index, exercise_id, source '
-                'FROM exercise_sets ORDER BY id ASC',
-              )
-              .get();
-          return rows.map((r) => r.data).toList();
-        } finally {
-          await db.close();
-        }
-      }
-
-      final firstSnapshot = await snapshot();
-      expect(firstSnapshot, hasLength(2));
-      expect(firstSnapshot.every((r) => r['exercise_id'] != null), isTrue);
-
-      final secondSnapshot = await snapshot();
-      expect(secondSnapshot, equals(firstSnapshot),
-          reason: 'backfill must be a no-op when exercise_id is already set');
     });
+
+    test(
+      'is idempotent: second re-open does not mutate row contents',
+      () async {
+        final dir = tempDir();
+        final dbPath = p.join(dir.path, 'liftlog.sqlite');
+
+        await seedV3DatabaseWithNullExerciseIds(
+          dbPath: dbPath,
+          setNames: const ['Bench Press', 'Squat'],
+          exerciseCanonicalNames: const ['Bench Press', 'Squat'],
+        );
+
+        Future<List<Map<String, Object?>>> snapshot() async {
+          final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
+          try {
+            final rows = await db
+                .customSelect(
+                  'SELECT id, session_id, exercise_name, reps, weight, '
+                  'weight_unit, status, order_index, exercise_id, source '
+                  'FROM exercise_sets ORDER BY id ASC',
+                )
+                .get();
+            return rows.map((r) => r.data).toList();
+          } finally {
+            await db.close();
+          }
+        }
+
+        final firstSnapshot = await snapshot();
+        expect(firstSnapshot, hasLength(2));
+        expect(firstSnapshot.every((r) => r['exercise_id'] != null), isTrue);
+
+        final secondSnapshot = await snapshot();
+        expect(
+          secondSnapshot,
+          equals(firstSnapshot),
+          reason: 'backfill must be a no-op when exercise_id is already set',
+        );
+      },
+    );
   });
 
   test(
-      'entries across all 4 entities survive DB close + reopen against same file',
-      () async {
-    final dir = Directory.systemTemp.createTempSync('liftlog_persist_');
-    addTearDown(() {
-      if (dir.existsSync()) dir.deleteSync(recursive: true);
-    });
+    'entries across all 4 entities survive DB close + reopen against same file',
+    () async {
+      final dir = Directory.systemTemp.createTempSync('liftlog_persist_');
+      addTearDown(() {
+        if (dir.existsSync()) dir.deleteSync(recursive: true);
+      });
 
-    final dbPath = p.join(dir.path, 'liftlog.sqlite');
-    final today = DateTime(2026, 4, 23, 12, 30);
+      final dbPath = p.join(dir.path, 'liftlog.sqlite');
+      final today = DateTime(2026, 4, 23, 12, 30);
 
-    late int sessionId;
+      late int sessionId;
 
-    // Phase 1: open DB, write rows, close.
-    {
-      final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
-      final food = FoodEntryRepository(db);
-      final weight = BodyWeightLogRepository(db);
-      final sessions = WorkoutSessionRepository(db);
-      final sets = ExerciseSetRepository(db);
+      // Phase 1: open DB, write rows, close.
+      {
+        final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
+        final food = FoodEntryRepository(db);
+        final weight = BodyWeightLogRepository(db);
+        final sessions = WorkoutSessionRepository(db);
+        final sets = ExerciseSetRepository(db);
 
-      await food.add(FoodEntriesCompanion.insert(
-        timestamp: today,
-        name: const Value('Eggs'),
-        kcal: 140,
-        proteinG: 12.0,
-        mealType: MealType.breakfast,
-        entryType: FoodEntryType.manual,
-      ));
-      await food.add(FoodEntriesCompanion.insert(
-        timestamp: today.add(const Duration(hours: 4)),
-        name: const Value('Chicken'),
-        kcal: 310,
-        proteinG: 45.0,
-        mealType: MealType.lunch,
-        entryType: FoodEntryType.manual,
-      ));
+        await food.add(
+          FoodEntriesCompanion.insert(
+            timestamp: today,
+            name: const Value('Eggs'),
+            kcal: 140,
+            proteinG: 12.0,
+            mealType: MealType.breakfast,
+            entryType: FoodEntryType.manual,
+          ),
+        );
+        await food.add(
+          FoodEntriesCompanion.insert(
+            timestamp: today.add(const Duration(hours: 4)),
+            name: const Value('Chicken'),
+            kcal: 310,
+            proteinG: 45.0,
+            mealType: MealType.lunch,
+            entryType: FoodEntryType.manual,
+          ),
+        );
 
-      await weight.add(BodyWeightLogsCompanion.insert(
-        timestamp: today,
-        value: 80.0,
-        unit: WeightUnit.kg,
-      ));
+        await weight.add(
+          BodyWeightLogsCompanion.insert(
+            timestamp: today,
+            value: 80.0,
+            unit: WeightUnit.kg,
+          ),
+        );
 
-      sessionId = await sessions.add(WorkoutSessionsCompanion.insert(
-        startedAt: today.add(const Duration(hours: 6)),
-      ));
+        sessionId = await sessions.add(
+          WorkoutSessionsCompanion.insert(
+            startedAt: today.add(const Duration(hours: 6)),
+          ),
+        );
 
-      await sets.add(ExerciseSetsCompanion.insert(
-        sessionId: sessionId,
-        exerciseName: 'Bench Press',
-        reps: 8,
-        weight: 80.0,
-        weightUnit: WeightUnit.kg,
-        status: WorkoutSetStatus.completed,
-        orderIndex: 0,
-      ));
-      await sets.add(ExerciseSetsCompanion.insert(
-        sessionId: sessionId,
-        exerciseName: 'Bench Press',
-        reps: 7,
-        weight: 82.5,
-        weightUnit: WeightUnit.kg,
-        status: WorkoutSetStatus.completed,
-        orderIndex: 1,
-      ));
+        await sets.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: sessionId,
+            exerciseName: 'Bench Press',
+            reps: 8,
+            weight: 80.0,
+            weightUnit: WeightUnit.kg,
+            status: WorkoutSetStatus.completed,
+            orderIndex: 0,
+          ),
+        );
+        await sets.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: sessionId,
+            exerciseName: 'Bench Press',
+            reps: 7,
+            weight: 82.5,
+            weightUnit: WeightUnit.kg,
+            status: WorkoutSetStatus.completed,
+            orderIndex: 1,
+          ),
+        );
 
-      await db.close();
-    }
+        await db.close();
+      }
 
-    // File must be on disk between phases.
-    expect(File(dbPath).existsSync(), isTrue,
-        reason: 'DB file must survive close');
+      // File must be on disk between phases.
+      expect(
+        File(dbPath).existsSync(),
+        isTrue,
+        reason: 'DB file must survive close',
+      );
 
-    // Phase 2: reopen DB against the same file, assert round-trip.
-    {
-      final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
-      final food = FoodEntryRepository(db);
-      final weight = BodyWeightLogRepository(db);
-      final sessions = WorkoutSessionRepository(db);
-      final sets = ExerciseSetRepository(db);
+      // Phase 2: reopen DB against the same file, assert round-trip.
+      {
+        final db = AppDatabase.forTesting(NativeDatabase(File(dbPath)));
+        final food = FoodEntryRepository(db);
+        final weight = BodyWeightLogRepository(db);
+        final sessions = WorkoutSessionRepository(db);
+        final sets = ExerciseSetRepository(db);
 
-      final foodRows = await food.listAll();
-      expect(foodRows, hasLength(2));
-      final byName = {for (final r in foodRows) r.name: r};
-      expect(byName['Eggs']!.kcal, 140);
-      expect(byName['Eggs']!.proteinG, 12.0);
-      expect(byName['Eggs']!.mealType, MealType.breakfast);
-      expect(byName['Chicken']!.kcal, 310);
+        final foodRows = await food.listAll();
+        expect(foodRows, hasLength(2));
+        final byName = {for (final r in foodRows) r.name: r};
+        expect(byName['Eggs']!.kcal, 140);
+        expect(byName['Eggs']!.proteinG, 12.0);
+        expect(byName['Eggs']!.mealType, MealType.breakfast);
+        expect(byName['Chicken']!.kcal, 310);
 
-      final totals = await food.watchDailyTotals(today).first;
-      expect(totals.kcal, 450);
-      expect(totals.proteinG, closeTo(57.0, 1e-9));
+        final totals = await food.watchDailyTotals(today).first;
+        expect(totals.kcal, 450);
+        expect(totals.proteinG, closeTo(57.0, 1e-9));
 
-      final weightRows = await weight.listAll();
-      expect(weightRows, hasLength(1));
-      expect(weightRows.first.value, 80.0);
-      expect(weightRows.first.unit, WeightUnit.kg);
+        final weightRows = await weight.listAll();
+        expect(weightRows, hasLength(1));
+        expect(weightRows.first.value, 80.0);
+        expect(weightRows.first.unit, WeightUnit.kg);
 
-      final sessionRows = await sessions.listAll();
-      expect(sessionRows, hasLength(1));
-      expect(sessionRows.first.id, sessionId);
+        final sessionRows = await sessions.listAll();
+        expect(sessionRows, hasLength(1));
+        expect(sessionRows.first.id, sessionId);
 
-      final setRows = await sets.listForSession(sessionId);
-      expect(setRows, hasLength(2));
-      expect(setRows[0].orderIndex, 0);
-      expect(setRows[0].weight, 80.0);
-      expect(setRows[1].orderIndex, 1);
-      expect(setRows[1].weight, 82.5);
-      expect(setRows.every((s) => s.status == WorkoutSetStatus.completed), isTrue);
+        final setRows = await sets.listForSession(sessionId);
+        expect(setRows, hasLength(2));
+        expect(setRows[0].orderIndex, 0);
+        expect(setRows[0].weight, 80.0);
+        expect(setRows[1].orderIndex, 1);
+        expect(setRows[1].weight, 82.5);
+        expect(
+          setRows.every((s) => s.status == WorkoutSetStatus.completed),
+          isTrue,
+        );
 
-      await db.close();
-    }
-  });
+        await db.close();
+      }
+    },
+  );
 }

--- a/test/data/routine_repository_test.dart
+++ b/test/data/routine_repository_test.dart
@@ -1,0 +1,496 @@
+// Unit tests for `RoutineRepository` (schema v4, issue #52).
+//
+// Mirrors the shape of `exercise_repository_test.dart`: an in-memory
+// Drift DB, the repo under test, full CRUD on both parent (routines)
+// and child (routine_exercises) rows, plus reorder + cascade-delete
+// assertions. Routines don't exist without exercises in the catalog,
+// so each test seeds a couple of `Exercises` rows up-front to satisfy
+// the `routine_exercises.exerciseId` FK.
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/data/repositories/exercise_repository.dart';
+import 'package:liftlog_app/data/repositories/exercise_set_repository.dart';
+import 'package:liftlog_app/data/repositories/routine_repository.dart';
+import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
+
+void main() {
+  late AppDatabase db;
+  late RoutineRepository repo;
+  late ExerciseRepository exerciseRepo;
+  late int benchId;
+  late int squatId;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = RoutineRepository(db);
+    exerciseRepo = ExerciseRepository(db);
+    // Seed the exercises catalog so routine_exercises FKs resolve.
+    final bench = await exerciseRepo.addIfMissing(
+      'Bench Press',
+      source: Source.userEntered,
+    );
+    final squat = await exerciseRepo.addIfMissing(
+      'Squat',
+      source: Source.userEntered,
+    );
+    benchId = bench.id;
+    squatId = squat.id;
+  });
+
+  tearDown(() async => db.close());
+
+  group('routines CRUD', () {
+    test('add + findById + listAll round-trip', () async {
+      final id = await repo.add(
+        RoutinesCompanion.insert(
+          name: 'Push A',
+          createdAt: DateTime(2026, 4, 20, 12),
+        ),
+      );
+      expect(id, isPositive);
+
+      final found = await repo.findById(id);
+      expect(found, isNotNull);
+      expect(found!.name, 'Push A');
+      expect(found.notes, isNull);
+      expect(
+        found.source,
+        Source.userEntered,
+        reason: 'source defaults to userEntered per schema DEFAULT',
+      );
+
+      final all = await repo.listAll();
+      expect(all, hasLength(1));
+      expect(all.single.id, id);
+    });
+
+    test('findById returns null for unknown id', () async {
+      expect(await repo.findById(999), isNull);
+    });
+
+    test('update writes every column (including cleared notes)', () async {
+      final id = await repo.add(
+        RoutinesCompanion.insert(
+          name: 'Push A',
+          notes: const Value('initial notes'),
+          createdAt: DateTime(2026, 4, 20, 12),
+        ),
+      );
+      final routine = (await repo.findById(id))!;
+
+      // Update name + clear notes. `replace` (not `write`) is the
+      // trust-rule compliant path — `write` would silently preserve
+      // the cleared `notes` via `nullToAbsent: true`.
+      final edited = routine.copyWith(
+        name: 'Push A (revised)',
+        notes: const Value(null),
+      );
+      await repo.update(edited);
+
+      final after = (await repo.findById(id))!;
+      expect(after.name, 'Push A (revised)');
+      expect(after.notes, isNull, reason: 'cleared notes must stay cleared');
+    });
+
+    test('delete removes the routine', () async {
+      final id = await repo.add(
+        RoutinesCompanion.insert(
+          name: 'Push A',
+          createdAt: DateTime(2026, 4, 20, 12),
+        ),
+      );
+      expect(await repo.findById(id), isNotNull);
+      final deleted = await repo.delete(id);
+      expect(deleted, 1);
+      expect(await repo.findById(id), isNull);
+    });
+
+    test(
+      'listAll orders newest-first by createdAt (id DESC as tiebreak)',
+      () async {
+        await repo.add(
+          RoutinesCompanion.insert(
+            name: 'Oldest',
+            createdAt: DateTime(2026, 4, 1),
+          ),
+        );
+        await repo.add(
+          RoutinesCompanion.insert(
+            name: 'Middle',
+            createdAt: DateTime(2026, 4, 10),
+          ),
+        );
+        await repo.add(
+          RoutinesCompanion.insert(
+            name: 'Newest',
+            createdAt: DateTime(2026, 4, 20),
+          ),
+        );
+
+        final all = await repo.listAll();
+        expect(all.map((r) => r.name).toList(), ['Newest', 'Middle', 'Oldest']);
+      },
+    );
+
+    test('watchAll emits rows ordered newest-first', () async {
+      await repo.add(
+        RoutinesCompanion.insert(
+          name: 'Older',
+          createdAt: DateTime(2026, 4, 10),
+        ),
+      );
+      await repo.add(
+        RoutinesCompanion.insert(
+          name: 'Newer',
+          createdAt: DateTime(2026, 4, 20),
+        ),
+      );
+
+      final rows = await repo.watchAll().first;
+      expect(rows.map((r) => r.name).toList(), ['Newer', 'Older']);
+    });
+  });
+
+  group('routine_exercises CRUD', () {
+    late int routineId;
+
+    setUp(() async {
+      routineId = await repo.add(
+        RoutinesCompanion.insert(
+          name: 'Push A',
+          createdAt: DateTime(2026, 4, 20, 12),
+        ),
+      );
+    });
+
+    test('addExercise + listExercises round-trip with every field', () async {
+      final id = await repo.addExercise(
+        RoutineExercisesCompanion.insert(
+          routineId: routineId,
+          exerciseId: benchId,
+          orderIndex: 0,
+          targetSets: const Value(4),
+          targetReps: const Value(8),
+          targetWeight: const Value(80.0),
+          targetWeightUnit: const Value(WeightUnit.kg),
+        ),
+      );
+      expect(id, isPositive);
+
+      final rows = await repo.listExercises(routineId);
+      expect(rows, hasLength(1));
+      final row = rows.single;
+      expect(row.routineId, routineId);
+      expect(row.exerciseId, benchId);
+      expect(row.orderIndex, 0);
+      expect(row.targetSets, 4);
+      expect(row.targetReps, 8);
+      expect(row.targetWeight, 80.0);
+      expect(row.targetWeightUnit, WeightUnit.kg);
+    });
+
+    test('addExercise accepts all-null target fields', () async {
+      final id = await repo.addExercise(
+        RoutineExercisesCompanion.insert(
+          routineId: routineId,
+          exerciseId: benchId,
+          orderIndex: 0,
+        ),
+      );
+      final row = (await repo.listExercises(routineId)).single;
+      expect(row.id, id);
+      expect(row.targetSets, isNull);
+      expect(row.targetReps, isNull);
+      expect(row.targetWeight, isNull);
+      expect(row.targetWeightUnit, isNull);
+    });
+
+    test(
+      'listExercises returns rows ordered by orderIndex ascending',
+      () async {
+        // Insert in a non-sorted order to prove the query sorts.
+        await repo.addExercise(
+          RoutineExercisesCompanion.insert(
+            routineId: routineId,
+            exerciseId: squatId,
+            orderIndex: 2,
+          ),
+        );
+        await repo.addExercise(
+          RoutineExercisesCompanion.insert(
+            routineId: routineId,
+            exerciseId: benchId,
+            orderIndex: 0,
+          ),
+        );
+        await repo.addExercise(
+          RoutineExercisesCompanion.insert(
+            routineId: routineId,
+            exerciseId: squatId,
+            orderIndex: 1,
+          ),
+        );
+
+        final rows = await repo.listExercises(routineId);
+        expect(rows.map((r) => r.orderIndex).toList(), [0, 1, 2]);
+      },
+    );
+
+    test('watchExercises emits rows ordered by orderIndex ascending', () async {
+      await repo.addExercise(
+        RoutineExercisesCompanion.insert(
+          routineId: routineId,
+          exerciseId: benchId,
+          orderIndex: 1,
+        ),
+      );
+      await repo.addExercise(
+        RoutineExercisesCompanion.insert(
+          routineId: routineId,
+          exerciseId: squatId,
+          orderIndex: 0,
+        ),
+      );
+
+      final rows = await repo.watchExercises(routineId).first;
+      expect(rows.map((r) => r.orderIndex).toList(), [0, 1]);
+    });
+
+    test('listExercises for a different routine does not leak rows', () async {
+      final otherId = await repo.add(
+        RoutinesCompanion.insert(
+          name: 'Pull A',
+          createdAt: DateTime(2026, 4, 20, 13),
+        ),
+      );
+      await repo.addExercise(
+        RoutineExercisesCompanion.insert(
+          routineId: routineId,
+          exerciseId: benchId,
+          orderIndex: 0,
+        ),
+      );
+      await repo.addExercise(
+        RoutineExercisesCompanion.insert(
+          routineId: otherId,
+          exerciseId: squatId,
+          orderIndex: 0,
+        ),
+      );
+
+      final a = await repo.listExercises(routineId);
+      final b = await repo.listExercises(otherId);
+      expect(a, hasLength(1));
+      expect(b, hasLength(1));
+      expect(a.single.exerciseId, benchId);
+      expect(b.single.exerciseId, squatId);
+    });
+  });
+
+  group('reorderExercises', () {
+    late int routineId;
+    late List<int> originalIds;
+
+    setUp(() async {
+      routineId = await repo.add(
+        RoutinesCompanion.insert(
+          name: 'Push A',
+          createdAt: DateTime(2026, 4, 20, 12),
+        ),
+      );
+      final aId = await repo.addExercise(
+        RoutineExercisesCompanion.insert(
+          routineId: routineId,
+          exerciseId: benchId,
+          orderIndex: 0,
+        ),
+      );
+      final bId = await repo.addExercise(
+        RoutineExercisesCompanion.insert(
+          routineId: routineId,
+          exerciseId: squatId,
+          orderIndex: 1,
+        ),
+      );
+      final cId = await repo.addExercise(
+        RoutineExercisesCompanion.insert(
+          routineId: routineId,
+          exerciseId: benchId,
+          orderIndex: 2,
+        ),
+      );
+      originalIds = [aId, bId, cId];
+    });
+
+    test('rewrites order_index in caller-supplied order', () async {
+      // Reverse the order: c, b, a.
+      await repo.reorderExercises(routineId, [
+        originalIds[2],
+        originalIds[1],
+        originalIds[0],
+      ]);
+
+      final rows = await repo.listExercises(routineId);
+      expect(rows.map((r) => r.id).toList(), [
+        originalIds[2],
+        originalIds[1],
+        originalIds[0],
+      ]);
+      expect(rows.map((r) => r.orderIndex).toList(), [0, 1, 2]);
+    });
+
+    test('ignores ids that belong to a different routine', () async {
+      // A second routine with one exercise — its id must not be
+      // rewritten by a reorder scoped to the first routine.
+      final otherId = await repo.add(
+        RoutinesCompanion.insert(
+          name: 'Pull A',
+          createdAt: DateTime(2026, 4, 20, 13),
+        ),
+      );
+      final strayId = await repo.addExercise(
+        RoutineExercisesCompanion.insert(
+          routineId: otherId,
+          exerciseId: squatId,
+          orderIndex: 99,
+        ),
+      );
+
+      // Caller mistakenly includes `strayId` — the per-row where clause
+      // on `routineId` must keep the stray row untouched.
+      await repo.reorderExercises(routineId, [strayId, ...originalIds]);
+
+      final strayRow = (await repo.listExercises(otherId)).single;
+      expect(strayRow.id, strayId);
+      expect(
+        strayRow.orderIndex,
+        99,
+        reason: 'stray routine_exercise row must not be reindexed',
+      );
+    });
+
+    test('leaves non-targeted columns alone', () async {
+      // Attach targets to one row; after reorder those targets should
+      // still be intact (partial column update via `.write()`).
+      final rowsBefore = await repo.listExercises(routineId);
+      final mid = rowsBefore[1];
+      await db
+          .update(db.routineExercises)
+          .replace(
+            mid.copyWith(
+              targetSets: const Value(5),
+              targetReps: const Value(5),
+              targetWeight: const Value(100.0),
+              targetWeightUnit: const Value(WeightUnit.kg),
+            ),
+          );
+
+      await repo.reorderExercises(routineId, [
+        originalIds[2],
+        originalIds[1],
+        originalIds[0],
+      ]);
+
+      final updated = (await repo.listExercises(
+        routineId,
+      )).firstWhere((r) => r.id == mid.id);
+      expect(updated.targetSets, 5);
+      expect(updated.targetReps, 5);
+      expect(updated.targetWeight, 100.0);
+      expect(updated.targetWeightUnit, WeightUnit.kg);
+    });
+  });
+
+  group('cascade delete', () {
+    test('deleting a routine removes its exercises', () async {
+      final routineId = await repo.add(
+        RoutinesCompanion.insert(
+          name: 'Push A',
+          createdAt: DateTime(2026, 4, 20, 12),
+        ),
+      );
+      await repo.addExercise(
+        RoutineExercisesCompanion.insert(
+          routineId: routineId,
+          exerciseId: benchId,
+          orderIndex: 0,
+        ),
+      );
+      await repo.addExercise(
+        RoutineExercisesCompanion.insert(
+          routineId: routineId,
+          exerciseId: squatId,
+          orderIndex: 1,
+        ),
+      );
+
+      expect(await repo.listExercises(routineId), hasLength(2));
+
+      await repo.delete(routineId);
+
+      expect(
+        await repo.listExercises(routineId),
+        isEmpty,
+        reason: 'ON DELETE CASCADE must remove the lineup',
+      );
+      expect(
+        await repo.listAllExercises(),
+        isEmpty,
+        reason: 'no orphan routine_exercises rows should survive the cascade',
+      );
+    });
+
+    test(
+      'deleting a routine does not touch unrelated ExerciseSet rows',
+      () async {
+        // Create a real workout session + its sets. These live on
+        // `workout_sessions` / `exercise_sets`, not on routines.
+        final sessions = WorkoutSessionRepository(db);
+        final sets = ExerciseSetRepository(db);
+        final sessionId = await sessions.add(
+          WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 22, 9)),
+        );
+        await sets.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: sessionId,
+            exerciseName: 'Bench Press',
+            reps: 8,
+            weight: 80.0,
+            weightUnit: WeightUnit.kg,
+            status: WorkoutSetStatus.completed,
+            orderIndex: 0,
+          ),
+        );
+
+        // Create a routine + lineup, then delete the routine.
+        final routineId = await repo.add(
+          RoutinesCompanion.insert(
+            name: 'Push A',
+            createdAt: DateTime(2026, 4, 20, 12),
+          ),
+        );
+        await repo.addExercise(
+          RoutineExercisesCompanion.insert(
+            routineId: routineId,
+            exerciseId: benchId,
+            orderIndex: 0,
+          ),
+        );
+
+        await repo.delete(routineId);
+
+        // The routine's lineup is gone …
+        expect(await repo.listExercises(routineId), isEmpty);
+        // … but the real workout's sets are untouched.
+        final remaining = await sets.listForSession(sessionId);
+        expect(remaining, hasLength(1));
+        expect(remaining.single.exerciseName, 'Bench Press');
+      },
+    );
+  });
+}

--- a/test/features/export/export_service_test.dart
+++ b/test/features/export/export_service_test.dart
@@ -18,8 +18,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:liftlog_app/data/database.dart';
 import 'package:liftlog_app/data/enums.dart';
 import 'package:liftlog_app/data/repositories/body_weight_log_repository.dart';
+import 'package:liftlog_app/data/repositories/exercise_repository.dart';
 import 'package:liftlog_app/data/repositories/exercise_set_repository.dart';
 import 'package:liftlog_app/data/repositories/food_entry_repository.dart';
+import 'package:liftlog_app/data/repositories/routine_repository.dart';
 import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
 import 'package:liftlog_app/features/export/export_service.dart';
 
@@ -29,6 +31,8 @@ void main() {
   late BodyWeightLogRepository weights;
   late WorkoutSessionRepository sessions;
   late ExerciseSetRepository sets;
+  late ExerciseRepository exerciseCatalog;
+  late RoutineRepository routines;
 
   setUp(() {
     db = AppDatabase.forTesting(NativeDatabase.memory());
@@ -36,6 +40,8 @@ void main() {
     weights = BodyWeightLogRepository(db);
     sessions = WorkoutSessionRepository(db);
     sets = ExerciseSetRepository(db);
+    exerciseCatalog = ExerciseRepository(db);
+    routines = RoutineRepository(db);
   });
 
   tearDown(() async => db.close());
@@ -50,64 +56,114 @@ void main() {
   Future<void> seedAll() async {
     // Food entries — insertion order deliberately scrambles timestamp
     // vs id so the sort-by-id assertion isn't trivially satisfied.
-    await foods.add(FoodEntriesCompanion.insert(
-      timestamp: DateTime.utc(2026, 4, 23, 8, 30),
-      name: const Value('Eggs'),
-      kcal: 140,
-      proteinG: 12.0,
-      mealType: MealType.breakfast,
-      entryType: FoodEntryType.manual,
-    ));
-    await foods.add(FoodEntriesCompanion.insert(
-      timestamp: DateTime.utc(2026, 4, 22, 13, 15),
-      name: const Value('Eyeball guac'),
-      kcal: 300,
-      proteinG: 3.5,
-      mealType: MealType.snack,
-      entryType: FoodEntryType.estimate,
-      note: const Value('rough'),
-    ));
+    await foods.add(
+      FoodEntriesCompanion.insert(
+        timestamp: DateTime.utc(2026, 4, 23, 8, 30),
+        name: const Value('Eggs'),
+        kcal: 140,
+        proteinG: 12.0,
+        mealType: MealType.breakfast,
+        entryType: FoodEntryType.manual,
+      ),
+    );
+    await foods.add(
+      FoodEntriesCompanion.insert(
+        timestamp: DateTime.utc(2026, 4, 22, 13, 15),
+        name: const Value('Eyeball guac'),
+        kcal: 300,
+        proteinG: 3.5,
+        mealType: MealType.snack,
+        entryType: FoodEntryType.estimate,
+        note: const Value('rough'),
+      ),
+    );
 
     // Body weight logs — two units to catch remap bugs.
-    await weights.add(BodyWeightLogsCompanion.insert(
-      timestamp: DateTime.utc(2026, 4, 23, 7),
-      value: 80.5,
-      unit: WeightUnit.kg,
-    ));
-    await weights.add(BodyWeightLogsCompanion.insert(
-      timestamp: DateTime.utc(2026, 4, 22, 7),
-      value: 177.5,
-      unit: WeightUnit.lb,
-    ));
+    await weights.add(
+      BodyWeightLogsCompanion.insert(
+        timestamp: DateTime.utc(2026, 4, 23, 7),
+        value: 80.5,
+        unit: WeightUnit.kg,
+      ),
+    );
+    await weights.add(
+      BodyWeightLogsCompanion.insert(
+        timestamp: DateTime.utc(2026, 4, 22, 7),
+        value: 177.5,
+        unit: WeightUnit.lb,
+      ),
+    );
 
     // Workout sessions — one completed, one in progress (null endedAt).
-    final completedId = await sessions.add(WorkoutSessionsCompanion.insert(
-      startedAt: DateTime.utc(2026, 4, 21, 18),
-      endedAt: Value(DateTime.utc(2026, 4, 21, 19, 5)),
-    ));
-    await sessions.add(WorkoutSessionsCompanion.insert(
-      startedAt: DateTime.utc(2026, 4, 23, 18),
-    ));
+    final completedId = await sessions.add(
+      WorkoutSessionsCompanion.insert(
+        startedAt: DateTime.utc(2026, 4, 21, 18),
+        endedAt: Value(DateTime.utc(2026, 4, 21, 19, 5)),
+      ),
+    );
+    await sessions.add(
+      WorkoutSessionsCompanion.insert(startedAt: DateTime.utc(2026, 4, 23, 18)),
+    );
 
     // Sets on the completed session. Include a skipped one.
-    await sets.add(ExerciseSetsCompanion.insert(
-      sessionId: completedId,
-      exerciseName: 'Bench Press',
-      reps: 8,
-      weight: 80.0,
-      weightUnit: WeightUnit.kg,
-      status: WorkoutSetStatus.completed,
-      orderIndex: 0,
-    ));
-    await sets.add(ExerciseSetsCompanion.insert(
-      sessionId: completedId,
-      exerciseName: 'Bench Press',
-      reps: 8,
-      weight: 80.0,
-      weightUnit: WeightUnit.kg,
-      status: WorkoutSetStatus.skipped,
-      orderIndex: 1,
-    ));
+    await sets.add(
+      ExerciseSetsCompanion.insert(
+        sessionId: completedId,
+        exerciseName: 'Bench Press',
+        reps: 8,
+        weight: 80.0,
+        weightUnit: WeightUnit.kg,
+        status: WorkoutSetStatus.completed,
+        orderIndex: 0,
+      ),
+    );
+    await sets.add(
+      ExerciseSetsCompanion.insert(
+        sessionId: completedId,
+        exerciseName: 'Bench Press',
+        reps: 8,
+        weight: 80.0,
+        weightUnit: WeightUnit.kg,
+        status: WorkoutSetStatus.skipped,
+        orderIndex: 1,
+      ),
+    );
+
+    // Routines + line items (schema v4, issue #52). Seed one routine
+    // with two lineup entries — one fully targeted, one with every
+    // target field null — so the export proves both paths.
+    final bench = await exerciseCatalog.addIfMissing(
+      'Bench Press',
+      source: Source.userEntered,
+    );
+    final squat = await exerciseCatalog.addIfMissing(
+      'Squat',
+      source: Source.userEntered,
+    );
+    final routineId = await routines.add(
+      RoutinesCompanion.insert(
+        name: 'Push A',
+        createdAt: DateTime.utc(2026, 4, 20, 12),
+      ),
+    );
+    await routines.addExercise(
+      RoutineExercisesCompanion.insert(
+        routineId: routineId,
+        exerciseId: bench.id,
+        orderIndex: 0,
+        targetSets: const Value(4),
+        targetReps: const Value(8),
+        targetWeight: const Value(80.0),
+        targetWeightUnit: const Value(WeightUnit.kg),
+      ),
+    );
+    await routines.addExercise(
+      RoutineExercisesCompanion.insert(
+        routineId: routineId,
+        exerciseId: squat.id,
+        orderIndex: 1,
+      ),
+    );
   }
 
   test('top-level keys are exactly meta + four entity arrays', () async {
@@ -127,6 +183,8 @@ void main() {
         'body_weight_logs',
         'workout_sessions',
         'exercise_sets',
+        'routines',
+        'routine_exercises',
       },
       reason: 'exact set of top-level keys is part of the format contract',
     );
@@ -153,6 +211,8 @@ void main() {
     expect(counts['body_weight_logs'], 2);
     expect(counts['workout_sessions'], 2);
     expect(counts['exercise_sets'], 2);
+    expect(counts['routines'], 1);
+    expect(counts['routine_exercises'], 2);
   });
 
   test('food entry every-field round-trip with enum + null note', () async {
@@ -215,8 +275,7 @@ void main() {
     expect(lbLog['unit'], 'lb');
   });
 
-  test('workout session serializes ended_at as null for in-progress',
-      () async {
+  test('workout session serializes ended_at as null for in-progress', () async {
     await seedAll();
 
     final json = await buildExportJson(
@@ -279,8 +338,11 @@ void main() {
     final now = DateTime.utc(2026, 4, 24, 9, 14);
     final a = await buildExportJson(db: db, now: now);
     final b = await buildExportJson(db: db, now: now);
-    expect(a, b,
-        reason: 'determinism: same DB + same `now` must emit identical bytes');
+    expect(
+      a,
+      b,
+      reason: 'determinism: same DB + same `now` must emit identical bytes',
+    );
   });
 
   test('each entity array is sorted by id ascending', () async {
@@ -292,16 +354,16 @@ void main() {
     );
     final decoded = jsonDecode(json) as Map<String, dynamic>;
 
-    List<int> ids(String key) => (decoded[key] as List)
-        .cast<Map>()
-        .map((m) => m['id'] as int)
-        .toList();
+    List<int> ids(String key) =>
+        (decoded[key] as List).cast<Map>().map((m) => m['id'] as int).toList();
 
     for (final key in [
       'food_entries',
       'body_weight_logs',
       'workout_sessions',
       'exercise_sets',
+      'routines',
+      'routine_exercises',
     ]) {
       final got = ids(key);
       final expected = [...got]..sort();
@@ -327,39 +389,110 @@ void main() {
       'daily_summary',
       'daily_summaries',
     ]) {
-      expect(json.contains(forbidden), isFalse,
-          reason: 'derived key "$forbidden" must not appear in export');
+      expect(
+        json.contains(forbidden),
+        isFalse,
+        reason: 'derived key "$forbidden" must not appear in export',
+      );
     }
   });
 
-  test('empty database still produces a valid shape with zero counts',
-      () async {
-    // No seed. Exports against an empty DB should still emit the full
-    // shape with empty arrays and zeroed counts — a freshly-installed
-    // app tapping "export" must not crash.
-    final json = await buildExportJson(
-      db: db,
-      now: DateTime.utc(2026, 4, 24, 9, 14),
-    );
-    final decoded = jsonDecode(json) as Map<String, dynamic>;
+  test(
+    'empty database still produces a valid shape with zero counts',
+    () async {
+      // No seed. Exports against an empty DB should still emit the full
+      // shape with empty arrays and zeroed counts — a freshly-installed
+      // app tapping "export" must not crash.
+      final json = await buildExportJson(
+        db: db,
+        now: DateTime.utc(2026, 4, 24, 9, 14),
+      );
+      final decoded = jsonDecode(json) as Map<String, dynamic>;
 
-    expect(decoded.keys.toSet(), {
-      'meta',
-      'food_entries',
-      'body_weight_logs',
-      'workout_sessions',
-      'exercise_sets',
-    });
-    expect((decoded['food_entries'] as List), isEmpty);
-    expect((decoded['body_weight_logs'] as List), isEmpty);
-    expect((decoded['workout_sessions'] as List), isEmpty);
-    expect((decoded['exercise_sets'] as List), isEmpty);
+      expect(decoded.keys.toSet(), {
+        'meta',
+        'food_entries',
+        'body_weight_logs',
+        'workout_sessions',
+        'exercise_sets',
+        'routines',
+        'routine_exercises',
+      });
+      expect((decoded['food_entries'] as List), isEmpty);
+      expect((decoded['body_weight_logs'] as List), isEmpty);
+      expect((decoded['workout_sessions'] as List), isEmpty);
+      expect((decoded['exercise_sets'] as List), isEmpty);
+      expect((decoded['routines'] as List), isEmpty);
+      expect((decoded['routine_exercises'] as List), isEmpty);
 
-    final counts =
-        (decoded['meta'] as Map<String, dynamic>)['counts'] as Map;
-    expect(counts['food_entries'], 0);
-    expect(counts['body_weight_logs'], 0);
-    expect(counts['workout_sessions'], 0);
-    expect(counts['exercise_sets'], 0);
-  });
+      final counts = (decoded['meta'] as Map<String, dynamic>)['counts'] as Map;
+      expect(counts['food_entries'], 0);
+      expect(counts['body_weight_logs'], 0);
+      expect(counts['workout_sessions'], 0);
+      expect(counts['exercise_sets'], 0);
+      expect(counts['routines'], 0);
+      expect(counts['routine_exercises'], 0);
+    },
+  );
+
+  test(
+    'routines every-field round-trip with source + nullable notes',
+    () async {
+      await seedAll();
+
+      final json = await buildExportJson(
+        db: db,
+        now: DateTime.utc(2026, 4, 24, 9, 14),
+      );
+      final decoded = jsonDecode(json) as Map<String, dynamic>;
+      final list = (decoded['routines'] as List).cast<Map>();
+      expect(list, hasLength(1));
+
+      final r = list.single;
+      expect(r['id'], 1);
+      expect(r['name'], 'Push A');
+      expect(r['notes'], isNull);
+      expect(r['created_at'], '2026-04-20T12:00:00.000Z');
+      // Source.userEntered is the default applied by the schema.
+      expect(r['source'], 'userEntered');
+    },
+  );
+
+  test(
+    'routine_exercises every-field round-trip including all-null targets',
+    () async {
+      await seedAll();
+
+      final json = await buildExportJson(
+        db: db,
+        now: DateTime.utc(2026, 4, 24, 9, 14),
+      );
+      final decoded = jsonDecode(json) as Map<String, dynamic>;
+      final list = (decoded['routine_exercises'] as List).cast<Map>();
+      expect(list, hasLength(2));
+
+      // First row — fully-targeted lineup entry.
+      final first = list[0];
+      expect(first['id'], 1);
+      expect(first['routine_id'], 1);
+      expect(first['exercise_id'], isA<int>());
+      expect(first['order_index'], 0);
+      expect(first['target_sets'], 4);
+      expect(first['target_reps'], 8);
+      expect(first['target_weight'], 80.0);
+      expect(first['target_weight_unit'], 'kg');
+
+      // Second row — every target column null.
+      final second = list[1];
+      expect(second['id'], 2);
+      expect(second['routine_id'], 1);
+      expect(second['order_index'], 1);
+      expect(second['target_sets'], isNull);
+      expect(second['target_reps'], isNull);
+      expect(second['target_weight'], isNull);
+      // Null enum serializes as JSON null and the key is always present.
+      expect(second.containsKey('target_weight_unit'), isTrue);
+      expect(second['target_weight_unit'], isNull);
+    },
+  );
 }

--- a/test/features/export/import_service_test.dart
+++ b/test/features/export/import_service_test.dart
@@ -22,8 +22,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:liftlog_app/data/database.dart';
 import 'package:liftlog_app/data/enums.dart';
 import 'package:liftlog_app/data/repositories/body_weight_log_repository.dart';
+import 'package:liftlog_app/data/repositories/exercise_repository.dart';
 import 'package:liftlog_app/data/repositories/exercise_set_repository.dart';
 import 'package:liftlog_app/data/repositories/food_entry_repository.dart';
+import 'package:liftlog_app/data/repositories/routine_repository.dart';
 import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
 import 'package:liftlog_app/features/export/export_service.dart';
 import 'package:liftlog_app/features/export/import_service.dart';
@@ -34,6 +36,8 @@ void main() {
   late BodyWeightLogRepository weights;
   late WorkoutSessionRepository sessions;
   late ExerciseSetRepository sets;
+  late ExerciseRepository exerciseCatalog;
+  late RoutineRepository routines;
 
   setUp(() {
     db = AppDatabase.forTesting(NativeDatabase.memory());
@@ -41,6 +45,8 @@ void main() {
     weights = BodyWeightLogRepository(db);
     sessions = WorkoutSessionRepository(db);
     sets = ExerciseSetRepository(db);
+    exerciseCatalog = ExerciseRepository(db);
+    routines = RoutineRepository(db);
   });
 
   tearDown(() async => db.close());
@@ -119,6 +125,40 @@ void main() {
         orderIndex: 1,
       ),
     );
+
+    // Routines + lineup entries — round-trip fidelity for schema v4.
+    final bench = await exerciseCatalog.addIfMissing(
+      'Bench Press',
+      source: Source.userEntered,
+    );
+    final squat = await exerciseCatalog.addIfMissing(
+      'Squat',
+      source: Source.userEntered,
+    );
+    final routineId = await routines.add(
+      RoutinesCompanion.insert(
+        name: 'Push A',
+        createdAt: DateTime.utc(2026, 4, 20, 12),
+      ),
+    );
+    await routines.addExercise(
+      RoutineExercisesCompanion.insert(
+        routineId: routineId,
+        exerciseId: bench.id,
+        orderIndex: 0,
+        targetSets: const Value(4),
+        targetReps: const Value(8),
+        targetWeight: const Value(80.0),
+        targetWeightUnit: const Value(WeightUnit.kg),
+      ),
+    );
+    await routines.addExercise(
+      RoutineExercisesCompanion.insert(
+        routineId: routineId,
+        exerciseId: squat.id,
+        orderIndex: 1,
+      ),
+    );
   }
 
   test('round-trip: export + importReplacing preserves every field', () async {
@@ -136,6 +176,10 @@ void main() {
       ..sort((a, b) => a.id.compareTo(b.id));
     final preSets = [...await sets.listAll()]
       ..sort((a, b) => a.id.compareTo(b.id));
+    final preRoutines = [...await routines.listAll()]
+      ..sort((a, b) => a.id.compareTo(b.id));
+    final preRoutineExercises = [...await routines.listAllExercises()]
+      ..sort((a, b) => a.id.compareTo(b.id));
 
     // Wipe + re-import via the replacing path.
     final result = await importJsonReplacing(
@@ -147,7 +191,12 @@ void main() {
     expect(result, isA<ImportSuccess>());
     expect(
       (result as ImportSuccess).rowsImported,
-      preFoods.length + preWeights.length + preSessions.length + preSets.length,
+      preFoods.length +
+          preWeights.length +
+          preSessions.length +
+          preSets.length +
+          preRoutines.length +
+          preRoutineExercises.length,
     );
 
     final postFoods = [...await foods.listAll()]
@@ -205,6 +254,35 @@ void main() {
       expect(b.weightUnit, a.weightUnit);
       expect(b.status, a.status);
       expect(b.orderIndex, a.orderIndex);
+    }
+
+    final postRoutines = [...await routines.listAll()]
+      ..sort((a, b) => a.id.compareTo(b.id));
+    expect(postRoutines.length, preRoutines.length);
+    for (var i = 0; i < preRoutines.length; i++) {
+      final a = preRoutines[i];
+      final b = postRoutines[i];
+      expect(b.id, a.id);
+      expect(b.name, a.name);
+      expect(b.notes, a.notes);
+      expect(b.createdAt.toUtc(), a.createdAt.toUtc());
+      expect(b.source, a.source);
+    }
+
+    final postRoutineExercises = [...await routines.listAllExercises()]
+      ..sort((a, b) => a.id.compareTo(b.id));
+    expect(postRoutineExercises.length, preRoutineExercises.length);
+    for (var i = 0; i < preRoutineExercises.length; i++) {
+      final a = preRoutineExercises[i];
+      final b = postRoutineExercises[i];
+      expect(b.id, a.id);
+      expect(b.routineId, a.routineId);
+      expect(b.exerciseId, a.exerciseId);
+      expect(b.orderIndex, a.orderIndex);
+      expect(b.targetSets, a.targetSets);
+      expect(b.targetReps, a.targetReps);
+      expect(b.targetWeight, a.targetWeight);
+      expect(b.targetWeightUnit, a.targetWeightUnit);
     }
   });
 
@@ -273,7 +351,9 @@ void main() {
         preFoodCount +
         (await weights.listAll()).length +
         (await sessions.listAll()).length +
-        (await sets.listAll()).length;
+        (await sets.listAll()).length +
+        (await routines.listAll()).length +
+        (await routines.listAllExercises()).length;
 
     // Build a valid payload from the current DB; importing it into the
     // same (non-empty) DB under safe mode must refuse.


### PR DESCRIPTION
## Summary
- Adds `routines` + `routine_exercises` tables via an additive-only v3 → v4 Drift migration. No data transform on existing tables — the new `if (from < 4)` branch only calls `createTable`. Backup path landed earlier in Runbooks per the platform-risk guardrail.
- Lands `RoutineRepository` with full CRUD on both tables, `watchAll`/`listAll` pairs (trust-rule: every watcher has a one-shot sibling), `listExercises` ordered by `orderIndex`, and a transactional `reorderExercises`. Registered via `routineRepositoryProvider`.
- Extends the export + import services with `"routines"` + `"routine_exercises"` sections. Every field serialized in snake_case with ISO-8601 UTC timestamps and enum `.name` strings. **`format_version` intentionally stays at `"1"`** — new keys are additive, old importers ignore unknown keys, and the import service treats missing keys as empty lists. Same reasoning used for the S5.1 `source` column addition.

## Non-goals
- No UI this sprint. No "start workout from routine" yet.
- No routine templates, samples, or sharing.

## Schema v3 → v4
Additive only; `schemaVersion` bumps 3 → 4; `onUpgrade` gains a `from < 4` branch after the existing `from < 3` work.

- `routines` — id, name, nullable notes, createdAt, provenance `source` (defaulted to `'userEntered'`).
- `routine_exercises` — FK `routineId → routines.id ON DELETE CASCADE`, FK `exerciseId → exercises.id`, `orderIndex`, and nullable targets (`targetSets`, `targetReps`, `targetWeight`, `targetWeightUnit`).

## Arch-rule callout — `reorderExercises`
Initially wrote the reorder as `.write(RoutineExercisesCompanion(orderIndex: Value(i)))` with a `// drift-write-ok:` marker. `dart format` broke `.write(` onto its own line, which the arch test scans line-by-line, so the marker stopped matching. Rewrote as a read-then-replace loop — stays fully compliant with the "replace(), not write()" rule without relying on opt-out markers.

## Source-enum parsing
The arch test forbids `lib/features/**` from referencing `Source.` directly. Added `parseSourceName(String) → Source` in `lib/data/enums.dart` so the import service can resolve the `routines.source` field without constructing a `Source` value raw. Unknown strings throw `ArgumentError`, translated to `ImportMalformed` at the feature-layer parser.

## Test plan
- [x] `dart run build_runner build --delete-conflicting-outputs`
- [x] `flutter analyze` — clean
- [x] `flutter test` — 279 passing (was 245 pre-PR)
- [x] Arch guardrail green
- [x] `test/data/persistence_round_trip_test.dart` "v3 → v4 migration" group: rows survive intact, both new tables exist + empty, routine-exercise FK enforced, cascade delete verified
- [x] `test/data/routine_repository_test.dart`: full CRUD, watch/list ordering, reorder (incl. cross-routine stray-id guard + non-targeted-columns preservation), cascade delete leaves unrelated `ExerciseSet` rows untouched
- [x] Export + import round-trip tests cover routines + routine_exercises with all-null-targets and fully-targeted rows

## Verification

```
flutter analyze
# No issues found!

flutter test
# All tests passed! (279)
```

No new pub dependencies.