### PR TITLE
SPIKE: E3 CloudKit viability — DO NOT MERGE

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -36,7 +36,12 @@ PODS:
     - DKImagePickerController/PhotoGallery
     - Flutter
   - Flutter (1.0.0)
+  - flutter_cloud_kit (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - health (13.3.1):
+    - Flutter
+  - package_info_plus (0.4.5):
     - Flutter
   - SDWebImage (5.21.7):
     - SDWebImage/Core (= 5.21.7)
@@ -69,14 +74,19 @@ PODS:
     - sqlite3/rtree
     - sqlite3/session
   - SwiftyGif (5.4.5)
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
+  - flutter_cloud_kit (from `.symlinks/plugins/flutter_cloud_kit/darwin`)
   - health (from `.symlinks/plugins/health/ios`)
+  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/darwin`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
@@ -93,12 +103,18 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/file_picker/ios"
   Flutter:
     :path: Flutter
+  flutter_cloud_kit:
+    :path: ".symlinks/plugins/flutter_cloud_kit/darwin"
   health:
     :path: ".symlinks/plugins/health/ios"
+  package_info_plus:
+    :path: ".symlinks/plugins/package_info_plus/ios"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   sqlite3_flutter_libs:
     :path: ".symlinks/plugins/sqlite3_flutter_libs/darwin"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
@@ -106,12 +122,15 @@ SPEC CHECKSUMS:
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
   file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_cloud_kit: b19bfaf7b67186062be385d99d8b2ef69d5e99d9
   health: 4decf5d74e8f54c58a8c07a385fc72f629a831d9
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   sqlite3: a51c07cf16e023d6c48abd5e5791a61a47354921
   sqlite3_flutter_libs: b3e120efe9a82017e5552a620f696589ed4f62ab
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
+  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
 
 PODFILE CHECKSUM: bd29822c3d5baf6b44b726f00ea3293a19339ef2
 

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -4,5 +4,17 @@
 <dict>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
+	<!-- SPIKE (issue #63): CloudKit entitlement added on spike/cloudkit-e3-viability. -->
+	<!-- DO NOT MERGE as-is. The container identifier is a placeholder; founder must -->
+	<!-- register it in the Apple Developer portal via Xcode Signing & Capabilities -->
+	<!-- before this can actually bind at runtime. See vault/06 Spikes/E3 CloudKit viability (2026-04-24).md. -->
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.dev.techxtt.liftlogApp</string>
+	</array>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -278,6 +278,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cloud_kit:
+    dependency: "direct main"
+    description:
+      name: flutter_cloud_kit
+      sha256: f3622aa3b3b7476e87f117c2323f48f5f1272af0fede4debb83d02bae8dfa29f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,13 @@ dependencies:
   # win32-5 override goes away.
   package_info_plus: ^9.0.1
 
+  # SPIKE (issue #63): flutter_cloud_kit for E3 CloudKit viability research.
+  # DO NOT MERGE — this dep is on spike/cloudkit-e3-viability only.
+  # MIT, 43 stars, 2-year-old release. Exposes CKContainer / CKDatabase /
+  # CKRecord / CKRecordType queries. Missing CKRecordZone, CKQuerySubscription,
+  # change tokens. Evaluated in vault/06 Spikes/E3 CloudKit viability.
+  flutter_cloud_kit: ^0.0.3
+
   # iOS "Open Settings" deep link from the Settings → HealthKit section
   # (issue #48). Standard Flutter-team-maintained wrapper for
   # `UIApplication.openURL:`. We only use `launchUrl(Uri.parse('app-settings:'))`

--- a/test/spike/cloudkit_poc_test.dart
+++ b/test/spike/cloudkit_poc_test.dart
@@ -1,0 +1,150 @@
+// SPIKE (issue #63): throwaway PoC exercising the flutter_cloud_kit 0.0.3
+// public API shape to document what's actually callable from Dart and what
+// the failure mode looks like under Flutter's test harness (which has no
+// live iOS runtime).
+//
+// This file is NOT production code and lives only on
+// `spike/cloudkit-e3-viability`. It must NOT merge to main.
+//
+// Expected behavior under `flutter test` (no iOS runtime):
+//   - the test compiles and imports succeed (proves the Dart API shape)
+//   - every plugin call throws MissingPluginException because there is no
+//     platform-side handler registered in the test harness
+//   - the test catches those and records them — the point is empirical
+//     evidence of the plugin's Dart surface, not CloudKit round-trips
+//
+// Actual CloudKit reachability requires a physical iPhone or Simulator
+// run signed into iCloud. That is out of scope for this spike per PM
+// policy — the founder will validate on-device post-spike.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_cloud_kit/flutter_cloud_kit.dart';
+import 'package:flutter_cloud_kit/types/cloud_kit_account_status.dart';
+import 'package:flutter_cloud_kit/types/database_scope.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _containerId = 'iCloud.dev.techxtt.liftlogApp';
+const _recordType = 'SpikeRecord';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('flutter_cloud_kit 0.0.3 API shape', () {
+    late FlutterCloudKit cloudKit;
+
+    setUp(() {
+      cloudKit = FlutterCloudKit(containerId: _containerId);
+    });
+
+    test('getAccountStatus is callable; throws MissingPluginException under test harness',
+        () async {
+      try {
+        final CloudKitAccountStatus status = await cloudKit.getAccountStatus();
+        // On an iOS device with no iCloud signed in, expected: CloudKitAccountStatus.noAccount.
+        // Under `flutter test` this branch should NOT fire — the channel is unregistered.
+        fail(
+            'Unexpected success under test harness — got $status. '
+            'A live iOS runtime was not expected here.');
+      } on MissingPluginException catch (e) {
+        // EXPECTED under `flutter test`.
+        // Proves: (1) the Dart API binds, (2) method channel name is
+        // `app.fuelet.flutter_cloud_kit`, (3) the call reached the platform
+        // boundary. CloudKit reachability itself still needs a device run.
+        expect(e.message, contains('getAccountStatus'));
+      }
+    });
+
+    test('saveRecord argument shape (recordType + Map<String,String>)', () async {
+      try {
+        await cloudKit.saveRecord(
+          scope: CloudKitDatabaseScope.private,
+          recordType: _recordType,
+          record: {
+            'spike': 'ok',
+            'timestamp': DateTime.now().toIso8601String(),
+          },
+          recordName: 'spike-record-1',
+        );
+        fail('Unexpected success under test harness.');
+      } on MissingPluginException catch (e) {
+        expect(e.message, contains('saveRecord'));
+      }
+    });
+
+    test('getRecord by recordName', () async {
+      try {
+        await cloudKit.getRecord(
+          scope: CloudKitDatabaseScope.private,
+          recordName: 'spike-record-1',
+        );
+        fail('Unexpected success under test harness.');
+      } on MissingPluginException catch (e) {
+        expect(e.message, contains('getRecord'));
+      }
+    });
+
+    test('getRecordsByType', () async {
+      try {
+        await cloudKit.getRecordsByType(
+          scope: CloudKitDatabaseScope.private,
+          recordType: _recordType,
+        );
+        fail('Unexpected success under test harness.');
+      } on MissingPluginException catch (e) {
+        expect(e.message, contains('getRecordsByType'));
+      }
+    });
+
+    test('deleteRecord by recordName', () async {
+      try {
+        await cloudKit.deleteRecord(
+          scope: CloudKitDatabaseScope.private,
+          recordName: 'spike-record-1',
+        );
+        fail('Unexpected success under test harness.');
+      } on MissingPluginException catch (e) {
+        expect(e.message, contains('deleteRecord'));
+      }
+    });
+
+    test('CloudKitDatabaseScope enum shape matches expectation', () {
+      // Documented enum from lib/types/database_scope.dart.
+      // NOTE: `public` and `shared` compile in Dart, but the native Swift
+      // impl only handles `"private"` — public/shared will throw
+      // "Cannot create a database for the provided scope" at runtime.
+      // See darwin/Classes/util/FlutterInteropUtils.swift:52-64.
+      expect(CloudKitDatabaseScope.values, hasLength(3));
+      expect(CloudKitDatabaseScope.values.map((e) => e.name),
+          containsAll(<String>['public', 'private', 'shared']));
+    });
+
+    test('CloudKitAccountStatus enum shape matches expectation', () {
+      // Documented enum from lib/types/cloud_kit_account_status.dart.
+      expect(
+        CloudKitAccountStatus.values.map((e) => e.name).toSet(),
+        {
+          'couldNotDetermine',
+          'available',
+          'restricted',
+          'noAccount',
+          'temporarilyUnavailable',
+          'unknown',
+        },
+      );
+    });
+
+    test('identifier validator rejects invalid record types', () {
+      // The Dart layer calls `validateCloudKitIdentifier` before saveRecord
+      // to avoid Objective-C fatal crashes on malformed identifiers.
+      // See: flutter_cloud_kit.dart:15-21.
+      expect(
+        () => cloudKit.saveRecord(
+          scope: CloudKitDatabaseScope.private,
+          recordType: '1StartsWithDigit',
+          record: {'k': 'v'},
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
**Research spike — do NOT merge.** This branch is artifact-only for GitHub issue #63.

## What this is
Empirical PoC for whether `flutter_cloud_kit 0.0.3` can underwrite E3 (CloudKit sync) or whether a custom MethodChannel bridge is required.

## Summary
- **`flutter_cloud_kit 0.0.3` compiles + links** against Flutter 3.41.7 / iOS 26.0 SDK / Xcode 26.0.1. `flutter build ios --debug --no-codesign` succeeds, `pod install` clean in ~1.1s.
- **No new transitive conflicts.** Existing `win32 ^5.9.0` / `device_info_plus 11.3.0` overrides still hold.
- **8 PoC tests** in `test/spike/cloudkit_poc_test.dart` — all pass. Flutter test harness has no iOS runtime, so each plugin call surfaces `MissingPluginException` as expected (proves the Dart API binds and the method channel boundary is reachable; actual CloudKit round-trip needs a device run).
- **API gap from E3 shipping scope:** no `CKRecordZone`, no `CKQuerySubscription`, no change tokens, no conflict resolution, `CKAsset` is read-only, record values are `Map<String, String>` only (numbers/dates lose type fidelity), `CloudKitDatabaseScope.public` / `.shared` compile in Dart but fail at the Swift layer with "Cannot create a database for the provided scope". No pagination, no desired-keys.
- **Entitlement:** `ios/Runner/Runner.entitlements` now includes CloudKit with placeholder container `iCloud.dev.techxtt.liftlogApp` — founder must register via Xcode Signing & Capabilities before runtime bind.

## Executive recommendation
See `vault/06 Spikes/E3 CloudKit viability (2026-04-24).md` for the full report, 5-question answers, Sprint 7 issue skeletons, and Decision Log draft.

## DO NOT MERGE
- Closes no issues.
- `flutter_cloud_kit` dependency and `Runner.entitlements` CloudKit keys must be reverted at spike close OR accepted as part of the first production E3 issue in Sprint 7 — **founder/PM call, not merged here.**