### PR TITLE
#60 — Exercise canonical picker on set form

### DIFF
--- a/lib/data/repositories/exercise_repository.dart
+++ b/lib/data/repositories/exercise_repository.dart
@@ -47,6 +47,23 @@ class ExerciseRepository {
         ..limit(1))
       .getSingleOrNull();
 
+  /// Feature-facing convenience entry point for the set form's canonical
+  /// picker (issue #60).
+  ///
+  /// The arch guardrail `test/arch/data_access_boundary_test.dart` forbids
+  /// `lib/features/**` from referencing `Source.` directly — features must
+  /// receive `Source`-typed values from repositories, not construct them
+  /// raw. The set-form picker always inserts with `Source.userEntered`
+  /// (the user typed a new exercise name), so we expose a dedicated
+  /// wrapper that hides the enum from the call site. Delegates to
+  /// [addIfMissing] with `source: Source.userEntered`.
+  ///
+  /// Use this from feature code; use [addIfMissing] from data-layer
+  /// callers that need to declare a different provenance (e.g. the
+  /// v2→v3 seeding pass, future import flows).
+  Future<Exercise> addIfMissingUserEntered(String name) =>
+      addIfMissing(name, source: Source.userEntered);
+
   /// Inserts `name` if it isn't already present, then returns the row
   /// (either the existing one or the one just inserted).
   ///

--- a/lib/features/workouts/exercise_set_form_screen.dart
+++ b/lib/features/workouts/exercise_set_form_screen.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -28,12 +29,30 @@ class ExerciseSetFormScreen extends ConsumerStatefulWidget {
 
 class _ExerciseSetFormScreenState extends ConsumerState<ExerciseSetFormScreen> {
   final _formKey = GlobalKey<FormState>();
-  late final TextEditingController _nameController;
+  // `_nameController` is owned by the Autocomplete widget (created via its
+  // `fieldViewBuilder`); we keep a handle to it so our save/edit/chip-tap
+  // flows can read and mutate the text field. The Autocomplete's
+  // field-view-builder hands us the same controller instance on every
+  // rebuild, so latching it once on first build is safe.
+  TextEditingController? _nameController;
   late final TextEditingController _repsController;
   late final TextEditingController _weightController;
   late WeightUnit _unit;
   late WorkoutSetStatus _status;
   bool _saving = false;
+
+  /// Canonical `exercises.id` the user has explicitly selected via a
+  /// typeahead suggestion tap (or a recent-exercise chip tap whose name
+  /// resolves to an existing row). Cleared when the user edits the text
+  /// after selecting, so a mid-selection free-type falls back to the
+  /// find-or-create path on save. See [_save].
+  int? _selectedExerciseId;
+
+  /// Cached canonical name for [_selectedExerciseId]. Used at save time to
+  /// decide whether the text still matches the selected exercise — if the
+  /// user edited the text after selecting, we drop the id and go through
+  /// find-or-create.
+  String? _selectedExerciseName;
 
   bool get _isEdit => widget.existing != null;
 
@@ -41,18 +60,23 @@ class _ExerciseSetFormScreenState extends ConsumerState<ExerciseSetFormScreen> {
   void initState() {
     super.initState();
     final e = widget.existing;
-    _nameController = TextEditingController(text: e?.exerciseName ?? '');
     _repsController =
         TextEditingController(text: e == null ? '' : '${e.reps}');
     _weightController =
         TextEditingController(text: e == null ? '' : e.weight.toString());
     _unit = e?.weightUnit ?? WeightUnit.kg;
     _status = e?.status ?? WorkoutSetStatus.completed;
+    // Prefill the selected-exercise-id from the existing row if it has
+    // one. The text controller itself is created lazily by Autocomplete;
+    // we seed it via `initialValue` on `RawAutocomplete` below.
+    if (e != null && e.exerciseId != null) {
+      _selectedExerciseId = e.exerciseId;
+      _selectedExerciseName = e.exerciseName;
+    }
   }
 
   @override
   void dispose() {
-    _nameController.dispose();
     _repsController.dispose();
     _weightController.dispose();
     super.dispose();
@@ -62,32 +86,121 @@ class _ExerciseSetFormScreenState extends ConsumerState<ExerciseSetFormScreen> {
   /// Caret lands at the end of the name so the user can continue typing
   /// (e.g. append " (variant)") without hitting End first. No
   /// auto-advance, no auto-submit — the user still chooses to save.
-  void _applyRecentName(String name) {
-    _nameController.value = TextEditingValue(
+  ///
+  /// Additionally (#60): if the chip name matches an `Exercise` row
+  /// exactly, latch the canonical `exerciseId` so save links the FK
+  /// without a second lookup. This is additive — the typeahead and the
+  /// chip strip feed the same selection state.
+  Future<void> _applyRecentName(String name) async {
+    _nameController?.value = TextEditingValue(
       text: name,
       selection: TextSelection.fromPosition(TextPosition(offset: name.length)),
     );
+    final repo = ref.read(exerciseRepositoryProvider);
+    final row = await repo.findByName(name);
+    if (!mounted) return;
+    setState(() {
+      _selectedExerciseId = row?.id;
+      _selectedExerciseName = row?.canonicalName;
+    });
+  }
+
+  /// Called when the Autocomplete surface emits a selection (user tapped
+  /// a suggestion). Latches both the canonical id and name so the save
+  /// path can short-circuit the find-or-create lookup.
+  void _onSuggestionSelected(Exercise suggestion) {
+    setState(() {
+      _selectedExerciseId = suggestion.id;
+      _selectedExerciseName = suggestion.canonicalName;
+    });
+  }
+
+  /// Called whenever the raw text in the Exercise field changes. If the
+  /// user edits away from the selected exercise's canonical name, we
+  /// drop the latched id so save falls through to find-or-create. If
+  /// they edit back to match, we do NOT auto-relatch — the user must
+  /// explicitly re-select from the typeahead. This is the safer default:
+  /// a free-typed match to an existing exercise still goes through
+  /// `findByName` at save time, which will find and link the row.
+  void _onFieldChanged(String text) {
+    if (_selectedExerciseId == null) return;
+    if (text != _selectedExerciseName) {
+      setState(() {
+        _selectedExerciseId = null;
+        _selectedExerciseName = null;
+      });
+    }
+  }
+
+  /// Typeahead suggestion source (#60). Non-empty queries match the
+  /// canonical name as a case-insensitive substring. Results are capped
+  /// at 8 and sorted so prefix matches come before interior-substring
+  /// matches, then alphabetically A–Z. Empty queries return an empty
+  /// iterable — we keep the surface clean until the user starts typing.
+  Future<Iterable<Exercise>> _buildSuggestions(String query) async {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) return const <Exercise>[];
+    final repo = ref.read(exerciseRepositoryProvider);
+    final all = await repo.listAll();
+    final needle = trimmed.toLowerCase();
+    final matches = <Exercise>[];
+    for (final e in all) {
+      if (e.canonicalName.toLowerCase().contains(needle)) {
+        matches.add(e);
+      }
+    }
+    matches.sort((a, b) {
+      final aPrefix = a.canonicalName.toLowerCase().startsWith(needle);
+      final bPrefix = b.canonicalName.toLowerCase().startsWith(needle);
+      if (aPrefix != bPrefix) return aPrefix ? -1 : 1;
+      return a.canonicalName.toLowerCase().compareTo(
+            b.canonicalName.toLowerCase(),
+          );
+    });
+    if (matches.length > 8) return matches.sublist(0, 8);
+    return matches;
   }
 
   Future<void> _save() async {
     if (!_formKey.currentState!.validate()) return;
     setState(() => _saving = true);
-    final repo = ref.read(exerciseSetRepositoryProvider);
-    final name = _nameController.text.trim();
+    final setsRepo = ref.read(exerciseSetRepositoryProvider);
+    final exercisesRepo = ref.read(exerciseRepositoryProvider);
+    final name = (_nameController?.text ?? '').trim();
     final reps = int.parse(_repsController.text.trim());
     final weight = double.parse(_weightController.text.trim());
 
     try {
+      // Resolve the canonical exercise id for the FK.
+      //
+      // 1. User tapped a suggestion AND the text still matches the
+      //    selected exercise's canonical name → use the latched id.
+      // 2. Otherwise find-or-create: exact-match lookup, then insert
+      //    via the feature-facing wrapper if still missing.
+      int exerciseId;
+      if (_selectedExerciseId != null && name == _selectedExerciseName) {
+        exerciseId = _selectedExerciseId!;
+      } else {
+        final existing = await exercisesRepo.findByName(name);
+        if (existing != null) {
+          exerciseId = existing.id;
+        } else {
+          final created = await exercisesRepo.addIfMissingUserEntered(name);
+          exerciseId = created.id;
+        }
+      }
+
       if (_isEdit) {
-        await repo.update(widget.existing!.copyWith(
+        await setsRepo.update(widget.existing!.copyWith(
           exerciseName: name,
+          exerciseId: Value(exerciseId),
           reps: reps,
           weight: weight,
           weightUnit: _unit,
           status: _status,
         ));
       } else {
-        await repo.add(ExerciseSetsCompanion.insert(
+        await setsRepo.add(ExerciseSetsCompanion.insert(
           sessionId: widget.sessionId,
           exerciseName: name,
           reps: reps,
@@ -95,6 +208,7 @@ class _ExerciseSetFormScreenState extends ConsumerState<ExerciseSetFormScreen> {
           weightUnit: _unit,
           status: _status,
           orderIndex: widget.nextOrderIndex ?? 0,
+          exerciseId: Value(exerciseId),
         ));
       }
       if (!mounted) return;
@@ -130,6 +244,7 @@ class _ExerciseSetFormScreenState extends ConsumerState<ExerciseSetFormScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final initialName = widget.existing?.exerciseName ?? '';
     return Scaffold(
       appBar: AppBar(
         title: Text(_isEdit ? 'Edit set' : 'Add set'),
@@ -146,18 +261,47 @@ class _ExerciseSetFormScreenState extends ConsumerState<ExerciseSetFormScreen> {
           key: _formKey,
           child: ListView(
             children: [
-              TextFormField(
-                controller: _nameController,
-                decoration: const InputDecoration(labelText: 'Exercise'),
-                textInputAction: TextInputAction.next,
-                validator: (v) => (v == null || v.trim().isEmpty)
-                    ? 'Exercise name is required'
-                    : null,
+              // Canonical-exercise typeahead (#60). Flutter's built-in
+              // `Autocomplete<T>` widget — no new pub dep needed.
+              // `optionsBuilder` reads from `ExerciseRepository.listAll`
+              // (one-shot, widget-test-safe); empty queries yield no
+              // suggestions; non-empty queries return ≤ 8 substring
+              // matches, prefix-matches first, alphabetical tiebreak.
+              Autocomplete<Exercise>(
+                displayStringForOption: (e) => e.canonicalName,
+                optionsBuilder: (TextEditingValue value) =>
+                    _buildSuggestions(value.text),
+                onSelected: _onSuggestionSelected,
+                fieldViewBuilder:
+                    (context, controller, focusNode, onFieldSubmitted) {
+                  // Seed the controller from the existing row the first
+                  // time we see it. Autocomplete hands us a fresh
+                  // controller; on subsequent builds it's the same
+                  // instance, so we only seed once.
+                  if (_nameController == null) {
+                    _nameController = controller;
+                    if (initialName.isNotEmpty) {
+                      controller.text = initialName;
+                    }
+                  }
+                  return TextFormField(
+                    controller: controller,
+                    focusNode: focusNode,
+                    decoration: const InputDecoration(labelText: 'Exercise'),
+                    textInputAction: TextInputAction.next,
+                    onChanged: _onFieldChanged,
+                    onFieldSubmitted: (_) => onFieldSubmitted(),
+                    validator: (v) => (v == null || v.trim().isEmpty)
+                        ? 'Exercise name is required'
+                        : null,
+                  );
+                },
               ),
               // Recent-exercises chip strip (issue #39). Sits directly
               // under the Exercise field — clearly "for" that field. Tap
-              // fills the text box and parks the caret at the end; the
-              // user still chooses to save.
+              // fills the text box, parks the caret at the end, and (new
+              // in #60) latches the canonical `exerciseId` if the chip
+              // name matches an `Exercise` row.
               RecentExercisesStrip(onSelected: _applyRecentName),
               const SizedBox(height: 12),
               TextFormField(

--- a/test/data/exercise_repository_test.dart
+++ b/test/data/exercise_repository_test.dart
@@ -94,4 +94,26 @@ void main() {
     final rows = await repo.watchAll().first;
     expect(rows.map((r) => r.canonicalName).toList(), ['Squat', 'Deadlift']);
   });
+
+  test('addIfMissingUserEntered is the feature-facing wrapper over addIfMissing',
+      () async {
+    // Feature code (lib/features/**) must not reference `Source.` directly
+    // (see test/arch/data_access_boundary_test.dart Rule 4). The set-form
+    // picker calls this wrapper; it must behave identically to
+    // addIfMissing(name, source: Source.userEntered).
+    final viaWrapper = await repo.addIfMissingUserEntered('Bench Press');
+    expect(viaWrapper.canonicalName, 'Bench Press');
+
+    // Second call is idempotent — UNIQUE on canonicalName + insertOrIgnore.
+    final again = await repo.addIfMissingUserEntered('Bench Press');
+    expect(again.id, viaWrapper.id);
+
+    // And the underlying addIfMissing returns the same row on a third
+    // call — proving the wrapper and the raw API share storage.
+    final raw =
+        await repo.addIfMissing('Bench Press', source: Source.userEntered);
+    expect(raw.id, viaWrapper.id);
+
+    expect(await repo.listAll(), hasLength(1));
+  });
 }

--- a/test/features/workouts/exercise_set_form_screen_test.dart
+++ b/test/features/workouts/exercise_set_form_screen_test.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -5,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:liftlog_app/data/database.dart';
 import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/data/repositories/exercise_repository.dart';
 import 'package:liftlog_app/data/repositories/exercise_set_repository.dart';
 import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
 import 'package:liftlog_app/features/workouts/exercise_set_form_screen.dart';
@@ -21,12 +23,14 @@ void main() {
   late AppDatabase db;
   late WorkoutSessionRepository sessionRepo;
   late ExerciseSetRepository setsRepo;
+  late ExerciseRepository exercisesRepo;
   late int sessionId;
 
   setUp(() async {
     db = AppDatabase.forTesting(NativeDatabase.memory());
     sessionRepo = WorkoutSessionRepository(db);
     setsRepo = ExerciseSetRepository(db);
+    exercisesRepo = ExerciseRepository(db);
     sessionId = await sessionRepo.add(WorkoutSessionsCompanion.insert(
       startedAt: DateTime(2026, 4, 23, 18),
     ));
@@ -128,5 +132,160 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(await setsRepo.listForSession(sessionId), isEmpty);
+  });
+
+  // ---------------------------------------------------------------------
+  // Canonical exercise picker (#60)
+  // ---------------------------------------------------------------------
+
+  testWidgets(
+      'typeahead: select existing exercise links set.exerciseId to its row',
+      (tester) async {
+    // Seed three canonical exercises; only one has "Be" as a prefix.
+    await exercisesRepo.addIfMissing('Squat', source: Source.userEntered);
+    final bench =
+        await exercisesRepo.addIfMissing('Bench Press', source: Source.userEntered);
+    await exercisesRepo.addIfMissing('Deadlift', source: Source.userEntered);
+
+    await tester.pumpWidget(_host(
+      db,
+      ExerciseSetFormScreen(sessionId: sessionId, nextOrderIndex: 0),
+    ));
+    await tester.pumpAndSettle();
+
+    // Type into the Exercise field. The Autocomplete widget's
+    // optionsBuilder is async (it awaits listAll), so we pumpAndSettle
+    // to let the suggestion overlay appear.
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Exercise'), 'Be');
+    await tester.pumpAndSettle();
+
+    // Exactly one suggestion — "Bench Press" — is rendered in the overlay.
+    // The field text itself also equals "Be", so the "Bench Press" visible
+    // in the overlay is distinct from the field content.
+    expect(find.text('Bench Press'), findsOneWidget);
+
+    // Tap the suggestion. This fires Autocomplete.onSelected, which both
+    // populates the text field to "Bench Press" and latches the
+    // canonical exerciseId in the screen state.
+    await tester.tap(find.text('Bench Press'));
+    await tester.pumpAndSettle();
+
+    // Fill the remaining fields and save.
+    await tester.enterText(find.widgetWithText(TextFormField, 'Reps'), '8');
+    await tester.enterText(find.widgetWithText(TextFormField, 'Weight'), '80');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final list = await setsRepo.listForSession(sessionId);
+    expect(list, hasLength(1));
+    final s = list.single;
+    expect(s.exerciseName, 'Bench Press');
+    expect(s.exerciseId, bench.id,
+        reason: 'tapping a suggestion must link the canonical exercises row');
+
+    // No new exercises row was created — the existing one was reused.
+    final all = await exercisesRepo.listAll();
+    expect(all, hasLength(3));
+  });
+
+  testWidgets(
+      'type-new-name: save creates a new exercises row and links the set',
+      (tester) async {
+    // No pre-seeded exercises. The form must insert a new row on save
+    // and link the set's FK to it.
+    expect(await exercisesRepo.listAll(), isEmpty);
+
+    await tester.pumpWidget(_host(
+      db,
+      ExerciseSetFormScreen(sessionId: sessionId, nextOrderIndex: 0),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.widgetWithText(TextFormField, 'Exercise'), 'Deadlift');
+    await tester.pumpAndSettle();
+
+    // With an empty exercises table there are no suggestions — the user
+    // types a brand-new name and saves. The screen must take the
+    // find-or-create branch (findByName miss → addIfMissingUserEntered).
+    await tester.enterText(find.widgetWithText(TextFormField, 'Reps'), '5');
+    await tester.enterText(find.widgetWithText(TextFormField, 'Weight'), '140');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final exercises = await exercisesRepo.listAll();
+    expect(exercises, hasLength(1),
+        reason: 'a brand-new exercise name must create one canonical row');
+    final created = exercises.single;
+    expect(created.canonicalName, 'Deadlift');
+
+    final sets = await setsRepo.listForSession(sessionId);
+    expect(sets, hasLength(1));
+    expect(sets.single.exerciseId, created.id,
+        reason: 'the just-saved set must link to the freshly-created row');
+  });
+
+  testWidgets('edit: existing exerciseId → field prefilled with canonical name',
+      (tester) async {
+    final bench =
+        await exercisesRepo.addIfMissing('Bench Press', source: Source.userEntered);
+    await setsRepo.add(ExerciseSetsCompanion.insert(
+      sessionId: sessionId,
+      exerciseName: 'Bench Press',
+      reps: 8,
+      weight: 80,
+      weightUnit: WeightUnit.kg,
+      status: WorkoutSetStatus.completed,
+      orderIndex: 0,
+      exerciseId: Value(bench.id),
+    ));
+    final existing = (await setsRepo.listForSession(sessionId)).single;
+    expect(existing.exerciseId, bench.id, reason: 'seeded with FK set');
+
+    await tester.pumpWidget(_host(
+      db,
+      ExerciseSetFormScreen(sessionId: sessionId, existing: existing),
+    ));
+    await tester.pumpAndSettle();
+
+    // Field prefilled with the canonical name. Scope to the TextFormField
+    // so we don't also match the recent-exercises chip with the same name.
+    expect(find.widgetWithText(TextFormField, 'Bench Press'), findsOneWidget);
+
+    // Re-save without editing; the FK must survive the round trip.
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final after = (await setsRepo.listForSession(sessionId)).single;
+    expect(after.exerciseId, bench.id,
+        reason: 'edit save preserves the canonical exerciseId');
+  });
+
+  testWidgets('edit: null exerciseId → field prefilled with raw exerciseName',
+      (tester) async {
+    // Seed a set without linking it to any `exercises` row — mirrors the
+    // pre-S5.1 state where historical rows have `exercise_id = null` and
+    // no matching canonical entry exists to backfill from.
+    await setsRepo.add(ExerciseSetsCompanion.insert(
+      sessionId: sessionId,
+      exerciseName: 'Legacy Lift',
+      reps: 10,
+      weight: 50,
+      weightUnit: WeightUnit.kg,
+      status: WorkoutSetStatus.completed,
+      orderIndex: 0,
+    ));
+    final existing = (await setsRepo.listForSession(sessionId)).single;
+    expect(existing.exerciseId, isNull,
+        reason: 'precondition: the seeded row has no FK');
+
+    await tester.pumpWidget(_host(
+      db,
+      ExerciseSetFormScreen(sessionId: sessionId, existing: existing),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(TextFormField, 'Legacy Lift'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Closes #60.

## Summary
- Replace the plain `Exercise` `TextFormField` on the set form with Flutter's built-in `Autocomplete<Exercise>` (no new pub dep). Non-empty queries return up to 8 case-insensitive substring matches from `ExerciseRepository.listAll`, prefix matches first, alphabetical tiebreak. Empty queries keep the surface clean.
- On save: if the user tapped a suggestion (and the text still matches that exercise's canonical name), use the latched `exerciseId`. Otherwise `findByName` → if hit use that id, else insert via `addIfMissingUserEntered` and use the returned id.
- `RecentExercisesStrip` chip taps now also run `findByName` so the latched id is set if the chip corresponds to a canonical `exercises` row. Consistent with the typeahead behavior.
- Edit flow preserves existing `exercise_id`. Sets with null FK prefill the raw `exercise_name` and save via find-or-create like any new entry.

## Source-enum-stays-out-of-features rule
Added `ExerciseRepository.addIfMissingUserEntered(String)` as the feature-facing convenience wrapper. It delegates to `addIfMissing(name, source: Source.userEntered)` inside the data layer. The set form calls the wrapper — zero `Source.` tokens under `lib/features/workouts/` (`grep -rn "Source\." lib/features/workouts/` returns no matches). Arch rule 4 in `test/arch/data_access_boundary_test.dart` stays green.

## No new deps
Used Flutter's built-in `Autocomplete<T>` widget — no `flutter_typeahead` or any other pub dep added. `pubspec.yaml` untouched.

## Test plan
- [x] `flutter analyze` clean (0 issues).
- [x] `flutter test` green — 326/326 (+5 over previous 321 baseline; 4 widget + 1 repo).
- [x] `grep -rn "Source\." lib/features/workouts/` returns 0 matches.
- New widget tests on `test/features/workouts/exercise_set_form_screen_test.dart`:
  - typeahead: select existing exercise links `set.exerciseId` to its row.
  - type-new-name: save creates a new `exercises` row and links the set.
  - edit with `exercise_id != null` prefills field with canonical name and preserves FK on re-save.
  - edit with `exercise_id == null` prefills field with raw `exercise_name`.
- New repo test on `test/data/exercise_repository_test.dart` covering the `addIfMissingUserEntered` wrapper's delegation + idempotency.

Out of scope (per issue): muscle-group tagging, exercise-library management screen, merge/rename of canonical rows, routine-specific suggestions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)