### PR TITLE
#61 — Routines UI + start-from-routine

### DIFF
--- a/lib/data/repositories/exercise_repository.dart
+++ b/lib/data/repositories/exercise_repository.dart
@@ -47,6 +47,15 @@ class ExerciseRepository {
         ..limit(1))
       .getSingleOrNull();
 
+  /// Returns the row with `id`, or `null` if no row matches.
+  ///
+  /// Added (#61) for the start-workout-from-routine flow, which reads
+  /// `RoutineExercise.exerciseId` and needs the canonical name to seed
+  /// `ExerciseSet.exerciseName`. Mirrors `findByName` (exact-match,
+  /// single-row, null on miss).
+  Future<Exercise?> findById(int id) =>
+      (_db.select(_db.exercises)..where((t) => t.id.equals(id))).getSingleOrNull();
+
   /// Feature-facing convenience entry point for the set form's canonical
   /// picker (issue #60).
   ///

--- a/lib/data/repositories/routine_repository.dart
+++ b/lib/data/repositories/routine_repository.dart
@@ -95,6 +95,18 @@ class RoutineRepository {
   Future<int> addExercise(RoutineExercisesCompanion exercise) =>
       _db.into(_db.routineExercises).insert(exercise);
 
+  /// Deletes a single routine-exercise line item by id.
+  ///
+  /// Added (#61) for the routine form's "save = wipe-and-rewrite" flow
+  /// on edit: after the user reorders / adds / removes rows in the
+  /// in-memory draft, the form deletes every existing line item and
+  /// re-inserts the draft rows in order. Scoped by line-item id so the
+  /// caller can target exactly the rows they want to remove.
+  Future<int> deleteExercise(int lineItemId) =>
+      (_db.delete(
+        _db.routineExercises,
+      )..where((t) => t.id.equals(lineItemId))).go();
+
   /// Rewrites `orderIndex` on every row in [exerciseIds] for the
   /// routine [routineId], in the order the caller supplied. The update
   /// runs inside a single Drift transaction so a partial reorder is

--- a/lib/features/routines/routine_detail_screen.dart
+++ b/lib/features/routines/routine_detail_screen.dart
@@ -1,0 +1,260 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/database.dart';
+import '../../data/enums.dart';
+import '../../providers/app_providers.dart';
+import '../../ui/formatters.dart';
+import '../../ui/show_save_error.dart';
+import '../workouts/workout_session_screen.dart';
+import 'routine_form_screen.dart';
+import 'start_from_routine_service.dart';
+
+/// Per-routine detail surface (#61).
+///
+/// One-shot reads (Future-backed) rather than streams because the form
+/// screen is the only place that writes to this routine, and the detail
+/// screen is pushed → user pops back → list re-streams. A live stream
+/// here would be over-engineering for a single-user tracker.
+class RoutineDetailScreen extends ConsumerStatefulWidget {
+  const RoutineDetailScreen({super.key, required this.routineId});
+
+  final int routineId;
+
+  @override
+  ConsumerState<RoutineDetailScreen> createState() =>
+      _RoutineDetailScreenState();
+}
+
+class _RoutineDetailScreenState extends ConsumerState<RoutineDetailScreen> {
+  Future<_RoutineView>? _future;
+  bool _starting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  Future<_RoutineView> _load() async {
+    final routineRepo = ref.read(routineRepositoryProvider);
+    final exerciseRepo = ref.read(exerciseRepositoryProvider);
+    final routine = await routineRepo.findById(widget.routineId);
+    if (routine == null) {
+      return _RoutineView.missing();
+    }
+    final lineItems = await routineRepo.listExercises(widget.routineId);
+    final rows = <_LineView>[];
+    for (final re in lineItems) {
+      final ex = await exerciseRepo.findById(re.exerciseId);
+      rows.add(
+        _LineView(
+          name: ex?.canonicalName ?? '(missing exercise)',
+          targetSets: re.targetSets,
+          targetReps: re.targetReps,
+          targetWeight: re.targetWeight,
+          targetWeightUnit: re.targetWeightUnit,
+        ),
+      );
+    }
+    return _RoutineView(routine: routine, rows: rows);
+  }
+
+  Future<void> _openEdit(Routine routine) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => RoutineFormScreen(existing: routine),
+      ),
+    );
+    // Refresh after return — the form might have edited or deleted.
+    if (!mounted) return;
+    setState(() {
+      _future = _load();
+    });
+  }
+
+  Future<void> _startWorkout() async {
+    if (_starting) return;
+    setState(() => _starting = true);
+    final service = StartFromRoutineService(
+      routineRepo: ref.read(routineRepositoryProvider),
+      exerciseRepo: ref.read(exerciseRepositoryProvider),
+      exerciseSetRepo: ref.read(exerciseSetRepositoryProvider),
+      sessionRepo: ref.read(workoutSessionRepositoryProvider),
+    );
+    try {
+      final sessionId = await service.start(
+        widget.routineId,
+        now: DateTime.now(),
+      );
+      if (!mounted) return;
+      // `pushReplacement` so back navigation from the session screen
+      // returns to Routines (the list), not the routine detail. Keeps
+      // the "I started a workout" mental model: detail → workout, not
+      // detail → workout → detail again.
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(
+          builder: (_) => WorkoutSessionScreen(sessionId: sessionId),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _starting = false);
+      showSaveError(context, 'start workout', e);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Routine')),
+      body: FutureBuilder<_RoutineView>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const SizedBox.shrink();
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Could not load: ${snapshot.error}'));
+          }
+          final view = snapshot.data!;
+          if (view.missing) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(24),
+                child: Text('Routine not found.'),
+              ),
+            );
+          }
+          return _RoutineBody(
+            view: view,
+            starting: _starting,
+            onEdit: () => _openEdit(view.routine!),
+            onStart: _startWorkout,
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _RoutineBody extends StatelessWidget {
+  const _RoutineBody({
+    required this.view,
+    required this.starting,
+    required this.onEdit,
+    required this.onStart,
+  });
+
+  final _RoutineView view;
+  final bool starting;
+  final VoidCallback onEdit;
+  final VoidCallback onStart;
+
+  @override
+  Widget build(BuildContext context) {
+    final routine = view.routine!;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(routine.name, style: Theme.of(context).textTheme.titleLarge),
+              if (routine.notes != null && routine.notes!.trim().isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(routine.notes!),
+                ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+          child: Row(
+            children: [
+              Expanded(
+                child: FilledButton.icon(
+                  onPressed: starting || view.rows.isEmpty ? null : onStart,
+                  icon: const Icon(Icons.play_arrow),
+                  label: const Text('Start workout'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              OutlinedButton.icon(
+                onPressed: starting ? null : onEdit,
+                icon: const Icon(Icons.edit),
+                label: const Text('Edit'),
+              ),
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        Expanded(
+          child: view.rows.isEmpty
+              ? const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(24),
+                    child: Text('No exercises yet. Tap Edit to add some.'),
+                  ),
+                )
+              : ListView.separated(
+                  itemCount: view.rows.length,
+                  separatorBuilder: (_, _) => const Divider(height: 1),
+                  itemBuilder: (context, i) {
+                    final r = view.rows[i];
+                    return ListTile(
+                      title: Text(r.name),
+                      subtitle: Text(r.formattedTargets()),
+                    );
+                  },
+                ),
+        ),
+      ],
+    );
+  }
+}
+
+/// View-model bundle for a single routine.
+class _RoutineView {
+  _RoutineView({required this.routine, required this.rows}) : missing = false;
+  _RoutineView.missing() : routine = null, rows = const [], missing = true;
+
+  final Routine? routine;
+  final List<_LineView> rows;
+  final bool missing;
+}
+
+class _LineView {
+  _LineView({
+    required this.name,
+    required this.targetSets,
+    required this.targetReps,
+    required this.targetWeight,
+    required this.targetWeightUnit,
+  });
+
+  final String name;
+  final int? targetSets;
+  final int? targetReps;
+  final double? targetWeight;
+  final WeightUnit? targetWeightUnit;
+
+  String formattedTargets() {
+    final parts = <String>[];
+    if (targetSets != null && targetReps != null) {
+      parts.add('${targetSets!} × ${targetReps!}');
+    } else if (targetSets != null) {
+      parts.add('${targetSets!} sets');
+    } else if (targetReps != null) {
+      parts.add('${targetReps!} reps');
+    }
+    if (targetWeight != null && targetWeightUnit != null) {
+      parts.add(formatWeight(targetWeight!, targetWeightUnit!));
+    }
+    if (parts.isEmpty) return 'No targets set';
+    return parts.join(' · ');
+  }
+}

--- a/lib/features/routines/routine_form_screen.dart
+++ b/lib/features/routines/routine_form_screen.dart
@@ -1,0 +1,627 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/database.dart';
+import '../../data/enums.dart';
+import '../../providers/app_providers.dart';
+import '../../ui/delete_confirm.dart';
+import '../../ui/labels.dart';
+import '../../ui/show_save_error.dart';
+
+/// Create-or-edit form for a routine (#61).
+///
+/// Holds the full in-memory draft — name, notes, and an ordered list of
+/// line items — and writes it out to the repositories on Save. We keep
+/// the draft entirely local (in `_rows`) so reorder / add / remove stay
+/// instant and the user can cancel without polluting the DB. On Save the
+/// persisted rows are replaced wholesale: delete every existing
+/// `RoutineExercise` for this routine and re-insert from the draft in
+/// the user's order. That keeps the persistence shape simple while
+/// honouring the cascade-delete + FK constraints (the routine row is
+/// preserved; only its line items are rewritten).
+///
+/// Autocomplete picker note (#61): the Exercise field reuses Flutter's
+/// built-in `Autocomplete<Exercise>` pattern from S6.2
+/// (`exercise_set_form_screen.dart`). A second copy rather than a shared
+/// widget — shared extraction turned out invasive because the set-form
+/// additionally owns recent-exercise chips and a latched canonical-id
+/// dance that routines don't need. Follow-up note: if a third consumer
+/// appears, extract both into `lib/features/workouts/exercise_picker.dart`.
+class RoutineFormScreen extends ConsumerStatefulWidget {
+  const RoutineFormScreen({super.key, this.existing});
+
+  /// Routine being edited. `null` → create mode.
+  final Routine? existing;
+
+  @override
+  ConsumerState<RoutineFormScreen> createState() => _RoutineFormScreenState();
+}
+
+class _RoutineFormScreenState extends ConsumerState<RoutineFormScreen> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameController;
+  late final TextEditingController _notesController;
+  final List<_DraftRow> _rows = [];
+  bool _saving = false;
+  bool _loadedInitial = false;
+
+  bool get _isEdit => widget.existing != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.existing?.name ?? '');
+    _notesController = TextEditingController(
+      text: widget.existing?.notes ?? '',
+    );
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _notesController.dispose();
+    for (final row in _rows) {
+      row.dispose();
+    }
+    super.dispose();
+  }
+
+  /// One-shot load of existing line items (edit mode only). Widget-test
+  /// safe: uses `listExercises`, not `watchExercises`.
+  Future<void> _loadExisting() async {
+    final existing = widget.existing;
+    if (existing == null) return;
+    final repo = ref.read(routineRepositoryProvider);
+    final rows = await repo.listExercises(existing.id);
+    if (!mounted) return;
+    setState(() {
+      _rows.clear();
+      for (final r in rows) {
+        _rows.add(_DraftRow.fromPersisted(r));
+      }
+      _loadedInitial = true;
+    });
+  }
+
+  void _addRow() {
+    setState(() {
+      _rows.add(_DraftRow.blank());
+    });
+  }
+
+  void _removeRow(int index) async {
+    final confirmed = await showDeleteConfirm(
+      context,
+      title: 'Remove exercise?',
+      message: 'This exercise will be removed from the routine.',
+    );
+    if (!confirmed) return;
+    if (!mounted) return;
+    setState(() {
+      final removed = _rows.removeAt(index);
+      removed.dispose();
+    });
+  }
+
+  void _moveUp(int index) {
+    if (index <= 0) return;
+    setState(() {
+      final row = _rows.removeAt(index);
+      _rows.insert(index - 1, row);
+    });
+  }
+
+  void _moveDown(int index) {
+    if (index >= _rows.length - 1) return;
+    setState(() {
+      final row = _rows.removeAt(index);
+      _rows.insert(index + 1, row);
+    });
+  }
+
+  Future<void> _save() async {
+    if (!_formKey.currentState!.validate()) return;
+    // Additional rule: every row must have a resolved exercise id. The
+    // row-level validator also catches this, but we double-check here
+    // because Autocomplete rows that have free-typed text without a
+    // selection would otherwise pass field-level validation (their text
+    // field is non-empty).
+    for (final row in _rows) {
+      if (row.exerciseId == null) {
+        _formKey.currentState!.validate();
+        if (!mounted) return;
+        showSaveError(context, 'save routine', 'Pick an exercise from the list');
+        return;
+      }
+    }
+
+    setState(() => _saving = true);
+    final routineRepo = ref.read(routineRepositoryProvider);
+    final name = _nameController.text.trim();
+    final notesRaw = _notesController.text.trim();
+    final notes = notesRaw.isEmpty ? null : notesRaw;
+
+    try {
+      int routineId;
+      if (_isEdit) {
+        // Preserve createdAt + source via copyWith (trust rule — no
+        // silent mutation of provenance).
+        await routineRepo.update(
+          widget.existing!.copyWith(name: name, notes: Value(notes)),
+        );
+        routineId = widget.existing!.id;
+        // Clear and re-insert line items in the user's order. We use
+        // the public delete-routine-exercises primitive if it exists,
+        // or fall back to the reorder + trim pattern. Since
+        // `RoutineRepository` doesn't expose a "delete all line items"
+        // method, we loop individual deletes — keeps the repo minimal.
+        final existingItems = await routineRepo.listExercises(routineId);
+        for (final r in existingItems) {
+          await routineRepo.deleteExercise(r.id);
+        }
+      } else {
+        routineId = await routineRepo.add(
+          RoutinesCompanion.insert(
+            name: name,
+            notes: Value(notes),
+            createdAt: DateTime.now(),
+          ),
+        );
+      }
+      // Insert line items in display order; orderIndex == loop index.
+      for (var i = 0; i < _rows.length; i++) {
+        final row = _rows[i];
+        await routineRepo.addExercise(
+          RoutineExercisesCompanion.insert(
+            routineId: routineId,
+            exerciseId: row.exerciseId!,
+            orderIndex: i,
+            targetSets: Value(row.targetSets),
+            targetReps: Value(row.targetReps),
+            targetWeight: Value(row.targetWeight),
+            targetWeightUnit: Value(row.targetWeightUnit),
+          ),
+        );
+      }
+      if (!mounted) return;
+      Navigator.of(context).pop();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _saving = false);
+      showSaveError(context, 'save routine', e);
+    }
+  }
+
+  Future<void> _delete() async {
+    final confirmed = await showDeleteConfirm(
+      context,
+      title: 'Delete routine?',
+      message:
+          'This routine and its exercises will be removed. This cannot be undone.',
+    );
+    if (!confirmed) return;
+    if (!mounted) return;
+    setState(() => _saving = true);
+    final repo = ref.read(routineRepositoryProvider);
+    try {
+      await repo.delete(widget.existing!.id);
+      if (!mounted) return;
+      Navigator.of(context).pop();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _saving = false);
+      showSaveError(context, 'delete routine', e);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Lazy one-shot load of existing line items. We do this in `build`
+    // (not `initState`) because `ref.read` at initState time is allowed
+    // but awaits + setState are cleaner here. Guard with `_loadedInitial`
+    // so we don't re-fire on every rebuild.
+    if (_isEdit && !_loadedInitial) {
+      _loadedInitial = true;
+      Future.microtask(_loadExisting);
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_isEdit ? 'Edit routine' : 'New routine'),
+        actions: [
+          if (_isEdit)
+            IconButton(
+              icon: const Icon(Icons.delete_outline),
+              tooltip: 'Delete routine',
+              onPressed: _saving ? null : _delete,
+            ),
+          TextButton(
+            onPressed: _saving ? null : _save,
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Name'),
+                textInputAction: TextInputAction.next,
+                validator: (v) => (v == null || v.trim().isEmpty)
+                    ? 'Name is required'
+                    : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _notesController,
+                decoration: const InputDecoration(labelText: 'Notes'),
+                maxLength: 500,
+                maxLines: 3,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Exercises',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              if (_rows.isEmpty)
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 12),
+                  child: Text(
+                    'No exercises yet. Tap + Add exercise to start.',
+                  ),
+                ),
+              for (var i = 0; i < _rows.length; i++)
+                _RoutineExerciseRowEditor(
+                  key: ValueKey(_rows[i].key),
+                  row: _rows[i],
+                  index: i,
+                  isFirst: i == 0,
+                  isLast: i == _rows.length - 1,
+                  onMoveUp: () => _moveUp(i),
+                  onMoveDown: () => _moveDown(i),
+                  onDelete: () => _removeRow(i),
+                  onChanged: () => setState(() {}),
+                ),
+              const SizedBox(height: 12),
+              OutlinedButton.icon(
+                onPressed: _saving ? null : _addRow,
+                icon: const Icon(Icons.add),
+                label: const Text('Add exercise'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// In-memory draft of a single line item. Holds its own controllers so
+/// reorder/move operations don't lose the user's in-progress input.
+class _DraftRow {
+  _DraftRow.blank()
+      : key = _nextKey(),
+        setsController = TextEditingController(),
+        repsController = TextEditingController(),
+        weightController = TextEditingController(),
+        targetWeightUnit = WeightUnit.kg,
+        exerciseId = null,
+        exerciseName = '';
+
+  _DraftRow.fromPersisted(RoutineExercise re)
+      : key = _nextKey(),
+        setsController = TextEditingController(
+          text: re.targetSets?.toString() ?? '',
+        ),
+        repsController = TextEditingController(
+          text: re.targetReps?.toString() ?? '',
+        ),
+        weightController = TextEditingController(
+          text: re.targetWeight == null ? '' : _formatWeight(re.targetWeight!),
+        ),
+        targetWeightUnit = re.targetWeightUnit ?? WeightUnit.kg,
+        exerciseId = re.exerciseId,
+        exerciseName = '';
+  // `exerciseName` populated once the row editor resolves it from the
+  // exercises table (see `_RoutineExerciseRowEditor.initState`).
+
+  static int _keyCounter = 0;
+  static int _nextKey() => _keyCounter++;
+
+  final int key;
+  final TextEditingController setsController;
+  final TextEditingController repsController;
+  final TextEditingController weightController;
+  WeightUnit targetWeightUnit;
+  int? exerciseId;
+  String exerciseName;
+
+  int? get targetSets {
+    final t = setsController.text.trim();
+    return t.isEmpty ? null : int.tryParse(t);
+  }
+
+  int? get targetReps {
+    final t = repsController.text.trim();
+    return t.isEmpty ? null : int.tryParse(t);
+  }
+
+  double? get targetWeight {
+    final t = weightController.text.trim();
+    return t.isEmpty ? null : double.tryParse(t);
+  }
+
+  void dispose() {
+    setsController.dispose();
+    repsController.dispose();
+    weightController.dispose();
+  }
+
+  static String _formatWeight(double v) {
+    if (v == v.roundToDouble()) return v.toStringAsFixed(0);
+    return v.toStringAsFixed(1);
+  }
+}
+
+/// Per-row editor with Autocomplete picker + target fields + reorder /
+/// delete buttons.
+class _RoutineExerciseRowEditor extends ConsumerStatefulWidget {
+  const _RoutineExerciseRowEditor({
+    super.key,
+    required this.row,
+    required this.index,
+    required this.isFirst,
+    required this.isLast,
+    required this.onMoveUp,
+    required this.onMoveDown,
+    required this.onDelete,
+    required this.onChanged,
+  });
+
+  final _DraftRow row;
+  final int index;
+  final bool isFirst;
+  final bool isLast;
+  final VoidCallback onMoveUp;
+  final VoidCallback onMoveDown;
+  final VoidCallback onDelete;
+  final VoidCallback onChanged;
+
+  @override
+  ConsumerState<_RoutineExerciseRowEditor> createState() =>
+      _RoutineExerciseRowEditorState();
+}
+
+class _RoutineExerciseRowEditorState
+    extends ConsumerState<_RoutineExerciseRowEditor> {
+  TextEditingController? _nameController;
+  bool _primedFromRow = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Resolve the exercise name for pre-populated rows (edit mode) on
+    // first frame so the Autocomplete field's initial value matches.
+    if (widget.row.exerciseId != null && widget.row.exerciseName.isEmpty) {
+      Future.microtask(_resolveExerciseName);
+    }
+  }
+
+  Future<void> _resolveExerciseName() async {
+    final repo = ref.read(exerciseRepositoryProvider);
+    final exercise = await repo.findById(widget.row.exerciseId!);
+    if (!mounted || exercise == null) return;
+    setState(() {
+      widget.row.exerciseName = exercise.canonicalName;
+      if (_nameController != null &&
+          _nameController!.text != exercise.canonicalName) {
+        _nameController!.text = exercise.canonicalName;
+      }
+    });
+  }
+
+  /// Autocomplete options builder. Mirrors the set form's algorithm —
+  /// substring match, prefix-first, alphabetical tiebreak, cap at 8.
+  Future<Iterable<Exercise>> _buildSuggestions(String query) async {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) return const <Exercise>[];
+    final repo = ref.read(exerciseRepositoryProvider);
+    final all = await repo.listAll();
+    final needle = trimmed.toLowerCase();
+    final matches = <Exercise>[];
+    for (final e in all) {
+      if (e.canonicalName.toLowerCase().contains(needle)) {
+        matches.add(e);
+      }
+    }
+    matches.sort((a, b) {
+      final aPrefix = a.canonicalName.toLowerCase().startsWith(needle);
+      final bPrefix = b.canonicalName.toLowerCase().startsWith(needle);
+      if (aPrefix != bPrefix) return aPrefix ? -1 : 1;
+      return a.canonicalName.toLowerCase().compareTo(
+        b.canonicalName.toLowerCase(),
+      );
+    });
+    if (matches.length > 8) return matches.sublist(0, 8);
+    return matches;
+  }
+
+  void _onSuggestionSelected(Exercise e) {
+    setState(() {
+      widget.row.exerciseId = e.id;
+      widget.row.exerciseName = e.canonicalName;
+    });
+    widget.onChanged();
+  }
+
+  void _onFieldChanged(String text) {
+    // Editing away from the resolved name drops the id — save path will
+    // re-validate that the user picked a canonical exercise.
+    if (widget.row.exerciseId == null) return;
+    if (text != widget.row.exerciseName) {
+      setState(() {
+        widget.row.exerciseId = null;
+      });
+      widget.onChanged();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final row = widget.row;
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 6),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Exercise ${widget.index + 1}',
+                    style: Theme.of(context).textTheme.labelLarge,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.arrow_upward),
+                  tooltip: 'Move up',
+                  onPressed: widget.isFirst ? null : widget.onMoveUp,
+                ),
+                IconButton(
+                  icon: const Icon(Icons.arrow_downward),
+                  tooltip: 'Move down',
+                  onPressed: widget.isLast ? null : widget.onMoveDown,
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  tooltip: 'Remove exercise',
+                  onPressed: widget.onDelete,
+                ),
+              ],
+            ),
+            Autocomplete<Exercise>(
+              displayStringForOption: (e) => e.canonicalName,
+              optionsBuilder: (TextEditingValue v) =>
+                  _buildSuggestions(v.text),
+              onSelected: _onSuggestionSelected,
+              fieldViewBuilder:
+                  (context, controller, focusNode, onFieldSubmitted) {
+                if (!_primedFromRow) {
+                  _nameController = controller;
+                  if (row.exerciseName.isNotEmpty) {
+                    controller.text = row.exerciseName;
+                  }
+                  _primedFromRow = true;
+                }
+                return TextFormField(
+                  controller: controller,
+                  focusNode: focusNode,
+                  decoration: const InputDecoration(labelText: 'Exercise'),
+                  textInputAction: TextInputAction.next,
+                  onChanged: _onFieldChanged,
+                  onFieldSubmitted: (_) => onFieldSubmitted(),
+                  validator: (v) {
+                    if (v == null || v.trim().isEmpty) {
+                      return 'Exercise is required';
+                    }
+                    if (row.exerciseId == null) {
+                      return 'Pick an exercise from the list';
+                    }
+                    return null;
+                  },
+                );
+              },
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: TextFormField(
+                    controller: row.setsController,
+                    decoration: const InputDecoration(labelText: 'Sets'),
+                    keyboardType: TextInputType.number,
+                    validator: (v) {
+                      final n = int.tryParse((v ?? '').trim());
+                      if (n == null) return 'Whole number';
+                      if (n < 1) return 'Must be ≥ 1';
+                      return null;
+                    },
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: TextFormField(
+                    controller: row.repsController,
+                    decoration: const InputDecoration(labelText: 'Reps'),
+                    keyboardType: TextInputType.number,
+                    validator: (v) {
+                      final n = int.tryParse((v ?? '').trim());
+                      if (n == null) return 'Whole number';
+                      if (n < 1) return 'Must be ≥ 1';
+                      return null;
+                    },
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  flex: 2,
+                  child: TextFormField(
+                    controller: row.weightController,
+                    decoration: const InputDecoration(
+                      labelText: 'Weight (optional)',
+                    ),
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    onChanged: (_) => widget.onChanged(),
+                    validator: (v) {
+                      final t = (v ?? '').trim();
+                      if (t.isEmpty) return null; // bodyweight / rep-only
+                      final n = double.tryParse(t);
+                      if (n == null) return 'Number';
+                      if (n < 0) return 'Must be ≥ 0';
+                      return null;
+                    },
+                  ),
+                ),
+                if ((row.weightController.text).trim().isNotEmpty) ...[
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: DropdownButtonFormField<WeightUnit>(
+                      initialValue: row.targetWeightUnit,
+                      decoration: const InputDecoration(labelText: 'Unit'),
+                      items: [
+                        for (final u in WeightUnit.values)
+                          DropdownMenuItem(
+                            value: u,
+                            child: Text(weightUnitLabel(u)),
+                          ),
+                      ],
+                      onChanged: (u) {
+                        if (u != null) {
+                          setState(() => row.targetWeightUnit = u);
+                          widget.onChanged();
+                        }
+                      },
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/routines/routine_list_screen.dart
+++ b/lib/features/routines/routine_list_screen.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/database.dart';
+import '../../providers/app_providers.dart';
+import 'routine_detail_screen.dart';
+import 'routine_form_screen.dart';
+
+/// Stream of routines, newest-first (see `RoutineRepository.watchAll`).
+///
+/// Lives with the feature rather than in a shared `routines_providers.dart`
+/// because no other feature currently consumes it.
+final _routinesListProvider = StreamProvider<List<Routine>>((ref) {
+  final repo = ref.watch(routineRepositoryProvider);
+  return repo.watchAll();
+});
+
+/// Routines tab entry point (#61).
+///
+/// Renders the user's saved routines newest-first with a `+` FAB to open
+/// `RoutineFormScreen` in create mode. Tapping a routine opens
+/// `RoutineDetailScreen` where the user can edit or start a workout from
+/// it.
+///
+/// The empty-state copy mirrors the Workouts tab — brief, actionable,
+/// no marketing fluff.
+class RoutineListScreen extends ConsumerWidget {
+  const RoutineListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final routines = ref.watch(_routinesListProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Routines')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _openCreate(context),
+        child: const Icon(Icons.add),
+      ),
+      body: routines.when(
+        data: (list) {
+          if (list.isEmpty) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(24),
+                child: Text(
+                  'No routines yet. Tap + to create one.',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+          return ListView.separated(
+            itemCount: list.length,
+            separatorBuilder: (_, _) => const Divider(height: 1),
+            itemBuilder: (context, i) {
+              final r = list[i];
+              return ListTile(
+                title: Text(r.name),
+                subtitle: r.notes == null || r.notes!.trim().isEmpty
+                    ? null
+                    : Text(
+                        r.notes!.trim(),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                onTap: () => _openDetail(context, r.id),
+              );
+            },
+          );
+        },
+        loading: () => const SizedBox.shrink(),
+        error: (err, _) =>
+            Center(child: Text('Could not load routines: $err')),
+      ),
+    );
+  }
+
+  void _openCreate(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const RoutineFormScreen()),
+    );
+  }
+
+  void _openDetail(BuildContext context, int routineId) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => RoutineDetailScreen(routineId: routineId),
+      ),
+    );
+  }
+}

--- a/lib/features/routines/start_from_routine_service.dart
+++ b/lib/features/routines/start_from_routine_service.dart
@@ -1,0 +1,107 @@
+import 'package:drift/drift.dart' show Value;
+
+import '../../data/database.dart';
+import '../../data/enums.dart';
+import '../../data/repositories/exercise_repository.dart';
+import '../../data/repositories/exercise_set_repository.dart';
+import '../../data/repositories/routine_repository.dart';
+import '../../data/repositories/workout_session_repository.dart';
+
+/// Encapsulates the "start a workout from a routine" flow (#61).
+///
+/// Creates a new `WorkoutSession` and seeds it with `ExerciseSet` rows
+/// built from the routine's line items: one row per `targetSets`, in
+/// `orderIndex` order, with a running global `orderIndex` across every
+/// exercise in the routine. Seeded sets always start in
+/// `WorkoutSetStatus.planned` — the user flips them to `completed` /
+/// `skipped` during the workout.
+///
+/// Fallbacks are explicit and conservative:
+/// - `targetSets == null` → we seed one set. Routines without a set count
+///   are rare (the form validates `>= 1`) but older rows may exist.
+/// - `targetReps == null` → we seed `reps = 0`. The user will edit.
+/// - `targetWeight == null` → we seed `weight = 0.0` (bodyweight / rep-only).
+/// - `targetWeightUnit == null` → we seed `WeightUnit.kg`. `kg` is the
+///   app default; the user can switch per set.
+///
+/// None of these mutate the routine itself — they're read-only fallbacks
+/// at seed time, not silent rewrites of targets (trust rule: no silent
+/// mutation of user-entered data).
+///
+/// If the canonical exercise row is missing (e.g. the user deleted it
+/// after creating the routine), we throw a `StateError` rather than
+/// falling back to an empty string — "no silent fallbacks" (CLAUDE.md).
+/// The caller surfaces it as a save error.
+class StartFromRoutineService {
+  StartFromRoutineService({
+    required RoutineRepository routineRepo,
+    required ExerciseRepository exerciseRepo,
+    required ExerciseSetRepository exerciseSetRepo,
+    required WorkoutSessionRepository sessionRepo,
+  }) : _routineRepo = routineRepo,
+       _exerciseRepo = exerciseRepo,
+       _exerciseSetRepo = exerciseSetRepo,
+       _sessionRepo = sessionRepo;
+
+  final RoutineRepository _routineRepo;
+  final ExerciseRepository _exerciseRepo;
+  final ExerciseSetRepository _exerciseSetRepo;
+  final WorkoutSessionRepository _sessionRepo;
+
+  /// Creates a new session + seeds planned sets from [routineId]'s line
+  /// items. Returns the new `sessionId`.
+  ///
+  /// [now] is injectable so widget tests can assert deterministic
+  /// `startedAt` values.
+  Future<int> start(int routineId, {required DateTime now}) async {
+    final lineItems = await _routineRepo.listExercises(routineId);
+    if (lineItems.isEmpty) {
+      // Empty routine → still create the session (user might want a
+      // blank slate named by the routine), but seed no sets. Matches the
+      // manual "Start workout" flow.
+      return _sessionRepo.add(
+        WorkoutSessionsCompanion.insert(startedAt: now),
+      );
+    }
+
+    final sessionId = await _sessionRepo.add(
+      WorkoutSessionsCompanion.insert(startedAt: now),
+    );
+
+    // Running global index across every exercise's sets, so the session
+    // list renders in the same order the routine prescribed.
+    var runningIndex = 0;
+    for (final re in lineItems) {
+      final exercise = await _exerciseRepo.findById(re.exerciseId);
+      if (exercise == null) {
+        // No silent fallback: if the canonical row was deleted, surface
+        // rather than seed with a placeholder name. The caller converts
+        // this into a SnackBar.
+        throw StateError(
+          'StartFromRoutineService: exercises row ${re.exerciseId} '
+          'missing while seeding routine $routineId',
+        );
+      }
+      final sets = re.targetSets ?? 1;
+      final reps = re.targetReps ?? 0;
+      final weight = re.targetWeight ?? 0.0;
+      final unit = re.targetWeightUnit ?? WeightUnit.kg;
+      for (var i = 0; i < sets; i++) {
+        await _exerciseSetRepo.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: sessionId,
+            exerciseName: exercise.canonicalName,
+            reps: reps,
+            weight: weight,
+            weightUnit: unit,
+            status: WorkoutSetStatus.planned,
+            orderIndex: runningIndex,
+            exerciseId: Value(re.exerciseId),
+          ),
+        );
+        runningIndex++;
+      }
+    }
+    return sessionId;
+  }
+}

--- a/lib/features/workouts/workout_list_screen.dart
+++ b/lib/features/workouts/workout_list_screen.dart
@@ -6,6 +6,7 @@ import '../../providers/app_providers.dart';
 import '../../sources/health_kit/health_source.dart';
 import '../../ui/labels.dart';
 import '../food/date_label.dart';
+import '../routines/routine_list_screen.dart';
 import 'hk_workout_providers.dart';
 import 'workout_providers.dart';
 import 'workout_session_screen.dart';
@@ -20,7 +21,16 @@ class WorkoutListScreen extends ConsumerWidget {
     final hkWorkouts = ref.watch(hkWorkoutsLast90dProvider);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Workouts')),
+      appBar: AppBar(
+        title: const Text('Workouts'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.format_list_bulleted),
+            tooltip: 'Routines',
+            onPressed: () => _openRoutines(context),
+          ),
+        ],
+      ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () => _startSession(context, ref),
         icon: const Icon(Icons.add),
@@ -169,6 +179,12 @@ class WorkoutListScreen extends ConsumerWidget {
       MaterialPageRoute(
         builder: (_) => WorkoutSessionScreen(sessionId: session.id),
       ),
+    );
+  }
+
+  void _openRoutines(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const RoutineListScreen()),
     );
   }
 }

--- a/test/features/routines/routine_detail_screen_test.dart
+++ b/test/features/routines/routine_detail_screen_test.dart
@@ -1,0 +1,166 @@
+// Widget tests for `RoutineDetailScreen` (#61).
+//
+// Renders a routine with a couple of line items, asserts the detail
+// displays them with formatted targets, and exercises the
+// "Start workout" flow end-to-end: the service seeds planned sets +
+// the screen navigates to `WorkoutSessionScreen`.
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/data/repositories/exercise_repository.dart';
+import 'package:liftlog_app/data/repositories/exercise_set_repository.dart';
+import 'package:liftlog_app/data/repositories/routine_repository.dart';
+import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
+import 'package:liftlog_app/features/routines/routine_detail_screen.dart';
+import 'package:liftlog_app/features/workouts/workout_session_screen.dart';
+import 'package:liftlog_app/providers/app_providers.dart';
+
+Widget _host(AppDatabase db, Widget child) {
+  return ProviderScope(
+    overrides: [appDatabaseProvider.overrideWithValue(db)],
+    child: MaterialApp(home: child),
+  );
+}
+
+void main() {
+  late AppDatabase db;
+  late RoutineRepository routineRepo;
+  late ExerciseRepository exerciseRepo;
+  late ExerciseSetRepository setsRepo;
+  late WorkoutSessionRepository sessionRepo;
+  late int benchId;
+  late int squatId;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    routineRepo = RoutineRepository(db);
+    exerciseRepo = ExerciseRepository(db);
+    setsRepo = ExerciseSetRepository(db);
+    sessionRepo = WorkoutSessionRepository(db);
+    final bench = await exerciseRepo.addIfMissing(
+      'Bench Press',
+      source: Source.userEntered,
+    );
+    final squat = await exerciseRepo.addIfMissing(
+      'Squat',
+      source: Source.userEntered,
+    );
+    benchId = bench.id;
+    squatId = squat.id;
+  });
+
+  tearDown(() async => db.close());
+
+  Future<int> seedRoutine() async {
+    final id = await routineRepo.add(
+      RoutinesCompanion.insert(
+        name: 'Push A',
+        notes: const Value('Upper body'),
+        createdAt: DateTime(2026, 4, 20),
+      ),
+    );
+    await routineRepo.addExercise(
+      RoutineExercisesCompanion.insert(
+        routineId: id,
+        exerciseId: benchId,
+        orderIndex: 0,
+        targetSets: const Value(3),
+        targetReps: const Value(8),
+        targetWeight: const Value(80),
+        targetWeightUnit: const Value(WeightUnit.kg),
+      ),
+    );
+    await routineRepo.addExercise(
+      RoutineExercisesCompanion.insert(
+        routineId: id,
+        exerciseId: squatId,
+        orderIndex: 1,
+        targetSets: const Value(4),
+        targetReps: const Value(5),
+      ),
+    );
+    return id;
+  }
+
+  testWidgets('renders routine name, notes, and line items', (tester) async {
+    final id = await seedRoutine();
+
+    await tester.pumpWidget(_host(db, RoutineDetailScreen(routineId: id)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Push A'), findsOneWidget);
+    expect(find.text('Upper body'), findsOneWidget);
+    expect(find.text('Bench Press'), findsOneWidget);
+    expect(find.text('Squat'), findsOneWidget);
+    // Targets rendered as "N × M" (and weight when present).
+    expect(find.text('3 × 8 · 80 kg'), findsOneWidget);
+    expect(find.text('4 × 5'), findsOneWidget);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets(
+    'Start workout seeds planned sets + navigates to WorkoutSessionScreen',
+    (tester) async {
+      final id = await seedRoutine();
+
+      await tester.pumpWidget(_host(db, RoutineDetailScreen(routineId: id)));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Start workout'));
+      await tester.pumpAndSettle();
+
+      // Navigation landed on WorkoutSessionScreen.
+      expect(find.byType(WorkoutSessionScreen), findsOneWidget);
+      // Routine detail replaced — back nav returns to Routines, not detail.
+      expect(find.byType(RoutineDetailScreen), findsNothing);
+
+      // Session created with seeded sets.
+      final sessions = await sessionRepo.listAll();
+      expect(sessions, hasLength(1));
+      final sessionId = sessions.single.id;
+      final sets = await setsRepo.listForSession(sessionId);
+      // 3 bench + 4 squat = 7 total seeded sets.
+      expect(sets, hasLength(7));
+      for (var i = 0; i < sets.length; i++) {
+        expect(sets[i].status, WorkoutSetStatus.planned);
+        expect(sets[i].orderIndex, i);
+      }
+      // First 3 → Bench Press.
+      expect(sets.take(3).every((s) => s.exerciseId == benchId), isTrue);
+      // Next 4 → Squat.
+      expect(sets.skip(3).every((s) => s.exerciseId == squatId), isTrue);
+
+      await _drainDriftTimers(tester);
+    },
+  );
+
+  testWidgets('Start workout disabled when routine has no exercises', (
+    tester,
+  ) async {
+    final id = await routineRepo.add(
+      RoutinesCompanion.insert(name: 'Empty', createdAt: DateTime(2026, 4, 20)),
+    );
+
+    await tester.pumpWidget(_host(db, RoutineDetailScreen(routineId: id)));
+    await tester.pumpAndSettle();
+
+    final button = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, 'Start workout'),
+    );
+    expect(button.onPressed, isNull);
+
+    await _drainDriftTimers(tester);
+  });
+}
+
+Future<void> _drainDriftTimers(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox());
+  await tester.pump(const Duration(milliseconds: 1));
+}

--- a/test/features/routines/routine_form_screen_test.dart
+++ b/test/features/routines/routine_form_screen_test.dart
@@ -1,0 +1,335 @@
+// Widget tests for `RoutineFormScreen` (#61).
+//
+// Covers create, edit, reorder, and delete flows. The Exercise picker
+// reuses the S6.2 Autocomplete pattern — we seed the `Exercises` catalog
+// up-front and drive the picker by tapping suggestions (same technique
+// as `exercise_set_form_screen_test.dart`).
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/data/repositories/exercise_repository.dart';
+import 'package:liftlog_app/data/repositories/routine_repository.dart';
+import 'package:liftlog_app/features/routines/routine_form_screen.dart';
+import 'package:liftlog_app/providers/app_providers.dart';
+
+Widget _host(AppDatabase db, Widget child) {
+  return ProviderScope(
+    overrides: [appDatabaseProvider.overrideWithValue(db)],
+    child: MaterialApp(home: child),
+  );
+}
+
+/// Sets a tall viewport so multi-row forms fit on one screen without
+/// scrolling. The default 800×600 test surface clips the second row's
+/// bottom controls + the "Add exercise" / "Save" affordances once two
+/// exercise cards are stacked. We expand vertically only — width stays
+/// at the Material default.
+void _useTallViewport(WidgetTester tester) {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = const Size(800, 2400);
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+void main() {
+  late AppDatabase db;
+  late RoutineRepository routineRepo;
+  late ExerciseRepository exerciseRepo;
+  late int benchId;
+  late int squatId;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    routineRepo = RoutineRepository(db);
+    exerciseRepo = ExerciseRepository(db);
+    final bench = await exerciseRepo.addIfMissing(
+      'Bench Press',
+      source: Source.userEntered,
+    );
+    final squat = await exerciseRepo.addIfMissing(
+      'Squat',
+      source: Source.userEntered,
+    );
+    benchId = bench.id;
+    squatId = squat.id;
+  });
+
+  tearDown(() async => db.close());
+
+  /// Fills the Nth exercise row's Autocomplete field + target ints.
+  /// Seeds targetSets/targetReps only (weight omitted → bodyweight).
+  Future<void> fillRow(
+    WidgetTester tester, {
+    required int rowIndex,
+    required String exerciseName,
+    required String sets,
+    required String reps,
+  }) async {
+    // There may be multiple 'Exercise' TextFormFields — scope by rowIndex.
+    final exerciseFields = find.widgetWithText(TextFormField, 'Exercise');
+    await tester.enterText(exerciseFields.at(rowIndex), exerciseName);
+    await tester.pumpAndSettle();
+    // Tap the Autocomplete suggestion to latch the canonical id.
+    await tester.tap(find.text(exerciseName).last);
+    await tester.pumpAndSettle();
+
+    final setsFields = find.widgetWithText(TextFormField, 'Sets');
+    final repsFields = find.widgetWithText(TextFormField, 'Reps');
+    await tester.enterText(setsFields.at(rowIndex), sets);
+    await tester.enterText(repsFields.at(rowIndex), reps);
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('create routine with 2 exercises → saves + persists',
+      (tester) async {
+    _useTallViewport(tester);
+    await tester.pumpWidget(_host(db, const RoutineFormScreen()));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'Push A',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Notes'),
+      'Feels good',
+    );
+
+    // Add first row, fill with Bench Press / 3 / 8.
+    await tester.tap(find.text('Add exercise'));
+    await tester.pumpAndSettle();
+    await fillRow(
+      tester,
+      rowIndex: 0,
+      exerciseName: 'Bench Press',
+      sets: '3',
+      reps: '8',
+    );
+
+    // Add second row, fill with Squat / 4 / 5.
+    await tester.tap(find.text('Add exercise'));
+    await tester.pumpAndSettle();
+    await fillRow(
+      tester,
+      rowIndex: 1,
+      exerciseName: 'Squat',
+      sets: '4',
+      reps: '5',
+    );
+
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    // Routine row persisted.
+    final routines = await routineRepo.listAll();
+    expect(routines, hasLength(1));
+    final routine = routines.single;
+    expect(routine.name, 'Push A');
+    expect(routine.notes, 'Feels good');
+
+    // Two line items persisted in order.
+    final items = await routineRepo.listExercises(routine.id);
+    expect(items, hasLength(2));
+    expect(items[0].exerciseId, benchId);
+    expect(items[0].orderIndex, 0);
+    expect(items[0].targetSets, 3);
+    expect(items[0].targetReps, 8);
+    expect(items[1].exerciseId, squatId);
+    expect(items[1].orderIndex, 1);
+    expect(items[1].targetSets, 4);
+    expect(items[1].targetReps, 5);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('edit routine name → save → persisted', (tester) async {
+    final id = await routineRepo.add(
+      RoutinesCompanion.insert(
+        name: 'Original',
+        createdAt: DateTime(2026, 4, 20),
+      ),
+    );
+    final existing = (await routineRepo.findById(id))!;
+
+    await tester.pumpWidget(
+      _host(db, RoutineFormScreen(existing: existing)),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'Renamed',
+    );
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final after = (await routineRepo.findById(id))!;
+    expect(after.name, 'Renamed');
+    // createdAt preserved (trust rule — no silent mutation).
+    expect(after.createdAt, DateTime(2026, 4, 20));
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('reorder exercises with arrow buttons → persists', (
+    tester,
+  ) async {
+    final id = await routineRepo.add(
+      RoutinesCompanion.insert(
+        name: 'Mixed',
+        createdAt: DateTime(2026, 4, 20),
+      ),
+    );
+    await routineRepo.addExercise(
+      RoutineExercisesCompanion.insert(
+        routineId: id,
+        exerciseId: benchId,
+        orderIndex: 0,
+        targetSets: const Value(3),
+        targetReps: const Value(8),
+      ),
+    );
+    await routineRepo.addExercise(
+      RoutineExercisesCompanion.insert(
+        routineId: id,
+        exerciseId: squatId,
+        orderIndex: 1,
+        targetSets: const Value(4),
+        targetReps: const Value(5),
+      ),
+    );
+    final existing = (await routineRepo.findById(id))!;
+
+    _useTallViewport(tester);
+    await tester.pumpWidget(
+      _host(db, RoutineFormScreen(existing: existing)),
+    );
+    await tester.pumpAndSettle();
+
+    // Move row 1 (Squat) up so the order becomes Squat, Bench Press.
+    final moveUpButtons = find.widgetWithIcon(IconButton, Icons.arrow_upward);
+    // Row 0's up-button is disabled (isFirst), so we target row 1's.
+    await tester.tap(moveUpButtons.at(1));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final after = await routineRepo.listExercises(id);
+    expect(after, hasLength(2));
+    expect(
+      after[0].exerciseId,
+      squatId,
+      reason: 'Squat moved to orderIndex 0',
+    );
+    expect(
+      after[1].exerciseId,
+      benchId,
+      reason: 'Bench dropped to orderIndex 1',
+    );
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('delete routine (AppBar trash) → confirm → cascade removes rows',
+      (tester) async {
+    final id = await routineRepo.add(
+      RoutinesCompanion.insert(
+        name: 'Doomed',
+        createdAt: DateTime(2026, 4, 20),
+      ),
+    );
+    await routineRepo.addExercise(
+      RoutineExercisesCompanion.insert(
+        routineId: id,
+        exerciseId: benchId,
+        orderIndex: 0,
+        targetSets: const Value(3),
+        targetReps: const Value(8),
+      ),
+    );
+    final existing = (await routineRepo.findById(id))!;
+    expect(await routineRepo.listExercises(id), hasLength(1));
+
+    await tester.pumpWidget(
+      _host(db, RoutineFormScreen(existing: existing)),
+    );
+    await tester.pumpAndSettle();
+
+    // Tap the AppBar trash icon.
+    await tester.tap(find.byIcon(Icons.delete_outline));
+    await tester.pumpAndSettle();
+
+    // Confirm dialog → tap Delete.
+    await tester.tap(find.widgetWithText(TextButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Routine gone + cascade removed the line item.
+    expect(await routineRepo.findById(id), isNull);
+    expect(await routineRepo.listExercises(id), isEmpty);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('remove exercise row → confirm → disappears from draft',
+      (tester) async {
+    _useTallViewport(tester);
+    await tester.pumpWidget(_host(db, const RoutineFormScreen()));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Name'),
+      'TwoRows',
+    );
+    await tester.tap(find.text('Add exercise'));
+    await tester.pumpAndSettle();
+    await fillRow(
+      tester,
+      rowIndex: 0,
+      exerciseName: 'Bench Press',
+      sets: '3',
+      reps: '8',
+    );
+    await tester.tap(find.text('Add exercise'));
+    await tester.pumpAndSettle();
+    await fillRow(
+      tester,
+      rowIndex: 1,
+      exerciseName: 'Squat',
+      sets: '4',
+      reps: '5',
+    );
+
+    // Tap the close button on row 1 (index 1 → second close icon).
+    final closeButtons = find.widgetWithIcon(IconButton, Icons.close);
+    await tester.tap(closeButtons.at(1));
+    await tester.pumpAndSettle();
+
+    // Confirm removal.
+    await tester.tap(find.widgetWithText(TextButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    // Save and verify only Bench Press persisted.
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final routines = await routineRepo.listAll();
+    expect(routines, hasLength(1));
+    final items = await routineRepo.listExercises(routines.single.id);
+    expect(items, hasLength(1));
+    expect(items.single.exerciseId, benchId);
+
+    await _drainDriftTimers(tester);
+  });
+}
+
+Future<void> _drainDriftTimers(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox());
+  await tester.pump(const Duration(milliseconds: 1));
+}

--- a/test/features/routines/routine_list_screen_test.dart
+++ b/test/features/routines/routine_list_screen_test.dart
@@ -1,0 +1,78 @@
+// Widget tests for `RoutineListScreen` (#61).
+//
+// Covers the two list states — empty and populated — and asserts
+// newest-first ordering. Navigation into the form / detail is exercised
+// by the other two widget-test files; this one stays scoped to the list
+// surface.
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/repositories/routine_repository.dart';
+import 'package:liftlog_app/features/routines/routine_list_screen.dart';
+import 'package:liftlog_app/providers/app_providers.dart';
+
+Widget _host(AppDatabase db) {
+  return ProviderScope(
+    overrides: [appDatabaseProvider.overrideWithValue(db)],
+    child: const MaterialApp(home: RoutineListScreen()),
+  );
+}
+
+void main() {
+  late AppDatabase db;
+  late RoutineRepository repo;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = RoutineRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  testWidgets('empty state renders the prompt copy', (tester) async {
+    await tester.pumpWidget(_host(db));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No routines yet. Tap + to create one.'), findsOneWidget);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('populated list renders routines newest-first', (tester) async {
+    await repo.add(
+      RoutinesCompanion.insert(
+        name: 'Push A',
+        createdAt: DateTime(2026, 4, 10, 9),
+      ),
+    );
+    await repo.add(
+      RoutinesCompanion.insert(
+        name: 'Pull B',
+        createdAt: DateTime(2026, 4, 20, 9),
+      ),
+    );
+
+    await tester.pumpWidget(_host(db));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Push A'), findsOneWidget);
+    expect(find.text('Pull B'), findsOneWidget);
+    expect(find.byType(ListTile), findsNWidgets(2));
+
+    // Newest-first ordering. Pull B (Apr 20) should be the first tile.
+    final tiles = tester.widgetList<ListTile>(find.byType(ListTile)).toList();
+    final firstTitle = (tiles.first.title! as Text).data;
+    expect(firstTitle, 'Pull B');
+
+    await _drainDriftTimers(tester);
+  });
+}
+
+Future<void> _drainDriftTimers(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox());
+  await tester.pump(const Duration(milliseconds: 1));
+}

--- a/test/features/routines/start_from_routine_service_test.dart
+++ b/test/features/routines/start_from_routine_service_test.dart
@@ -1,0 +1,229 @@
+// Unit tests for `StartFromRoutineService` (issue #61).
+//
+// Covers the seeding contract: a new `WorkoutSession` is created, and
+// planned `ExerciseSet` rows are seeded one-per-target-set per
+// line-item, with running `orderIndex`, `status = planned`, `exerciseId`
+// linked, and the canonical name copied onto `exerciseName`.
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/data/repositories/exercise_repository.dart';
+import 'package:liftlog_app/data/repositories/exercise_set_repository.dart';
+import 'package:liftlog_app/data/repositories/routine_repository.dart';
+import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
+import 'package:liftlog_app/features/routines/start_from_routine_service.dart';
+
+void main() {
+  late AppDatabase db;
+  late RoutineRepository routineRepo;
+  late ExerciseRepository exerciseRepo;
+  late ExerciseSetRepository setsRepo;
+  late WorkoutSessionRepository sessionRepo;
+  late int benchId;
+  late int squatId;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    routineRepo = RoutineRepository(db);
+    exerciseRepo = ExerciseRepository(db);
+    setsRepo = ExerciseSetRepository(db);
+    sessionRepo = WorkoutSessionRepository(db);
+    final bench = await exerciseRepo.addIfMissing(
+      'Bench Press',
+      source: Source.userEntered,
+    );
+    final squat = await exerciseRepo.addIfMissing(
+      'Squat',
+      source: Source.userEntered,
+    );
+    benchId = bench.id;
+    squatId = squat.id;
+  });
+
+  tearDown(() async => db.close());
+
+  Future<int> seedRoutineWithTwoExercises() async {
+    final routineId = await routineRepo.add(
+      RoutinesCompanion.insert(name: 'Push A', createdAt: DateTime(2026, 4, 1)),
+    );
+    await routineRepo.addExercise(
+      RoutineExercisesCompanion.insert(
+        routineId: routineId,
+        exerciseId: benchId,
+        orderIndex: 0,
+        targetSets: const Value(3),
+        targetReps: const Value(8),
+        targetWeight: const Value(80.0),
+        targetWeightUnit: const Value(WeightUnit.kg),
+      ),
+    );
+    await routineRepo.addExercise(
+      RoutineExercisesCompanion.insert(
+        routineId: routineId,
+        exerciseId: squatId,
+        orderIndex: 1,
+        targetSets: const Value(2),
+        targetReps: const Value(5),
+        targetWeight: const Value(100.0),
+        targetWeightUnit: const Value(WeightUnit.kg),
+      ),
+    );
+    return routineId;
+  }
+
+  test('seeds planned sets with running orderIndex and linked exerciseId',
+      () async {
+    final routineId = await seedRoutineWithTwoExercises();
+    final service = StartFromRoutineService(
+      routineRepo: routineRepo,
+      exerciseRepo: exerciseRepo,
+      exerciseSetRepo: setsRepo,
+      sessionRepo: sessionRepo,
+    );
+
+    final now = DateTime(2026, 4, 23, 9);
+    final sessionId = await service.start(routineId, now: now);
+
+    final session = await sessionRepo.findById(sessionId);
+    expect(session, isNotNull);
+    expect(session!.startedAt, now);
+    expect(session.endedAt, isNull, reason: 'session is fresh / open');
+
+    final sets = await setsRepo.listForSession(sessionId);
+    // 3 bench + 2 squat = 5 seeded sets.
+    expect(sets, hasLength(5));
+
+    // orderIndex runs 0..4 across all five, in line-item order.
+    for (var i = 0; i < sets.length; i++) {
+      expect(sets[i].orderIndex, i);
+      expect(
+        sets[i].status,
+        WorkoutSetStatus.planned,
+        reason: 'seeded sets start as planned',
+      );
+    }
+
+    // First 3 → Bench Press (benchId, 8 reps @ 80 kg).
+    for (var i = 0; i < 3; i++) {
+      expect(sets[i].exerciseName, 'Bench Press');
+      expect(sets[i].exerciseId, benchId);
+      expect(sets[i].reps, 8);
+      expect(sets[i].weight, 80.0);
+      expect(sets[i].weightUnit, WeightUnit.kg);
+    }
+    // Next 2 → Squat (squatId, 5 reps @ 100 kg).
+    for (var i = 3; i < 5; i++) {
+      expect(sets[i].exerciseName, 'Squat');
+      expect(sets[i].exerciseId, squatId);
+      expect(sets[i].reps, 5);
+      expect(sets[i].weight, 100.0);
+    }
+  });
+
+  test(
+      'null target_weight → weight 0.0 and default unit kg; null target_sets → one set',
+      () async {
+    final routineId = await routineRepo.add(
+      RoutinesCompanion.insert(
+        name: 'Bodyweight',
+        createdAt: DateTime(2026, 4, 1),
+      ),
+    );
+    // Rep-only row: no weight → seed as 0.0 kg (routine form normally
+    // enforces sets/reps ≥ 1, but the service must still handle nulls
+    // defensively since older rows may exist).
+    await routineRepo.addExercise(
+      RoutineExercisesCompanion.insert(
+        routineId: routineId,
+        exerciseId: benchId,
+        orderIndex: 0,
+        targetSets: const Value(2),
+        targetReps: const Value(10),
+        // weight + unit omitted = null on read
+      ),
+    );
+    final service = StartFromRoutineService(
+      routineRepo: routineRepo,
+      exerciseRepo: exerciseRepo,
+      exerciseSetRepo: setsRepo,
+      sessionRepo: sessionRepo,
+    );
+
+    final sessionId = await service.start(
+      routineId,
+      now: DateTime(2026, 4, 23),
+    );
+    final sets = await setsRepo.listForSession(sessionId);
+    expect(sets, hasLength(2));
+    for (final s in sets) {
+      expect(s.weight, 0.0);
+      expect(s.weightUnit, WeightUnit.kg);
+      expect(s.reps, 10);
+      expect(s.status, WorkoutSetStatus.planned);
+    }
+  });
+
+  test('empty routine → session created but no sets seeded', () async {
+    final routineId = await routineRepo.add(
+      RoutinesCompanion.insert(name: 'Empty', createdAt: DateTime(2026, 4, 1)),
+    );
+    final service = StartFromRoutineService(
+      routineRepo: routineRepo,
+      exerciseRepo: exerciseRepo,
+      exerciseSetRepo: setsRepo,
+      sessionRepo: sessionRepo,
+    );
+
+    final sessionId = await service.start(
+      routineId,
+      now: DateTime(2026, 4, 23),
+    );
+    expect(await sessionRepo.findById(sessionId), isNotNull);
+    expect(await setsRepo.listForSession(sessionId), isEmpty);
+  });
+
+  test(
+    'weight-only null unit falls back to kg default (defensive for old rows)',
+    () async {
+      // Construct a pathological old row: has weight set but NO unit
+      // (shouldn't happen through the UI, but the model allows it since
+      // targetWeightUnit is nullable). Service must fall back to kg —
+      // the documented default.
+      final routineId = await routineRepo.add(
+        RoutinesCompanion.insert(
+          name: 'Legacy',
+          createdAt: DateTime(2026, 4, 1),
+        ),
+      );
+      await routineRepo.addExercise(
+        RoutineExercisesCompanion.insert(
+          routineId: routineId,
+          exerciseId: benchId,
+          orderIndex: 0,
+          targetSets: const Value(1),
+          targetReps: const Value(5),
+          targetWeight: const Value(60.0),
+          // targetWeightUnit omitted = null
+        ),
+      );
+      final service = StartFromRoutineService(
+        routineRepo: routineRepo,
+        exerciseRepo: exerciseRepo,
+        exerciseSetRepo: setsRepo,
+        sessionRepo: sessionRepo,
+      );
+      final sessionId = await service.start(
+        routineId,
+        now: DateTime(2026, 4, 23),
+      );
+      final sets = await setsRepo.listForSession(sessionId);
+      expect(sets, hasLength(1));
+      expect(sets.single.weight, 60.0);
+      expect(sets.single.weightUnit, WeightUnit.kg);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Closes the E2 UI loop over the `Routines` + `RoutineExercises` data model shipped in S5.5. The founder can now create / edit / delete routines, reorder exercises with up/down buttons, and spin up a new workout that seeds planned `ExerciseSet` rows from the routine's targets.

Closes #61.

## Scope in
- `lib/features/routines/routine_list_screen.dart` — newest-first list with a `+` FAB; empty state "No routines yet. Tap + to create one."
- `lib/features/routines/routine_form_screen.dart` — create + edit. Name, notes (max 500), ordered draft rows with per-row Autocomplete exercise picker, target sets / reps / weight / unit, reorder buttons, per-row delete confirm, routine-level delete confirm in edit mode.
- `lib/features/routines/routine_detail_screen.dart` — name + notes header, line-item list with formatted targets ("3 × 8 · 80 kg"), "Start workout" primary CTA + "Edit" secondary.
- `lib/features/routines/start_from_routine_service.dart` — testable service; creates the session + seeds planned sets in `orderIndex` order with running global index. Documented conservative fallbacks for null targets (sets→1, reps→0, weight→0.0, unit→kg). Missing exercise row → `StateError` rather than a silent placeholder.
- `WorkoutListScreen` AppBar IconButton (`Icons.format_list_bulleted`) opens `RoutineListScreen`.
- `ExerciseRepository.findById(int)` + `RoutineRepository.deleteExercise(int)` — minimal data-layer helpers the new service + form need.

## Scope out
- Routine templates / samples library (empty state is fine).
- Routine sharing / cloud.
- Auto-progression (E7).
- Super-sets / circuits / rest timers.
- Drag-and-drop reorder via `ReorderableListView` — up/down buttons chosen for widget-test simplicity (per the brief).

## Acceptance criteria
- [x] Routines reachable from Workouts tab (AppBar IconButton).
- [x] Create + edit + delete + reorder work as specified.
- [x] Start-workout-from-routine seeds sets correctly + opens `WorkoutSessionScreen` (via `pushReplacement` so back-nav returns to Routines).
- [x] Cascade delete verified at widget-test level (delete routine → `listExercises` returns empty).
- [x] Arch test green: no `Source.` references in feature code; narrow `show Value;` drift imports only.
- [x] `flutter analyze` clean; `flutter test` 340/340 green (+14 over baseline 326).

## Deliberate choices
- **Autocomplete picker duplicated**, not extracted. The S6.2 set-form picker additionally owns recent-exercise chips + a latched-canonical-id dance that routines don't need. Follow-up: if a third consumer appears, extract into `lib/features/workouts/exercise_picker.dart`.
- **Wipe-and-rewrite on edit-save.** Edit mode deletes every existing `routine_exercises` row and re-inserts the draft in the user's order. Keeps the form's reorder / add / remove flow trivially correct and the repo surface minimal. The parent `routines` row is preserved via `routineRepo.update(copyWith(...))` so `createdAt` + `source` don't mutate silently.
- **Widget tests for multi-row forms use an 800×2400 virtual viewport** (`tester.view.physicalSize`) so all exercise cards + AppBar affordances fit on one screen. Easier than scrolling helpers; noted in-file as a comment.

## Trust rules honored
- Seeded planned sets use conservative per-row fallbacks for missing target columns, documented in the service; never silently rewrite the routine itself.
- Missing canonical exercise row → `StateError`. No silent fallback.
- Routine delete + per-row removal both go through explicit confirm dialogs (shared `showDeleteConfirm`).
- Autocomplete picker blocks save if the user's free-typed text didn't resolve to a canonical `Exercise` row.
- Update paths use `replace()` (`RoutineRepository.update`, `ExerciseSetRepository.add`) — never silently preserving cleared nullables.

## Test plan
- [x] `flutter analyze` — clean.
- [x] `flutter test` — 340/340 green.
- [x] Arch test (`test/arch/data_access_boundary_test.dart`) — green on all four rules.
- [x] `grep -rn "Source\." lib/features/` — only doc-comment mentions remain (arch-test-stripped).
- [x] `grep -rn "import 'package:drift" lib/features/routines/` — narrow `show Value` only.

## New env vars / secrets
None.

## New deps
None. Uses Flutter's built-in `Autocomplete<T>` per the brief.