### PR TITLE
#72 — S7.4 — Session notes UI (surface WorkoutSession.note)

### DIFF
--- a/lib/data/repositories/workout_session_repository.dart
+++ b/lib/data/repositories/workout_session_repository.dart
@@ -20,6 +20,29 @@ class WorkoutSessionRepository {
     await _db.update(_db.workoutSessions).replace(session);
   }
 
+  /// Persists a note on [sessionId]. Empty / whitespace-only strings are
+  /// normalized to `null` so the column is either a real note or absent —
+  /// keeps the UI's "+ Add note" vs. rendered-note branch a clean boolean.
+  ///
+  /// Read-then-`replace` (not `.write`) so clearing the note actually
+  /// nulls the column (Drift's `write` silently drops nulls per the
+  /// `write` vs. `replace` trust-rule skill).
+  ///
+  /// Errors surface to the caller — UI shows a SnackBar and does not
+  /// mutate its own state (trust rule: no silent fallbacks).
+  Future<void> updateNote(int sessionId, String? note) async {
+    final row = await findById(sessionId);
+    if (row == null) {
+      throw StateError(
+        'WorkoutSessionRepository.updateNote: session $sessionId not found',
+      );
+    }
+    final normalized = (note == null || note.trim().isEmpty) ? null : note;
+    await _db.update(_db.workoutSessions).replace(
+          row.copyWith(note: Value(normalized)),
+        );
+  }
+
   Future<int> delete(int id) =>
       (_db.delete(_db.workoutSessions)..where((t) => t.id.equals(id))).go();
 

--- a/lib/features/routines/routine_detail_screen.dart
+++ b/lib/features/routines/routine_detail_screen.dart
@@ -73,8 +73,19 @@ class _RoutineDetailScreenState extends ConsumerState<RoutineDetailScreen> {
     });
   }
 
-  Future<void> _startWorkout() async {
+  Future<void> _startWorkout(Routine routine) async {
     if (_starting) return;
+    // Pre-populate the note field from the routine's notes column, if
+    // present. The user can still edit or clear before confirm — this
+    // is a helpful default, not a silent mutation (trust rule: every
+    // decision is overridable).
+    final result = await showDialog<_StartConfirmResult>(
+      context: context,
+      builder: (ctx) =>
+          _StartConfirmDialog(initialNote: routine.notes ?? ''),
+    );
+    if (result == null) return;
+    if (!mounted) return;
     setState(() => _starting = true);
     final service = StartFromRoutineService(
       routineRepo: ref.read(routineRepositoryProvider),
@@ -86,6 +97,7 @@ class _RoutineDetailScreenState extends ConsumerState<RoutineDetailScreen> {
       final sessionId = await service.start(
         widget.routineId,
         now: DateTime.now(),
+        note: result.note,
       );
       if (!mounted) return;
       // `pushReplacement` so back navigation from the session screen
@@ -130,7 +142,7 @@ class _RoutineDetailScreenState extends ConsumerState<RoutineDetailScreen> {
             view: view,
             starting: _starting,
             onEdit: () => _openEdit(view.routine!),
-            onStart: _startWorkout,
+            onStart: () => _startWorkout(view.routine!),
           );
         },
       ),
@@ -256,5 +268,69 @@ class _LineView {
     }
     if (parts.isEmpty) return 'No targets set';
     return parts.join(' · ');
+  }
+}
+
+/// Result returned from the start-from-routine confirm dialog. `null`
+/// return from `showDialog` means the user cancelled — no session is
+/// created. A non-null result carries the (possibly empty) note; the
+/// service normalizes empty → `null` before persisting.
+class _StartConfirmResult {
+  const _StartConfirmResult(this.note);
+  final String? note;
+}
+
+/// Confirm step before seeding a session from a routine. The user can
+/// edit or clear the pre-populated note (from `Routines.notes`) before
+/// tapping Start. Cancel aborts — no session is created.
+class _StartConfirmDialog extends StatefulWidget {
+  const _StartConfirmDialog({required this.initialNote});
+
+  final String initialNote;
+
+  @override
+  State<_StartConfirmDialog> createState() => _StartConfirmDialogState();
+}
+
+class _StartConfirmDialogState extends State<_StartConfirmDialog> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialNote);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Start workout'),
+      content: TextField(
+        controller: _controller,
+        autofocus: true,
+        maxLines: 4,
+        decoration: const InputDecoration(
+          hintText: 'Optional note (leave blank to skip)',
+          border: OutlineInputBorder(),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context)
+              .pop(_StartConfirmResult(_controller.text)),
+          child: const Text('Start'),
+        ),
+      ],
+    );
   }
 }

--- a/lib/features/routines/start_from_routine_service.dart
+++ b/lib/features/routines/start_from_routine_service.dart
@@ -53,19 +53,37 @@ class StartFromRoutineService {
   ///
   /// [now] is injectable so widget tests can assert deterministic
   /// `startedAt` values.
-  Future<int> start(int routineId, {required DateTime now}) async {
+  ///
+  /// [note] is the optional session-level note (trust rule: provenance
+  /// stays user-chosen; the caller may pre-populate from the routine's
+  /// `notes` column but the user can edit/clear before confirm). Empty
+  /// or whitespace-only strings are normalized to `null` at persistence
+  /// time so the `WorkoutSessions.note` column is never an empty string.
+  Future<int> start(
+    int routineId, {
+    required DateTime now,
+    String? note,
+  }) async {
+    final normalizedNote =
+        (note == null || note.trim().isEmpty) ? null : note;
     final lineItems = await _routineRepo.listExercises(routineId);
     if (lineItems.isEmpty) {
       // Empty routine → still create the session (user might want a
       // blank slate named by the routine), but seed no sets. Matches the
       // manual "Start workout" flow.
       return _sessionRepo.add(
-        WorkoutSessionsCompanion.insert(startedAt: now),
+        WorkoutSessionsCompanion.insert(
+          startedAt: now,
+          note: Value(normalizedNote),
+        ),
       );
     }
 
     final sessionId = await _sessionRepo.add(
-      WorkoutSessionsCompanion.insert(startedAt: now),
+      WorkoutSessionsCompanion.insert(
+        startedAt: now,
+        note: Value(normalizedNote),
+      ),
     );
 
     // Running global index across every exercise's sets, so the session

--- a/lib/features/workouts/workout_list_screen.dart
+++ b/lib/features/workouts/workout_list_screen.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -157,10 +158,26 @@ class WorkoutListScreen extends ConsumerWidget {
   }
 
   Future<void> _startSession(BuildContext context, WidgetRef ref) async {
+    // Ask for an optional note first — keeps the FAB's "+ tap → logging"
+    // rhythm while making `WorkoutSessions.note` reachable at creation.
+    // Cancel from the dialog aborts the whole start flow; empty-on-save
+    // persists with `note: null` (no note, not an empty string).
+    final result = await showDialog<_StartSessionResult>(
+      context: context,
+      builder: (ctx) => const _StartSessionDialog(),
+    );
+    if (result == null) return;
+    if (!context.mounted) return;
     final repo = ref.read(workoutSessionRepositoryProvider);
     try {
+      final note = result.note;
+      final normalized =
+          (note == null || note.trim().isEmpty) ? null : note;
       final id = await repo.add(
-        WorkoutSessionsCompanion.insert(startedAt: DateTime.now()),
+        WorkoutSessionsCompanion.insert(
+          startedAt: DateTime.now(),
+          note: Value(normalized),
+        ),
       );
       if (!context.mounted) return;
       Navigator.of(context).push(
@@ -209,6 +226,62 @@ class _SectionHeader extends StatelessWidget {
           fontWeight: FontWeight.w600,
         ),
       ),
+    );
+  }
+}
+
+/// Result from the Start Workout dialog. `null` return from `showDialog`
+/// means the user cancelled — no session is created. Non-null carries
+/// the optional note (may itself be `null` / empty).
+class _StartSessionResult {
+  const _StartSessionResult(this.note);
+  final String? note;
+}
+
+/// Pre-session dialog that asks for an optional note before creating the
+/// `WorkoutSession`. Kept deliberately lightweight — no date picker, no
+/// routine picker (start-from-routine has its own flow) — so the normal
+/// "tap Start, start logging" rhythm stays one confirm away.
+class _StartSessionDialog extends StatefulWidget {
+  const _StartSessionDialog();
+
+  @override
+  State<_StartSessionDialog> createState() => _StartSessionDialogState();
+}
+
+class _StartSessionDialogState extends State<_StartSessionDialog> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Start workout'),
+      content: TextField(
+        controller: _controller,
+        autofocus: true,
+        maxLines: 4,
+        decoration: const InputDecoration(
+          hintText: 'Optional note (leave blank to skip)',
+          border: OutlineInputBorder(),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context)
+              .pop(_StartSessionResult(_controller.text)),
+          child: const Text('Start'),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/workouts/workout_session_screen.dart
+++ b/lib/features/workouts/workout_session_screen.dart
@@ -47,6 +47,10 @@ class WorkoutSessionScreen extends ConsumerWidget {
             sessionAsync: session,
             onEndSession: () => _endSession(context, ref),
           ),
+          _NoteRow(
+            sessionAsync: session,
+            onEdit: (current) => _editNote(context, ref, current),
+          ),
           const Divider(height: 1),
           Expanded(
             child: sets.when(
@@ -107,6 +111,29 @@ class WorkoutSessionScreen extends ConsumerWidget {
         nextOrderIndex: count,
       ),
     ));
+  }
+
+  Future<void> _editNote(
+    BuildContext context,
+    WidgetRef ref,
+    String? current,
+  ) async {
+    final next = await showDialog<_NoteDialogResult>(
+      context: context,
+      builder: (ctx) => _NoteEditDialog(initial: current),
+    );
+    if (next == null) return; // Cancel or dismiss — no mutation.
+    if (!context.mounted) return;
+    try {
+      await ref
+          .read(workoutSessionRepositoryProvider)
+          .updateNote(sessionId, next.note);
+    } catch (e) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Could not save note: $e')),
+      );
+    }
   }
 
   Future<void> _endSession(BuildContext context, WidgetRef ref) async {
@@ -219,6 +246,113 @@ class _SessionHeader extends StatelessWidget {
         padding: const EdgeInsets.all(16),
         child: Text('Could not load workout: $err'),
       ),
+    );
+  }
+}
+
+/// Renders the session's note — or a "+ Add note" affordance when the
+/// column is null. Tapping either surface opens the edit dialog via the
+/// [onEdit] callback with the current note as its argument.
+class _NoteRow extends StatelessWidget {
+  const _NoteRow({required this.sessionAsync, required this.onEdit});
+
+  final AsyncValue<WorkoutSession?> sessionAsync;
+  final void Function(String? current) onEdit;
+
+  @override
+  Widget build(BuildContext context) {
+    return sessionAsync.maybeWhen(
+      data: (s) {
+        if (s == null) return const SizedBox.shrink();
+        final note = s.note;
+        if (note == null || note.trim().isEmpty) {
+          return Align(
+            alignment: Alignment.centerLeft,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(8, 0, 16, 8),
+              child: TextButton.icon(
+                onPressed: () => onEdit(null),
+                icon: const Icon(Icons.add, size: 18),
+                label: const Text('Add note'),
+              ),
+            ),
+          );
+        }
+        return InkWell(
+          onTap: () => onEdit(note),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+            child: Text(
+              note,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    fontStyle: FontStyle.italic,
+                    color: Theme.of(context).hintColor,
+                  ),
+            ),
+          ),
+        );
+      },
+      orElse: () => const SizedBox.shrink(),
+    );
+  }
+}
+
+/// Result from the note edit dialog. `null` return from `showDialog`
+/// means the user cancelled; a non-null result carries the new note
+/// (which may itself be `null` / empty if the user cleared the field).
+class _NoteDialogResult {
+  const _NoteDialogResult(this.note);
+  final String? note;
+}
+
+class _NoteEditDialog extends StatefulWidget {
+  const _NoteEditDialog({required this.initial});
+
+  final String? initial;
+
+  @override
+  State<_NoteEditDialog> createState() => _NoteEditDialogState();
+}
+
+class _NoteEditDialogState extends State<_NoteEditDialog> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initial ?? '');
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.initial == null ? 'Add note' : 'Edit note'),
+      content: TextField(
+        controller: _controller,
+        autofocus: true,
+        maxLines: 4,
+        decoration: const InputDecoration(
+          hintText: 'Optional note for this workout',
+          border: OutlineInputBorder(),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context)
+              .pop(_NoteDialogResult(_controller.text)),
+          child: const Text('Save'),
+        ),
+      ],
     );
   }
 }

--- a/test/data/workout_repository_test.dart
+++ b/test/data/workout_repository_test.dart
@@ -142,6 +142,56 @@ void main() {
     );
   });
 
+  group('updateNote', () {
+    test('persists a non-null note and round-trips', () async {
+      final id = await sessions.add(WorkoutSessionsCompanion.insert(
+        startedAt: DateTime(2026, 4, 23),
+      ));
+
+      await sessions.updateNote(id, 'Felt strong today');
+      final row = await sessions.findById(id);
+      expect(row, isNotNull);
+      expect(row!.note, 'Felt strong today');
+    });
+
+    test('empty string and whitespace normalize to null', () async {
+      final id = await sessions.add(WorkoutSessionsCompanion.insert(
+        startedAt: DateTime(2026, 4, 23),
+        note: const Value('Initial'),
+      ));
+
+      // Clear via empty string.
+      await sessions.updateNote(id, '');
+      expect((await sessions.findById(id))!.note, isNull);
+
+      // Whitespace-only also normalizes to null.
+      await sessions.updateNote(id, '   ');
+      expect((await sessions.findById(id))!.note, isNull);
+
+      // Explicit null clears too.
+      await sessions.updateNote(id, 'something');
+      await sessions.updateNote(id, null);
+      expect((await sessions.findById(id))!.note, isNull);
+    });
+
+    test('overwrites existing note (no silent preserve)', () async {
+      final id = await sessions.add(WorkoutSessionsCompanion.insert(
+        startedAt: DateTime(2026, 4, 23),
+        note: const Value('first'),
+      ));
+
+      await sessions.updateNote(id, 'second');
+      expect((await sessions.findById(id))!.note, 'second');
+    });
+
+    test('missing session id throws StateError', () async {
+      await expectLater(
+        sessions.updateNote(999, 'note'),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+
   group('listRecentDistinctExerciseNames', () {
     test('empty DB returns an empty list', () async {
       expect(await sets.listRecentDistinctExerciseNames(), isEmpty);

--- a/test/features/routines/routine_detail_screen_test.dart
+++ b/test/features/routines/routine_detail_screen_test.dart
@@ -116,6 +116,10 @@ void main() {
       await tester.tap(find.widgetWithText(FilledButton, 'Start workout'));
       await tester.pumpAndSettle();
 
+      // Confirm dialog opens — tap Start to proceed without editing the note.
+      await tester.tap(find.widgetWithText(TextButton, 'Start'));
+      await tester.pumpAndSettle();
+
       // Navigation landed on WorkoutSessionScreen.
       expect(find.byType(WorkoutSessionScreen), findsOneWidget);
       // Routine detail replaced — back nav returns to Routines, not detail.
@@ -136,6 +140,92 @@ void main() {
       expect(sets.take(3).every((s) => s.exerciseId == benchId), isTrue);
       // Next 4 → Squat.
       expect(sets.skip(3).every((s) => s.exerciseId == squatId), isTrue);
+
+      await _drainDriftTimers(tester);
+    },
+  );
+
+  testWidgets(
+    'Start workout confirm dialog pre-populates from routine.notes and '
+    'persists on confirm',
+    (tester) async {
+      final id = await seedRoutine();
+
+      await tester.pumpWidget(_host(db, RoutineDetailScreen(routineId: id)));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Start workout'));
+      await tester.pumpAndSettle();
+
+      // Dialog renders with the routine's notes pre-populated in the field.
+      expect(find.byType(AlertDialog), findsOneWidget);
+      expect(
+        find.widgetWithText(TextField, 'Upper body'),
+        findsOneWidget,
+        reason: 'note field pre-populated from routines.notes',
+      );
+
+      // Edit the note before confirming.
+      await tester.enterText(find.byType(TextField), 'Starting strong');
+      await tester.tap(find.widgetWithText(TextButton, 'Start'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(WorkoutSessionScreen), findsOneWidget);
+
+      final sessions = await sessionRepo.listAll();
+      expect(sessions, hasLength(1));
+      expect(sessions.single.note, 'Starting strong');
+
+      await _drainDriftTimers(tester);
+    },
+  );
+
+  testWidgets(
+    'Start workout confirm dialog Cancel aborts (no session created)',
+    (tester) async {
+      final id = await seedRoutine();
+
+      await tester.pumpWidget(_host(db, RoutineDetailScreen(routineId: id)));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Start workout'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pumpAndSettle();
+
+      // No navigation; no session; still on the detail screen.
+      expect(find.byType(WorkoutSessionScreen), findsNothing);
+      expect(find.byType(RoutineDetailScreen), findsOneWidget);
+      expect(await sessionRepo.listAll(), isEmpty);
+
+      await _drainDriftTimers(tester);
+    },
+  );
+
+  testWidgets(
+    'Start workout confirm dialog clearing the note persists null',
+    (tester) async {
+      final id = await seedRoutine();
+
+      await tester.pumpWidget(_host(db, RoutineDetailScreen(routineId: id)));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Start workout'));
+      await tester.pumpAndSettle();
+
+      // Clear pre-populated note, then confirm.
+      await tester.enterText(find.byType(TextField), '');
+      await tester.tap(find.widgetWithText(TextButton, 'Start'));
+      await tester.pumpAndSettle();
+
+      final sessions = await sessionRepo.listAll();
+      expect(sessions, hasLength(1));
+      expect(
+        sessions.single.note,
+        isNull,
+        reason: 'empty string normalizes to null',
+      );
 
       await _drainDriftTimers(tester);
     },

--- a/test/features/workouts/workout_list_screen_test.dart
+++ b/test/features/workouts/workout_list_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:liftlog_app/data/database.dart';
 import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
 import 'package:liftlog_app/features/workouts/workout_list_screen.dart';
+import 'package:liftlog_app/features/workouts/workout_session_screen.dart';
 import 'package:liftlog_app/providers/app_providers.dart';
 import 'package:liftlog_app/sources/health_kit/health_source.dart';
 import 'package:liftlog_app/sources/health_kit/health_source_fake.dart';
@@ -120,6 +121,83 @@ void main() {
       await _drainDriftTimers(tester);
     },
   );
+
+  testWidgets('Start workout dialog persists note on the new session', (
+    tester,
+  ) async {
+    await tester.pumpWidget(app(hk: HealthSourceFake.notAuthorized()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(FloatingActionButton, 'Start workout'));
+    await tester.pumpAndSettle();
+
+    // Start dialog is up.
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    await tester.enterText(
+      find.byType(TextField),
+      'Heavy day — deadlift focus',
+    );
+    await tester.tap(find.widgetWithText(TextButton, 'Start'));
+    await tester.pumpAndSettle();
+
+    // Navigated to session screen.
+    expect(find.byType(WorkoutSessionScreen), findsOneWidget);
+
+    // The single created session has the note persisted.
+    final repo = WorkoutSessionRepository(db);
+    final all = await repo.listAll();
+    expect(all, hasLength(1));
+    expect(all.single.note, 'Heavy day — deadlift focus');
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('Start workout dialog with empty note persists null', (
+    tester,
+  ) async {
+    await tester.pumpWidget(app(hk: HealthSourceFake.notAuthorized()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(FloatingActionButton, 'Start workout'));
+    await tester.pumpAndSettle();
+
+    // Leave field blank; tap Start.
+    await tester.tap(find.widgetWithText(TextButton, 'Start'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(WorkoutSessionScreen), findsOneWidget);
+    final repo = WorkoutSessionRepository(db);
+    final all = await repo.listAll();
+    expect(all, hasLength(1));
+    expect(
+      all.single.note,
+      isNull,
+      reason: 'empty string normalizes to null (no empty-string columns)',
+    );
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('Start workout dialog Cancel aborts (no session created)', (
+    tester,
+  ) async {
+    await tester.pumpWidget(app(hk: HealthSourceFake.notAuthorized()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(FloatingActionButton, 'Start workout'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    // No navigation; no session.
+    expect(find.byType(WorkoutSessionScreen), findsNothing);
+    final repo = WorkoutSessionRepository(db);
+    expect(await repo.listAll(), isEmpty);
+
+    await _drainDriftTimers(tester);
+  });
 }
 
 Future<void> _drainDriftTimers(WidgetTester tester) async {

--- a/test/features/workouts/workout_session_screen_test.dart
+++ b/test/features/workouts/workout_session_screen_test.dart
@@ -1,0 +1,139 @@
+// Widget tests for `WorkoutSessionScreen` note UI (S7.4 / #72).
+//
+// Covers the session-level note surface:
+// - non-null note renders as italic muted text above the sets list
+// - null note shows a "+ Add note" affordance in the same slot
+// - tap opens the edit dialog; Save persists via the repo; Cancel doesn't
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
+import 'package:liftlog_app/features/workouts/workout_session_screen.dart';
+import 'package:liftlog_app/providers/app_providers.dart';
+import 'package:liftlog_app/sources/health_kit/health_source_fake.dart';
+
+Widget _host(AppDatabase db, Widget child) {
+  return ProviderScope(
+    overrides: [
+      appDatabaseProvider.overrideWithValue(db),
+      healthSourceProvider.overrideWithValue(HealthSourceFake.notAuthorized()),
+    ],
+    child: MaterialApp(home: child),
+  );
+}
+
+void main() {
+  late AppDatabase db;
+  late WorkoutSessionRepository sessions;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    sessions = WorkoutSessionRepository(db);
+  });
+
+  tearDown(() async => db.close());
+
+  testWidgets('session with non-null note renders note text', (tester) async {
+    final id = await sessions.add(WorkoutSessionsCompanion.insert(
+      startedAt: DateTime(2026, 4, 23, 10),
+      note: const Value('Felt strong today'),
+    ));
+
+    await tester.pumpWidget(_host(db, WorkoutSessionScreen(sessionId: id)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Felt strong today'), findsOneWidget);
+    // No "Add note" CTA when a note is already present.
+    expect(find.text('Add note'), findsNothing);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('session with null note shows "+ Add note" affordance', (
+    tester,
+  ) async {
+    final id = await sessions.add(WorkoutSessionsCompanion.insert(
+      startedAt: DateTime(2026, 4, 23, 10),
+    ));
+
+    await tester.pumpWidget(_host(db, WorkoutSessionScreen(sessionId: id)));
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(TextButton, 'Add note'), findsOneWidget);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('tapping "+ Add note" opens dialog; Save persists', (
+    tester,
+  ) async {
+    final id = await sessions.add(WorkoutSessionsCompanion.insert(
+      startedAt: DateTime(2026, 4, 23, 10),
+    ));
+
+    await tester.pumpWidget(_host(db, WorkoutSessionScreen(sessionId: id)));
+    await tester.pumpAndSettle();
+
+    // Tap the TextButton-labelled "Add note" affordance (the dialog
+    // title will also render "Add note" once opened, so we scope the
+    // tap to the button).
+    await tester.tap(find.widgetWithText(TextButton, 'Add note'));
+    await tester.pumpAndSettle();
+
+    // Dialog is up.
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'Back squat felt heavy');
+    await tester.tap(find.widgetWithText(TextButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    // DB was updated.
+    final row = await sessions.findById(id);
+    expect(row!.note, 'Back squat felt heavy');
+
+    // The note now renders above the sets list (the same find.text the
+    // first test uses — proves the live stream re-renders the row).
+    expect(find.text('Back squat felt heavy'), findsOneWidget);
+    // Add-note CTA replaced by the rendered note.
+    expect(find.widgetWithText(TextButton, 'Add note'), findsNothing);
+
+    await _drainDriftTimers(tester);
+  });
+
+  testWidgets('Cancel from the note dialog discards (no mutation)', (
+    tester,
+  ) async {
+    final id = await sessions.add(WorkoutSessionsCompanion.insert(
+      startedAt: DateTime(2026, 4, 23, 10),
+      note: const Value('original'),
+    ));
+
+    await tester.pumpWidget(_host(db, WorkoutSessionScreen(sessionId: id)));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('original'));
+    await tester.pumpAndSettle();
+
+    // Clear and type new text, then Cancel — should NOT persist.
+    await tester.enterText(find.byType(TextField), 'new content');
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    // DB still has the original note.
+    final row = await sessions.findById(id);
+    expect(row!.note, 'original');
+    expect(find.text('original'), findsOneWidget);
+
+    await _drainDriftTimers(tester);
+  });
+}
+
+Future<void> _drainDriftTimers(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox());
+  await tester.pump(const Duration(milliseconds: 1));
+}


### PR DESCRIPTION
Closes #72.

## Summary
Surfaces the existing `WorkoutSessions.note` column in the UI and adds
the repository plumbing to write to it. No schema change.

## Scope (from issue #72)
- Session detail screen renders the note (italic/muted) above the sets
  list, or shows a "+ Add note" affordance when null. Tap opens a
  dialog (4-line `TextField` + Save/Cancel) that persists via
  `WorkoutSessionRepository.updateNote`.
- New workout (Start FAB) opens an optional-note dialog before creating
  the session; note lands on `WorkoutSession.note`.
- Start-workout-from-routine flow adds a confirm step with an optional
  note field pre-populated from `Routines.notes` (the v4 schema already
  carries a `notes` column — see schema observation below).
- New repo method `WorkoutSessionRepository.updateNote(int, String?)`.

## Schema observation
The scope brief asked whether `Routines.note` exists. **It's named
`notes` (plural)** in `lib/data/database.dart` (v4). Same semantic
intent — a free-form routine-level note — so S7.4 uses it as the
pre-fill source. No migration needed.

No Sprint-8 seed required: the existing column already covers the
scope. Renaming `notes` → `note` for symmetry with `WorkoutSession.note`
is out of scope (breaking rename) — call out if you want that raised as
a separate cleanup.

## Repo method
`WorkoutSessionRepository.updateNote(int sessionId, String? note)`:
- read-then-`replace` inside the method so clearing a note actually
  nulls the column (Drift `write` silently preserves nulls — trust-rule
  skill #1)
- empty / whitespace-only strings normalize to `null` before write
  (semantic cleanup, not a silent conversion — documented in the doc
  comment)
- missing session id throws `StateError`; caller surfaces as SnackBar

## Trust rules
- Save failures bubble to a `SnackBar` and do not mutate local state
  (no silent fallback).
- Clearing a note is a save, not a delete — no confirm modal (note is
  not derived-consequential). Empty string and whitespace-only both
  collapse to `null` so the column is either a real note or absent.
- Pre-fill of the start-from-routine note from `Routines.notes` is a
  default, not an apply — user can still edit or clear before confirm
  (every decision is overridable).

## Arch guardrails
- `lib/features/workouts/**` drift-free except `show Value;` (arch
  guardrail #1 clean).
- No `Source.` references in features (arch guardrail #4 clean).
- Repo uses `.replace(row.copyWith(...))`; no `.write(` (arch
  guardrail #2 clean).
- All writes awaited; failures bubble to the UI.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — 376/376 (was 362 before; +14 new)
- [x] `flutter build ios --debug --no-codesign` green, then `flutter clean`
- [x] `dart format` applied only to the 9 files touched

New tests:
- 4 × `WorkoutSessionRepository.updateNote` unit (persist / clear via
  empty+whitespace+explicit-null / overwrite / missing-id throws)
- 4 × `WorkoutSessionScreen` widget (non-null renders, null shows Add
  note, tap+save persists, cancel discards)
- 3 × `WorkoutListScreen` widget (start dialog persists, empty→null,
  cancel aborts)
- 3 × `RoutineDetailScreen` widget (pre-populate from routines.notes,
  cancel aborts, clearing persists null)

Existing `RoutineDetailScreen` "Start workout seeds planned sets"
test updated to tap through the new confirm dialog.

## Device-verification notes (optional)
This PR is UI-surface heavy; PM verification is code-level only per
the 2026-04-23 policy. If the founder wants a quick device check:
1. Start a new workout → dialog appears → Cancel or type a note, Start
2. Open the session → note renders, or "+ Add note" affordance shows
3. Tap the slot → dialog with 4-line field → Save / Cancel work
4. Open Routines → pick a routine with notes → tap Start → confirm
   dialog pre-fills from routine notes → edit/clear/Start works

🤖 Generated with [Claude Code](https://claude.com/claude-code)