### PR TITLE
#70 — S7.2 — Typed CloudKit record save + fetch

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
 		CE01B71100000001000CE001 /* CloudKitBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01B71000000001000CE001 /* CloudKitBridge.swift */; };
 		CE01B71300000001000CE001 /* CloudKitAccountStatusHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01B71200000001000CE001 /* CloudKitAccountStatusHandler.swift */; };
+		CE01B72100000002000CE002 /* CloudKitRecordCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01B72000000002000CE002 /* CloudKitRecordCodec.swift */; };
+		CE01B72300000002000CE002 /* SaveRecordHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01B72200000002000CE002 /* SaveRecordHandler.swift */; };
+		CE01B72500000002000CE002 /* GetRecordHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01B72400000002000CE002 /* GetRecordHandler.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -72,6 +75,9 @@
 		FD6AF2C02F9B6D0A00FAF320 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		CE01B71000000001000CE001 /* CloudKitBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitBridge.swift; sourceTree = "<group>"; };
 		CE01B71200000001000CE001 /* CloudKitAccountStatusHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitAccountStatusHandler.swift; sourceTree = "<group>"; };
+		CE01B72000000002000CE002 /* CloudKitRecordCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitRecordCodec.swift; sourceTree = "<group>"; };
+		CE01B72200000002000CE002 /* SaveRecordHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveRecordHandler.swift; sourceTree = "<group>"; };
+		CE01B72400000002000CE002 /* GetRecordHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRecordHandler.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -157,6 +163,9 @@
 			children = (
 				CE01B71000000001000CE001 /* CloudKitBridge.swift */,
 				CE01B71200000001000CE001 /* CloudKitAccountStatusHandler.swift */,
+				CE01B72000000002000CE002 /* CloudKitRecordCodec.swift */,
+				CE01B72200000002000CE002 /* SaveRecordHandler.swift */,
+				CE01B72400000002000CE002 /* GetRecordHandler.swift */,
 			);
 			path = CloudKit;
 			sourceTree = "<group>";
@@ -400,6 +409,9 @@
 				7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */,
 				CE01B71100000001000CE001 /* CloudKitBridge.swift in Sources */,
 				CE01B71300000001000CE001 /* CloudKitAccountStatusHandler.swift in Sources */,
+				CE01B72100000002000CE002 /* CloudKitRecordCodec.swift in Sources */,
+				CE01B72300000002000CE002 /* SaveRecordHandler.swift in Sources */,
+				CE01B72500000002000CE002 /* GetRecordHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/CloudKit/CloudKitBridge.swift
+++ b/ios/Runner/CloudKit/CloudKitBridge.swift
@@ -13,9 +13,9 @@
 // Trust-rule notes mirroring `cloud_kit_source.dart`:
 // * No silent fallback. Errors surface as `FlutterError` with a typed
 //   code string the Dart side can match.
-// * No record CRUD and no zones in S7.1 — those are S7.2 (#70) and
-//   S7.3 (#71). Do not grow the switch beyond `getAccountStatus` in
-//   this PR.
+// * S7.1 shipped `getAccountStatus`; S7.2 (this file) adds
+//   `saveRecord` + `getRecord` for the typed-record round-trip. Zones
+//   remain S7.3 (#71).
 
 import Flutter
 import Foundation
@@ -37,6 +37,8 @@ public final class CloudKitBridge {
     /// Handlers — one per method name. Kept as lets so each is lazily
     /// final and the dispatch switch stays tiny.
     private let accountStatusHandler = CloudKitAccountStatusHandler()
+    private let saveRecordHandler = SaveRecordHandler()
+    private let getRecordHandler = GetRecordHandler()
 
     /// Binds the CloudKit channel against [binaryMessenger]. Typically
     /// the root `FlutterViewController`'s messenger.
@@ -70,6 +72,10 @@ public final class CloudKitBridge {
         switch call.method {
         case "getAccountStatus":
             accountStatusHandler.handle(arguments: call.arguments, result: result)
+        case "saveRecord":
+            saveRecordHandler.handle(arguments: call.arguments, result: result)
+        case "getRecord":
+            getRecordHandler.handle(arguments: call.arguments, result: result)
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/ios/Runner/CloudKit/CloudKitRecordCodec.swift
+++ b/ios/Runner/CloudKit/CloudKitRecordCodec.swift
@@ -1,0 +1,241 @@
+// CloudKit typed record codec — issue #70 (S7.2).
+//
+// Translates between Flutter's channel map representation and
+// CloudKit's `CKRecord`. The Dart side owns the `CloudKitRecord` value
+// type; this file is the sole place in the app that reaches into
+// CloudKit typed setters/getters.
+//
+// Wire protocol (MUST match the Dart side in
+// `method_channel_cloud_kit_source.dart`):
+//
+//   Each field crosses the channel as a 2-element `[typeTag, raw]`
+//   array. typeTag is one of:
+//     "string"   — raw = String
+//     "int"      — raw = Int64 (Flutter sends NSNumber, Swift reads via
+//                  the integer pathway; `NSNumber(value: Int64)` on the
+//                  response side preserves integer vs double precision)
+//     "double"   — raw = Double
+//     "bool"     — raw = Bool
+//     "dateTime" — raw = Int64 milliseconds-since-epoch (UTC). Swift
+//                  decodes via `Date(timeIntervalSince1970: ms/1000.0)`.
+//                  Response path: `NSDate.timeIntervalSince1970 * 1000`
+//                  rounded to Int64.
+//
+//   Save method args map:
+//     { "recordType": String,
+//       "recordName": String,
+//       "fields": [String: [Any]]  (each value is [typeTag, raw]) }
+//
+//   Get method response (or null on record-not-found):
+//     same shape as save args.
+//
+// Unknown typeTag on decode → throws `CloudKitCodecError.unknownTypeTag`;
+// the caller surfaces as `FlutterError(code: "CK_UNKNOWN_TYPE_TAG")`.
+// No silent fallback to String — matches the Dart side's trust rule.
+
+import CloudKit
+import Foundation
+
+enum CloudKitCodecError: Error, CustomStringConvertible {
+    case missingKey(String)
+    case wrongType(field: String, expected: String, got: String)
+    case unknownTypeTag(field: String, tag: String)
+    case malformedField(field: String, reason: String)
+
+    var description: String {
+        switch self {
+        case .missingKey(let k):
+            return "CloudKitCodecError.missingKey(\(k))"
+        case .wrongType(let f, let e, let g):
+            return "CloudKitCodecError.wrongType(field: \(f), expected: \(e), got: \(g))"
+        case .unknownTypeTag(let f, let t):
+            return "CloudKitCodecError.unknownTypeTag(field: \(f), tag: \(t))"
+        case .malformedField(let f, let r):
+            return "CloudKitCodecError.malformedField(field: \(f), reason: \(r))"
+        }
+    }
+}
+
+public enum CloudKitRecordCodec {
+    // Wire tag constants — mirror the Dart side's `_kTag*` constants.
+    static let tagString = "string"
+    static let tagInt = "int"
+    static let tagDouble = "double"
+    static let tagBool = "bool"
+    static let tagDateTime = "dateTime"
+
+    /// Decodes the inbound args map into a `CKRecord` in the default
+    /// zone (no custom zone — S7.3 adds zones).
+    ///
+    /// Expected shape: `{ "recordType": String, "recordName": String,
+    /// "fields": [String: [Any]] }`.
+    public static func decodeRecord(from arguments: Any?) throws -> CKRecord {
+        guard let args = arguments as? [String: Any] else {
+            throw CloudKitCodecError.missingKey("arguments must be a [String: Any] map")
+        }
+        guard let recordType = args["recordType"] as? String else {
+            throw CloudKitCodecError.missingKey("recordType")
+        }
+        guard let recordName = args["recordName"] as? String else {
+            throw CloudKitCodecError.missingKey("recordName")
+        }
+        guard let rawFields = args["fields"] as? [String: Any] else {
+            throw CloudKitCodecError.missingKey("fields")
+        }
+
+        let recordID = CKRecord.ID(recordName: recordName)
+        let record = CKRecord(recordType: recordType, recordID: recordID)
+
+        for (key, value) in rawFields {
+            try applyField(to: record, key: key, wire: value)
+        }
+        return record
+    }
+
+    /// Encodes a `CKRecord` into the response map Flutter expects.
+    /// Inverse of `decodeRecord` — every encoded record must round-trip
+    /// through the same wire protocol.
+    public static func encodeRecord(_ record: CKRecord) throws -> [String: Any] {
+        var fields: [String: [Any]] = [:]
+        for key in record.allKeys() {
+            let native = record[key]
+            fields[key] = try encodeValue(native, field: key)
+        }
+        return [
+            "recordType": record.recordType,
+            "recordName": record.recordID.recordName,
+            "fields": fields,
+        ]
+    }
+
+    // MARK: - Internals
+
+    private static func applyField(to record: CKRecord, key: String, wire: Any) throws {
+        guard let pair = wire as? [Any], pair.count == 2 else {
+            throw CloudKitCodecError.malformedField(
+                field: key,
+                reason: "expected 2-element [typeTag, value] array"
+            )
+        }
+        guard let tag = pair[0] as? String else {
+            throw CloudKitCodecError.malformedField(
+                field: key,
+                reason: "typeTag must be String"
+            )
+        }
+        let raw = pair[1]
+
+        switch tag {
+        case tagString:
+            guard let s = raw as? String else {
+                throw CloudKitCodecError.wrongType(
+                    field: key, expected: "String", got: String(describing: type(of: raw))
+                )
+            }
+            record.setValue(s as NSString, forKey: key)
+
+        case tagInt:
+            // Flutter's standard codec surfaces Ints as either Int32 or
+            // Int64 depending on magnitude. Accept either, store as
+            // Int64 so the integer precision is preserved in the
+            // CKRecord (CKRecord otherwise coerces bare numbers to
+            // Double on some paths).
+            let i64: Int64
+            if let n = raw as? Int64 {
+                i64 = n
+            } else if let n = raw as? Int32 {
+                i64 = Int64(n)
+            } else if let n = raw as? Int {
+                i64 = Int64(n)
+            } else {
+                throw CloudKitCodecError.wrongType(
+                    field: key, expected: "Int/Int64", got: String(describing: type(of: raw))
+                )
+            }
+            record.setValue(NSNumber(value: i64), forKey: key)
+
+        case tagDouble:
+            guard let d = raw as? Double else {
+                throw CloudKitCodecError.wrongType(
+                    field: key, expected: "Double", got: String(describing: type(of: raw))
+                )
+            }
+            record.setValue(NSNumber(value: d), forKey: key)
+
+        case tagBool:
+            guard let b = raw as? Bool else {
+                throw CloudKitCodecError.wrongType(
+                    field: key, expected: "Bool", got: String(describing: type(of: raw))
+                )
+            }
+            record.setValue(NSNumber(value: b), forKey: key)
+
+        case tagDateTime:
+            // Dart sends milliseconds-since-epoch as Int. Accept Int /
+            // Int32 / Int64 variants the standard codec might surface.
+            let ms: Int64
+            if let n = raw as? Int64 {
+                ms = n
+            } else if let n = raw as? Int32 {
+                ms = Int64(n)
+            } else if let n = raw as? Int {
+                ms = Int64(n)
+            } else {
+                throw CloudKitCodecError.wrongType(
+                    field: key,
+                    expected: "Int64 ms-since-epoch",
+                    got: String(describing: type(of: raw))
+                )
+            }
+            let date = Date(timeIntervalSince1970: TimeInterval(ms) / 1000.0)
+            record.setValue(date as NSDate, forKey: key)
+
+        default:
+            throw CloudKitCodecError.unknownTypeTag(field: key, tag: tag)
+        }
+    }
+
+    private static func encodeValue(_ native: Any?, field: String) throws -> [Any] {
+        // Encode in Bool/Int/Double order mattering — `NSNumber` can
+        // bridge to Bool AND Int AND Double; the canonical way to tell
+        // a Boolean NSNumber apart from a numeric one is its
+        // `objCType` ("c" for Bool). We use `CFGetTypeID` +
+        // `CFBooleanGetTypeID()` which is the Apple-documented path.
+        if native == nil {
+            // CKRecord keys with nil values shouldn't happen — allKeys()
+            // only lists keys with values. Surface loudly if it does.
+            throw CloudKitCodecError.malformedField(
+                field: field, reason: "nil value for key on CKRecord"
+            )
+        }
+        if let s = native as? String {
+            return [tagString, s]
+        }
+        if let d = native as? Date {
+            let ms = Int64((d.timeIntervalSince1970 * 1000.0).rounded())
+            return [tagDateTime, NSNumber(value: ms)]
+        }
+        if let n = native as? NSNumber {
+            // Bool check first — NSNumber bridges Bool, Int, Double.
+            if CFGetTypeID(n) == CFBooleanGetTypeID() {
+                return [tagBool, n.boolValue]
+            }
+            // `objCType` is a C string like "q" (Int64), "i" (Int32),
+            // "d" (Double), "f" (Float), "c" (Char/Bool), ...
+            // Anything floating-point → Double; anything integer →
+            // Int64. CKRecord doesn't distinguish Int32 vs Int64 on
+            // reads — it gives us NSNumber and the Swift side picks.
+            let objcType = String(cString: n.objCType)
+            switch objcType {
+            case "f", "d":
+                return [tagDouble, n.doubleValue]
+            default:
+                return [tagInt, NSNumber(value: n.int64Value)]
+            }
+        }
+        throw CloudKitCodecError.malformedField(
+            field: field,
+            reason: "unsupported CKRecord value type \(type(of: native!))"
+        )
+    }
+}

--- a/ios/Runner/CloudKit/GetRecordHandler.swift
+++ b/ios/Runner/CloudKit/GetRecordHandler.swift
@@ -1,0 +1,99 @@
+// Handler for `getRecord` — issue #70 (S7.2).
+//
+// Fetches a single record by name from the default container's private
+// database (default zone). Uses `CKDatabase.fetch(withRecordID:
+// completionHandler:)`. Encodes the resulting `CKRecord` via
+// `CloudKitRecordCodec` and returns it as a `[String: Any]` map to
+// Flutter.
+//
+// Trust-rule notes:
+// * Record-not-found → `nil` result (Dart-side null). Get-by-id
+//   semantics: "not found" is a value, not an error. Only maps to nil
+//   when the underlying CKError is `.unknownItem`; every other error
+//   surfaces as `FlutterError`.
+// * No silent fallback on encode failure — if `encodeRecord` throws,
+//   that surfaces as `FlutterError(code: "CK_ENCODE_FAILED")`.
+
+import CloudKit
+import Flutter
+import Foundation
+
+public final class GetRecordHandler {
+
+    public init() {}
+
+    public func handle(
+        arguments: Any?,
+        result: @escaping FlutterResult
+    ) {
+        // Arg extraction — `recordType` isn't strictly needed for the
+        // CKDatabase.fetch call (record IDs disambiguate on CloudKit's
+        // side), but we take it for API symmetry with saveRecord and
+        // to ease future validation when zones land in S7.3.
+        guard let args = arguments as? [String: Any] else {
+            result(FlutterError(
+                code: "CK_BAD_ARGS",
+                message: "getRecord arguments must be a Map",
+                details: nil
+            ))
+            return
+        }
+        guard let recordName = args["recordName"] as? String else {
+            result(FlutterError(
+                code: "CK_BAD_ARGS",
+                message: "getRecord arguments missing 'recordName' String",
+                details: nil
+            ))
+            return
+        }
+        // `recordType` is read + validated for shape even though we
+        // don't consume it in the fetch call — if Dart forgets to send
+        // it the contract is broken.
+        guard args["recordType"] is String else {
+            result(FlutterError(
+                code: "CK_BAD_ARGS",
+                message: "getRecord arguments missing 'recordType' String",
+                details: nil
+            ))
+            return
+        }
+
+        let db = CKContainer.default().privateCloudDatabase
+        let recordID = CKRecord.ID(recordName: recordName)
+        db.fetch(withRecordID: recordID) { record, error in
+            if let ckError = error as? CKError, ckError.code == .unknownItem {
+                // Record-not-found — Dart sees this as `null`.
+                result(nil)
+                return
+            }
+            if let error = error {
+                result(FlutterError(
+                    code: "CK_GET_RECORD_FAILED",
+                    message: error.localizedDescription,
+                    details: String(describing: error)
+                ))
+                return
+            }
+            guard let record = record else {
+                // Belt-and-braces: CKDatabase.fetch shouldn't return
+                // nil-nil, but surface it clearly if it does.
+                result(FlutterError(
+                    code: "CK_GET_RECORD_FAILED",
+                    message: "CKDatabase.fetch returned nil record + nil error",
+                    details: nil
+                ))
+                return
+            }
+            do {
+                let encoded = try CloudKitRecordCodec.encodeRecord(record)
+                result(encoded)
+            } catch {
+                result(FlutterError(
+                    code: "CK_ENCODE_FAILED",
+                    message: "failed to encode CKRecord for Dart",
+                    details: String(describing: error)
+                ))
+            }
+        }
+    }
+}

--- a/ios/Runner/CloudKit/SaveRecordHandler.swift
+++ b/ios/Runner/CloudKit/SaveRecordHandler.swift
@@ -1,0 +1,56 @@
+// Handler for `saveRecord` — issue #70 (S7.2).
+//
+// Wraps `CKDatabase.save(_:completionHandler:)` on the default
+// container's private database (default zone — zones arrive in S7.3).
+// Decodes the incoming Flutter args map into a `CKRecord` via
+// `CloudKitRecordCodec`, then pushes it to CloudKit. On completion,
+// signals success via a Flutter `null` result; on failure, surfaces a
+// typed `FlutterError` the Dart side re-raises as
+// `CloudKitChannelError`.
+//
+// Trust-rule notes:
+// * No silent fallback: if `CKDatabase.save` fails, the Dart side sees
+//   a failure. Callers never observe a fire-and-forget save.
+// * `CKDatabase.save` overwrites by default (no change-tag check) —
+//   that's the S7.2 design. Conflict detection lands in S7.4 via
+//   `CKModifyRecordsOperation` with `.ifServerRecordUnchanged`.
+
+import CloudKit
+import Flutter
+import Foundation
+
+public final class SaveRecordHandler {
+
+    public init() {}
+
+    public func handle(
+        arguments: Any?,
+        result: @escaping FlutterResult
+    ) {
+        let record: CKRecord
+        do {
+            record = try CloudKitRecordCodec.decodeRecord(from: arguments)
+        } catch {
+            result(FlutterError(
+                code: "CK_ENCODE_FAILED",
+                message: "failed to decode CloudKitRecord from Dart args",
+                details: String(describing: error)
+            ))
+            return
+        }
+
+        let db = CKContainer.default().privateCloudDatabase
+        db.save(record) { _, error in
+            if let error = error {
+                result(FlutterError(
+                    code: "CK_SAVE_RECORD_FAILED",
+                    message: error.localizedDescription,
+                    details: String(describing: error)
+                ))
+                return
+            }
+            // Success — Dart-side `saveRecord` returns `Future<void>`.
+            result(nil)
+        }
+    }
+}

--- a/lib/sources/cloudkit/cloud_kit_source.dart
+++ b/lib/sources/cloudkit/cloud_kit_source.dart
@@ -109,6 +109,11 @@ class CloudKitChannelError implements Exception {
 ///   degrade.
 /// * Never fabricate an account status — an out-of-range raw value
 ///   throws [CloudKitUnknownError].
+/// * Preserve type fidelity on record round-trips. Saving a [CKDouble]
+///   and fetching it back must return a [CKDouble] with bit-identical
+///   value (the spike showed the `Map<String, String>` fallback loses
+///   precision — trust rule "no silent mutation of totals" forbids that
+///   path; see S7.2 issue #70).
 abstract class CloudKitSource {
   /// Asks the native side for the current `CKAccountStatus`.
   ///
@@ -117,4 +122,215 @@ abstract class CloudKitSource {
   /// one of the five [CloudKitAccountStatus] values; throws on any
   /// platform error or unrecognised raw value.
   Future<CloudKitAccountStatus> getAccountStatus();
+
+  /// Saves [record] to the private database (default zone).
+  ///
+  /// On iOS the underlying call is
+  /// `CKDatabase.save(_:completionHandler:)` on
+  /// `CKContainer.default().privateCloudDatabase`. CKRecord.save
+  /// overwrites by default — callers that need conflict detection wait
+  /// for S7.4's batch modify operation.
+  ///
+  /// Errors surface as [CloudKitChannelError]; a `MissingPluginException`
+  /// propagates unchanged. Never fire-and-forget: the returned Future
+  /// completes only when the native side has acknowledged the save.
+  Future<void> saveRecord(CloudKitRecord record);
+
+  /// Fetches a single record by [recordType] + [recordName] from the
+  /// private database (default zone).
+  ///
+  /// Returns `null` when CloudKit reports the record does not exist
+  /// (native-side maps `CKError.unknownItem` to a null result). Any
+  /// other error surfaces as [CloudKitChannelError].
+  ///
+  /// Type fidelity guarantee: every field in the returned record uses
+  /// the same [CloudKitValue] subtype as the saved record — see the
+  /// round-trip test in
+  /// `test/sources/cloud_kit_source_test.dart`.
+  Future<CloudKitRecord?> getRecord({
+    required String recordType,
+    required String recordName,
+  });
+}
+
+/// Pure-Dart description of a single CloudKit record.
+///
+/// Fields are keyed by String name and carry typed [CloudKitValue]
+/// payloads — the codec at the channel boundary uses the value's runtime
+/// type to pick the right `CKRecord` setter on the Swift side, and the
+/// typeTag on the wire to reconstruct the right subtype on decode.
+///
+/// Equality is value-based so tests can assert round-trip equality
+/// directly.
+class CloudKitRecord {
+  const CloudKitRecord({
+    required this.recordType,
+    required this.recordName,
+    required this.fields,
+  });
+
+  /// CloudKit record type name (e.g. `"HealthSpike"`). Must match the
+  /// type registered in the CloudKit container schema — on first save
+  /// CloudKit auto-registers the type, but the developer still has to
+  /// configure queryable / sortable indexes in the CloudKit Console if
+  /// the record is ever queried. See Runbooks.md.
+  final String recordType;
+
+  /// CloudKit record name (unique within the record type + zone).
+  /// Produced by the caller — CloudKit does not auto-generate.
+  final String recordName;
+
+  /// Field payload. Keys are field names (on Swift side, the CKRecord
+  /// key). Values carry both the Dart type and the raw value.
+  final Map<String, CloudKitValue> fields;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! CloudKitRecord) return false;
+    if (other.recordType != recordType) return false;
+    if (other.recordName != recordName) return false;
+    if (other.fields.length != fields.length) return false;
+    for (final entry in fields.entries) {
+      if (other.fields[entry.key] != entry.value) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    recordType,
+    recordName,
+    // Order-independent hash of the field map — CloudKit record fields
+    // have no intrinsic order, and two records with the same fields in
+    // different iteration orders should still compare equal.
+    Object.hashAllUnordered(
+      fields.entries.map((e) => Object.hash(e.key, e.value)),
+    ),
+  );
+
+  @override
+  String toString() =>
+      'CloudKitRecord(recordType: $recordType, recordName: $recordName, fields: $fields)';
+}
+
+/// Sealed root for all value types that can cross the CloudKit channel.
+///
+/// Sealed so exhaustive switches are compiler-enforced — adding a new
+/// subtype (asset / reference, post-S7.2) forces every consumer's switch
+/// to grow a branch at compile time, matching the canonical-enum rule in
+/// CLAUDE.md ("no fallthrough defaults").
+///
+/// Round-trip contract: every subtype preserves its underlying Dart
+/// value bit-for-bit across the channel. `DateTime` values round-trip
+/// through millisecond-since-epoch (UTC); sub-millisecond precision is
+/// truncated by the wire protocol. Documented in
+/// `method_channel_cloud_kit_source.dart` / `CloudKitRecordCodec.swift`.
+sealed class CloudKitValue {
+  const CloudKitValue();
+}
+
+/// String field value.
+class CKString extends CloudKitValue {
+  const CKString(this.value);
+  final String value;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is CKString && other.value == value);
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  String toString() => 'CKString($value)';
+}
+
+/// 64-bit signed integer field value. Preserves integer precision — the
+/// Swift side uses `NSNumber(value: Int64)` so values up to 2^63-1
+/// survive the round-trip without being coerced to `Double`.
+class CKInt extends CloudKitValue {
+  const CKInt(this.value);
+  final int value;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is CKInt && other.value == value);
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  String toString() => 'CKInt($value)';
+}
+
+/// 64-bit double-precision float field value. The Swift side uses
+/// `NSNumber(value: Double)` so IEEE 754 bit-pattern is preserved.
+class CKDouble extends CloudKitValue {
+  const CKDouble(this.value);
+  final double value;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is CKDouble && other.value == value);
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  String toString() => 'CKDouble($value)';
+}
+
+/// Boolean field value. Crosses the channel as an explicit `"bool"`
+/// typeTag (rather than riding as an Int) so a future consumer that
+/// grows e.g. a tri-state flag type doesn't collide with 0/1 ints.
+class CKBool extends CloudKitValue {
+  const CKBool(this.value);
+  final bool value;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is CKBool && other.value == value);
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  String toString() => 'CKBool($value)';
+}
+
+/// DateTime field value.
+///
+/// Wire encoding: milliseconds-since-epoch as an `int`, tagged
+/// `"dateTime"`. The Swift side converts to `NSDate` via
+/// `Date(timeIntervalSince1970: ms / 1000.0)`. Round-trip precision is
+/// milliseconds; Dart's sub-millisecond microsecond precision is
+/// truncated at the wire boundary.
+///
+/// The underlying [DateTime] is preserved as-given — no implicit
+/// UTC conversion. Callers that want UTC should pass a UTC `DateTime`;
+/// callers that want local time should pass a local `DateTime`. The
+/// codec carries the absolute instant (milliseconds since epoch) either
+/// way, so the instant is preserved; only the `isUtc` flag may differ
+/// on the return trip (Swift returns UTC, which Dart surfaces as a UTC
+/// `DateTime`).
+class CKDateTime extends CloudKitValue {
+  const CKDateTime(this.value);
+  final DateTime value;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! CKDateTime) return false;
+    // Equality on the absolute instant — matches the round-trip
+    // contract. Two DateTimes that represent the same millisecond
+    // instant compare equal even if one is local and one is UTC.
+    return other.value.millisecondsSinceEpoch == value.millisecondsSinceEpoch;
+  }
+
+  @override
+  int get hashCode => value.millisecondsSinceEpoch.hashCode;
+
+  @override
+  String toString() => 'CKDateTime($value)';
 }

--- a/lib/sources/cloudkit/fake_cloud_kit_source.dart
+++ b/lib/sources/cloudkit/fake_cloud_kit_source.dart
@@ -30,6 +30,20 @@ class FakeCloudKitSource implements CloudKitSource {
   /// Useful for "did the controller re-poll?" tests.
   int getAccountStatusCallCount = 0;
 
+  /// How many times [saveRecord] has been invoked.
+  int saveRecordCallCount = 0;
+
+  /// How many times [getRecord] has been invoked.
+  int getRecordCallCount = 0;
+
+  /// In-memory record store keyed by `(recordType, recordName)`. Keeps
+  /// type-by-type namespacing honest — two records with the same name
+  /// but different types don't collide (mirrors CKRecord.ID semantics).
+  final Map<String, CloudKitRecord> _store = {};
+
+  String _key(String recordType, String recordName) =>
+      '$recordType\u0000$recordName';
+
   /// Swap the account status the fake will return on subsequent calls.
   /// Not called by production code — test-only seam.
   // ignore: use_setters_to_change_properties
@@ -40,5 +54,24 @@ class FakeCloudKitSource implements CloudKitSource {
     getAccountStatusCallCount += 1;
     if (_error != null) throw _error;
     return _status;
+  }
+
+  @override
+  Future<void> saveRecord(CloudKitRecord record) async {
+    saveRecordCallCount += 1;
+    if (_error != null) throw _error;
+    // Upsert — matches the real CloudKit default `save` semantics
+    // (S7.2 scope: no conflict detection, S7.4 adds batch + policy).
+    _store[_key(record.recordType, record.recordName)] = record;
+  }
+
+  @override
+  Future<CloudKitRecord?> getRecord({
+    required String recordType,
+    required String recordName,
+  }) async {
+    getRecordCallCount += 1;
+    if (_error != null) throw _error;
+    return _store[_key(recordType, recordName)];
   }
 }

--- a/lib/sources/cloudkit/method_channel_cloud_kit_source.dart
+++ b/lib/sources/cloudkit/method_channel_cloud_kit_source.dart
@@ -14,6 +14,36 @@
 // * `PlatformError` from the native side is re-typed as
 //   [CloudKitChannelError] so feature code never imports
 //   `package:flutter/services.dart` just to catch a platform error.
+//
+// Wire protocol (S7.2 / #70) — MUST match `CloudKitRecordCodec.swift`:
+//
+//   saveRecord:
+//     args = {
+//       "recordType": String,
+//       "recordName": String,
+//       "fields": Map<String, List> where each value is
+//                 a 2-element List<dynamic> of the form [typeTag, raw],
+//                 typeTag ∈ {"string","int","double","bool","dateTime"},
+//                 raw encoded as:
+//                   "string"   → String
+//                   "int"      → int (Int64 on Swift side)
+//                   "double"   → double
+//                   "bool"     → bool
+//                   "dateTime" → int milliseconds-since-epoch (UTC),
+//                                Swift decodes via
+//                                Date(timeIntervalSince1970: ms/1000.0)
+//     }
+//     returns: null
+//
+//   getRecord:
+//     args    = { "recordType": String, "recordName": String }
+//     returns: null if record does not exist (CKError.unknownItem);
+//              otherwise Map with the same shape as saveRecord's args
+//              (including "recordType" + "recordName" + "fields").
+//
+// Unknown typeTag on decode → [CloudKitChannelError]. No fallback to
+// String: the spike showed that lossy path is exactly the trust-rule
+// violation S7.2 exists to prevent.
 
 import 'package:flutter/services.dart';
 
@@ -32,6 +62,19 @@ const String kCloudKitChannelName = 'dev.techxtt.liftlog/cloudkit';
 /// Method name for the account-status handler. String literal lives here
 /// and on the Swift side only — callers go through the façade.
 const String _kGetAccountStatus = 'getAccountStatus';
+
+/// Method name for `saveRecord`.
+const String _kSaveRecord = 'saveRecord';
+
+/// Method name for `getRecord`.
+const String _kGetRecord = 'getRecord';
+
+// Wire typeTags. Mirrored on the Swift side in `CloudKitRecordCodec`.
+const String _kTagString = 'string';
+const String _kTagInt = 'int';
+const String _kTagDouble = 'double';
+const String _kTagBool = 'bool';
+const String _kTagDateTime = 'dateTime';
 
 class MethodChannelCloudKitSource implements CloudKitSource {
   /// Construct a source backed by the default channel name. Pass
@@ -79,4 +122,223 @@ class MethodChannelCloudKitSource implements CloudKitSource {
     }
     return CloudKitAccountStatus.values[raw];
   }
+
+  @override
+  Future<void> saveRecord(CloudKitRecord record) async {
+    final encodedFields = <String, List<Object?>>{};
+    for (final entry in record.fields.entries) {
+      encodedFields[entry.key] = _encodeValue(entry.value);
+    }
+    try {
+      await _channel.invokeMethod<void>(_kSaveRecord, <String, Object?>{
+        'recordType': record.recordType,
+        'recordName': record.recordName,
+        'fields': encodedFields,
+      });
+    } on PlatformException catch (e) {
+      throw CloudKitChannelError(
+        code: e.code,
+        message: e.message ?? '',
+        details: e.details,
+      );
+    }
+  }
+
+  @override
+  Future<CloudKitRecord?> getRecord({
+    required String recordType,
+    required String recordName,
+  }) async {
+    final Object? raw;
+    try {
+      raw = await _channel.invokeMethod<Object?>(_kGetRecord, <String, Object?>{
+        'recordType': recordType,
+        'recordName': recordName,
+      });
+    } on PlatformException catch (e) {
+      throw CloudKitChannelError(
+        code: e.code,
+        message: e.message ?? '',
+        details: e.details,
+      );
+    }
+
+    // Native side returns null for CKError.unknownItem — get-by-id
+    // semantics: "not found" is a value, not an error.
+    if (raw == null) return null;
+
+    if (raw is! Map) {
+      throw CloudKitChannelError(
+        code: 'CK_MALFORMED_RESPONSE',
+        message: 'getRecord expected Map response, got ${raw.runtimeType}',
+        details: raw,
+      );
+    }
+    return _decodeRecord(raw);
+  }
+}
+
+/// Encodes a [CloudKitValue] as its 2-element `[typeTag, raw]` wire
+/// form. Exhaustive switch over the sealed subtype hierarchy — the Dart
+/// analyzer enforces that any future subtype must be handled here.
+List<Object?> _encodeValue(CloudKitValue value) {
+  return switch (value) {
+    CKString(:final value) => <Object?>[_kTagString, value],
+    CKInt(:final value) => <Object?>[_kTagInt, value],
+    CKDouble(:final value) => <Object?>[_kTagDouble, value],
+    CKBool(:final value) => <Object?>[_kTagBool, value],
+    // Milliseconds-since-epoch. `millisecondsSinceEpoch` on a Dart
+    // `DateTime` returns the absolute instant regardless of the
+    // DateTime's `isUtc` flag — exactly what we want on the wire.
+    CKDateTime(:final value) => <Object?>[
+      _kTagDateTime,
+      value.millisecondsSinceEpoch,
+    ],
+  };
+}
+
+/// Decodes a `[typeTag, raw]` wire entry back into a [CloudKitValue].
+///
+/// Unknown typeTag → [CloudKitChannelError]. No silent fallback to
+/// String — the spike showed that's exactly the lossy trap we're here
+/// to prevent.
+CloudKitValue _decodeValue(String fieldName, Object? wire) {
+  if (wire is! List || wire.length != 2) {
+    throw CloudKitChannelError(
+      code: 'CK_MALFORMED_FIELD',
+      message:
+          'field "$fieldName": expected 2-element [typeTag, value] list, '
+          'got ${wire.runtimeType}',
+      details: wire,
+    );
+  }
+  final tag = wire[0];
+  final raw = wire[1];
+  if (tag is! String) {
+    throw CloudKitChannelError(
+      code: 'CK_MALFORMED_FIELD',
+      message:
+          'field "$fieldName": typeTag must be String, got ${tag.runtimeType}',
+      details: wire,
+    );
+  }
+
+  switch (tag) {
+    case _kTagString:
+      if (raw is! String) {
+        throw CloudKitChannelError(
+          code: 'CK_MALFORMED_FIELD',
+          message:
+              'field "$fieldName": typeTag "$tag" expected String value, '
+              'got ${raw.runtimeType}',
+          details: wire,
+        );
+      }
+      return CKString(raw);
+    case _kTagInt:
+      if (raw is! int) {
+        throw CloudKitChannelError(
+          code: 'CK_MALFORMED_FIELD',
+          message:
+              'field "$fieldName": typeTag "$tag" expected int value, '
+              'got ${raw.runtimeType}',
+          details: wire,
+        );
+      }
+      return CKInt(raw);
+    case _kTagDouble:
+      // Swift NSNumber(value: Double) arrives as `double` in the
+      // standard codec. Guard to keep the codec honest.
+      if (raw is! double) {
+        throw CloudKitChannelError(
+          code: 'CK_MALFORMED_FIELD',
+          message:
+              'field "$fieldName": typeTag "$tag" expected double value, '
+              'got ${raw.runtimeType}',
+          details: wire,
+        );
+      }
+      return CKDouble(raw);
+    case _kTagBool:
+      if (raw is! bool) {
+        throw CloudKitChannelError(
+          code: 'CK_MALFORMED_FIELD',
+          message:
+              'field "$fieldName": typeTag "$tag" expected bool value, '
+              'got ${raw.runtimeType}',
+          details: wire,
+        );
+      }
+      return CKBool(raw);
+    case _kTagDateTime:
+      if (raw is! int) {
+        throw CloudKitChannelError(
+          code: 'CK_MALFORMED_FIELD',
+          message:
+              'field "$fieldName": typeTag "$tag" expected int ms-since-epoch, '
+              'got ${raw.runtimeType}',
+          details: wire,
+        );
+      }
+      // Swift sends UTC; surface as UTC on the Dart side. Callers that
+      // want local time can `.toLocal()`.
+      return CKDateTime(DateTime.fromMillisecondsSinceEpoch(raw, isUtc: true));
+    default:
+      throw CloudKitChannelError(
+        code: 'CK_UNKNOWN_TYPE_TAG',
+        message:
+            'field "$fieldName": unknown typeTag "$tag"; expected one of '
+            '$_kTagString, $_kTagInt, $_kTagDouble, $_kTagBool, $_kTagDateTime',
+        details: wire,
+      );
+  }
+}
+
+/// Decodes the top-level `getRecord` response map to [CloudKitRecord].
+CloudKitRecord _decodeRecord(Map<Object?, Object?> raw) {
+  final recordType = raw['recordType'];
+  final recordName = raw['recordName'];
+  final rawFields = raw['fields'];
+  if (recordType is! String) {
+    throw CloudKitChannelError(
+      code: 'CK_MALFORMED_RESPONSE',
+      message: 'getRecord response missing "recordType" String',
+      details: raw,
+    );
+  }
+  if (recordName is! String) {
+    throw CloudKitChannelError(
+      code: 'CK_MALFORMED_RESPONSE',
+      message: 'getRecord response missing "recordName" String',
+      details: raw,
+    );
+  }
+  if (rawFields is! Map) {
+    throw CloudKitChannelError(
+      code: 'CK_MALFORMED_RESPONSE',
+      message:
+          'getRecord response "fields" must be a Map, got '
+          '${rawFields.runtimeType}',
+      details: raw,
+    );
+  }
+  final fields = <String, CloudKitValue>{};
+  for (final entry in rawFields.entries) {
+    final key = entry.key;
+    if (key is! String) {
+      throw CloudKitChannelError(
+        code: 'CK_MALFORMED_RESPONSE',
+        message:
+            'getRecord response field key must be String, got '
+            '${key.runtimeType}',
+        details: raw,
+      );
+    }
+    fields[key] = _decodeValue(key, entry.value);
+  }
+  return CloudKitRecord(
+    recordType: recordType,
+    recordName: recordName,
+    fields: fields,
+  );
 }

--- a/test/sources/cloud_kit_source_test.dart
+++ b/test/sources/cloud_kit_source_test.dart
@@ -111,4 +111,232 @@ void main() {
       expect(err.toString(), contains('ns-error-description'));
     });
   });
+
+  group('CloudKitValue — equality + hash', () {
+    test('CKString equality and hash', () {
+      expect(const CKString('a'), const CKString('a'));
+      expect(const CKString('a').hashCode, const CKString('a').hashCode);
+      expect(const CKString('a') == const CKString('b'), isFalse);
+    });
+
+    test('CKInt equality preserves integer precision', () {
+      // Values near Int64.max — these are the ones that would be
+      // silently stringified by the flutter_cloud_kit plugin.
+      const big = CKInt(9007199254740992); // 2^53
+      expect(big, const CKInt(9007199254740992));
+      expect(big == const CKInt(9007199254740993), isFalse);
+    });
+
+    test('CKDouble equality preserves bit pattern', () {
+      const pi = CKDouble(3.141592653589793);
+      expect(pi, const CKDouble(3.141592653589793));
+      expect(pi == const CKDouble(3.14), isFalse);
+    });
+
+    test('CKBool equality', () {
+      expect(const CKBool(true), const CKBool(true));
+      expect(const CKBool(true) == const CKBool(false), isFalse);
+    });
+
+    test('CKDateTime equality on absolute instant', () {
+      final utc = DateTime.utc(2026, 4, 24, 12, 0, 0, 123);
+      final localEquiv = utc.toLocal();
+      expect(CKDateTime(utc), CKDateTime(localEquiv));
+      expect(
+        CKDateTime(utc) == CKDateTime(utc.add(const Duration(milliseconds: 1))),
+        isFalse,
+      );
+    });
+
+    test('heterogeneous subtypes never compare equal', () {
+      // A Boolean true and an Int 1 shouldn't compare equal. Trust-rule
+      // reason: a toggle (bool) and a count (int) must never silently
+      // alias, even though their JSON/channel form might be
+      // indistinguishable on an untyped path.
+      expect(const CKBool(true) == const CKInt(1), isFalse);
+      expect(const CKString('1') == const CKInt(1), isFalse);
+    });
+  });
+
+  group('CloudKitRecord — equality + hash', () {
+    test('equal when type + name + field map all match', () {
+      const a = CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'spike-1',
+        fields: {'note': CKString('ok'), 'kcal': CKInt(612)},
+      );
+      const b = CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'spike-1',
+        // Different iteration order — must still compare equal since
+        // CKRecord field order isn't semantic.
+        fields: {'kcal': CKInt(612), 'note': CKString('ok')},
+      );
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('differs on recordType', () {
+      const a = CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'x',
+        fields: {},
+      );
+      const b = CloudKitRecord(
+        recordType: 'OtherType',
+        recordName: 'x',
+        fields: {},
+      );
+      expect(a == b, isFalse);
+    });
+
+    test('differs on recordName', () {
+      const a = CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'a',
+        fields: {},
+      );
+      const b = CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'b',
+        fields: {},
+      );
+      expect(a == b, isFalse);
+    });
+
+    test('differs on field value', () {
+      const a = CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'x',
+        fields: {'kcal': CKInt(612)},
+      );
+      const b = CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'x',
+        fields: {'kcal': CKInt(613)},
+      );
+      expect(a == b, isFalse);
+    });
+  });
+
+  group('FakeCloudKitSource — record CRUD', () {
+    /// Helper: the canonical mixed-type spike record used across tests.
+    /// One field of each of the 5 supported CloudKit value types.
+    CloudKitRecord spikeRecord() {
+      return CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'spike-1',
+        fields: {
+          'title': const CKString('evening session'),
+          'reps': const CKInt(12),
+          'weightKg': const CKDouble(102.5),
+          'wasPr': const CKBool(true),
+          'when': CKDateTime(DateTime.utc(2026, 4, 24, 18, 30, 45, 789)),
+        },
+      );
+    }
+
+    test(
+      'round-trips a record with all 5 value types, preserving equality',
+      () async {
+        final fake = FakeCloudKitSource();
+        final saved = spikeRecord();
+        await fake.saveRecord(saved);
+
+        final fetched = await fake.getRecord(
+          recordType: 'HealthSpike',
+          recordName: 'spike-1',
+        );
+
+        expect(fetched, isNotNull);
+        expect(fetched, equals(saved));
+        // Spot-check DateTime precision — millisecond-accurate.
+        expect(
+          (fetched!.fields['when']! as CKDateTime).value.millisecondsSinceEpoch,
+          (saved.fields['when']! as CKDateTime).value.millisecondsSinceEpoch,
+        );
+        expect(fake.saveRecordCallCount, 1);
+        expect(fake.getRecordCallCount, 1);
+      },
+    );
+
+    test('returns null for record that was never saved', () async {
+      final fake = FakeCloudKitSource();
+      final fetched = await fake.getRecord(
+        recordType: 'HealthSpike',
+        recordName: 'missing',
+      );
+      expect(fetched, isNull);
+    });
+
+    test('saveRecord upserts — second save overwrites the first', () async {
+      final fake = FakeCloudKitSource();
+      const v1 = CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'spike-1',
+        fields: {'kcal': CKInt(600)},
+      );
+      const v2 = CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'spike-1',
+        fields: {'kcal': CKInt(650)},
+      );
+      await fake.saveRecord(v1);
+      await fake.saveRecord(v2);
+
+      final fetched = await fake.getRecord(
+        recordType: 'HealthSpike',
+        recordName: 'spike-1',
+      );
+      expect(fetched, equals(v2));
+    });
+
+    test(
+      'recordType namespaces recordName — same name in different types do not collide',
+      () async {
+        final fake = FakeCloudKitSource();
+        const a = CloudKitRecord(
+          recordType: 'TypeA',
+          recordName: 'same',
+          fields: {'v': CKInt(1)},
+        );
+        const b = CloudKitRecord(
+          recordType: 'TypeB',
+          recordName: 'same',
+          fields: {'v': CKInt(2)},
+        );
+        await fake.saveRecord(a);
+        await fake.saveRecord(b);
+
+        expect(
+          await fake.getRecord(recordType: 'TypeA', recordName: 'same'),
+          equals(a),
+        );
+        expect(
+          await fake.getRecord(recordType: 'TypeB', recordName: 'same'),
+          equals(b),
+        );
+      },
+    );
+
+    test('configured error surfaces on saveRecord', () async {
+      final err = Exception('network down');
+      final fake = FakeCloudKitSource(error: err);
+      const record = CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'x',
+        fields: {},
+      );
+      expect(() => fake.saveRecord(record), throwsA(same(err)));
+    });
+
+    test('configured error surfaces on getRecord', () async {
+      final err = Exception('network down');
+      final fake = FakeCloudKitSource(error: err);
+      expect(
+        () => fake.getRecord(recordType: 'HealthSpike', recordName: 'x'),
+        throwsA(same(err)),
+      );
+    });
+  });
 }

--- a/test/sources/method_channel_cloud_kit_source_test.dart
+++ b/test/sources/method_channel_cloud_kit_source_test.dart
@@ -147,4 +147,299 @@ void main() {
       );
     });
   });
+
+  group('saveRecord — wire encoding', () {
+    test('encodes one field of each of the 5 supported types', () async {
+      MethodCall? observed;
+      mockChannel((call) async {
+        observed = call;
+        return null;
+      });
+      final source = MethodChannelCloudKitSource();
+      final when = DateTime.utc(2026, 4, 24, 18, 30, 45, 789);
+      final record = CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'spike-1',
+        fields: {
+          'title': const CKString('evening session'),
+          'reps': const CKInt(12),
+          'weightKg': const CKDouble(102.5),
+          'wasPr': const CKBool(true),
+          'when': CKDateTime(when),
+        },
+      );
+
+      await source.saveRecord(record);
+
+      expect(observed, isNotNull);
+      expect(observed!.method, 'saveRecord');
+      final args = observed!.arguments as Map;
+      expect(args['recordType'], 'HealthSpike');
+      expect(args['recordName'], 'spike-1');
+      final fields = args['fields'] as Map;
+
+      expect(fields['title'], equals(['string', 'evening session']));
+      expect(fields['reps'], equals(['int', 12]));
+      expect(fields['weightKg'], equals(['double', 102.5]));
+      expect(fields['wasPr'], equals(['bool', true]));
+      expect(fields['when'], equals(['dateTime', when.millisecondsSinceEpoch]));
+    });
+
+    test('PlatformException on save → CloudKitChannelError', () async {
+      mockChannel((_) async {
+        throw PlatformException(
+          code: 'CK_SAVE_RECORD_FAILED',
+          message: 'network unavailable',
+          details: 'nserror-details',
+        );
+      });
+      final source = MethodChannelCloudKitSource();
+      await expectLater(
+        () => source.saveRecord(
+          const CloudKitRecord(
+            recordType: 'HealthSpike',
+            recordName: 'spike-1',
+            fields: {'v': CKInt(1)},
+          ),
+        ),
+        throwsA(
+          isA<CloudKitChannelError>().having(
+            (e) => e.code,
+            'code',
+            'CK_SAVE_RECORD_FAILED',
+          ),
+        ),
+      );
+    });
+  });
+
+  group('getRecord — wire decoding', () {
+    test('decodes each typeTag to the correct CloudKitValue subtype', () async {
+      final whenMs = DateTime.utc(
+        2026,
+        4,
+        24,
+        18,
+        30,
+        45,
+        789,
+      ).millisecondsSinceEpoch;
+      mockChannel((call) async {
+        expect(call.method, 'getRecord');
+        final args = call.arguments as Map;
+        expect(args['recordType'], 'HealthSpike');
+        expect(args['recordName'], 'spike-1');
+        return <String, Object?>{
+          'recordType': 'HealthSpike',
+          'recordName': 'spike-1',
+          'fields': <String, Object?>{
+            'title': <Object?>['string', 'evening session'],
+            'reps': <Object?>['int', 12],
+            'weightKg': <Object?>['double', 102.5],
+            'wasPr': <Object?>['bool', true],
+            'when': <Object?>['dateTime', whenMs],
+          },
+        };
+      });
+
+      final source = MethodChannelCloudKitSource();
+      final fetched = await source.getRecord(
+        recordType: 'HealthSpike',
+        recordName: 'spike-1',
+      );
+
+      expect(fetched, isNotNull);
+      expect(fetched!.recordType, 'HealthSpike');
+      expect(fetched.recordName, 'spike-1');
+      expect(fetched.fields['title'], const CKString('evening session'));
+      expect(fetched.fields['reps'], const CKInt(12));
+      expect(fetched.fields['weightKg'], const CKDouble(102.5));
+      expect(fetched.fields['wasPr'], const CKBool(true));
+      expect(
+        (fetched.fields['when']! as CKDateTime).value.millisecondsSinceEpoch,
+        whenMs,
+      );
+      // The decoded DateTime surfaces as UTC — Swift side sends UTC.
+      expect((fetched.fields['when']! as CKDateTime).value.isUtc, isTrue);
+    });
+
+    test(
+      'null channel response → null record (get-by-id "not found")',
+      () async {
+        mockChannel((_) async => null);
+        final source = MethodChannelCloudKitSource();
+        final fetched = await source.getRecord(
+          recordType: 'HealthSpike',
+          recordName: 'missing',
+        );
+        expect(fetched, isNull);
+      },
+    );
+
+    test(
+      'unknown typeTag → CloudKitChannelError (no silent fallback)',
+      () async {
+        mockChannel(
+          (_) async => <String, Object?>{
+            'recordType': 'HealthSpike',
+            'recordName': 'spike-1',
+            'fields': <String, Object?>{
+              'weird': <Object?>['asset', 'file://whatever'],
+            },
+          },
+        );
+        final source = MethodChannelCloudKitSource();
+        await expectLater(
+          () => source.getRecord(
+            recordType: 'HealthSpike',
+            recordName: 'spike-1',
+          ),
+          throwsA(
+            isA<CloudKitChannelError>().having(
+              (e) => e.code,
+              'code',
+              'CK_UNKNOWN_TYPE_TAG',
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'malformed field (not a 2-element list) → CloudKitChannelError',
+      () async {
+        mockChannel(
+          (_) async => <String, Object?>{
+            'recordType': 'HealthSpike',
+            'recordName': 'spike-1',
+            'fields': <String, Object?>{'bad': 'just-a-string'},
+          },
+        );
+        final source = MethodChannelCloudKitSource();
+        await expectLater(
+          () => source.getRecord(
+            recordType: 'HealthSpike',
+            recordName: 'spike-1',
+          ),
+          throwsA(
+            isA<CloudKitChannelError>().having(
+              (e) => e.code,
+              'code',
+              'CK_MALFORMED_FIELD',
+            ),
+          ),
+        );
+      },
+    );
+
+    test('type mismatch for declared tag → CloudKitChannelError', () async {
+      // Tag says "int" but value is a Double. No silent coercion.
+      mockChannel(
+        (_) async => <String, Object?>{
+          'recordType': 'HealthSpike',
+          'recordName': 'spike-1',
+          'fields': <String, Object?>{
+            'reps': <Object?>['int', 3.14],
+          },
+        },
+      );
+      final source = MethodChannelCloudKitSource();
+      await expectLater(
+        () =>
+            source.getRecord(recordType: 'HealthSpike', recordName: 'spike-1'),
+        throwsA(
+          isA<CloudKitChannelError>().having(
+            (e) => e.code,
+            'code',
+            'CK_MALFORMED_FIELD',
+          ),
+        ),
+      );
+    });
+
+    test('response not a Map → CloudKitChannelError', () async {
+      mockChannel((_) async => 'definitely-not-a-map');
+      final source = MethodChannelCloudKitSource();
+      await expectLater(
+        () =>
+            source.getRecord(recordType: 'HealthSpike', recordName: 'spike-1'),
+        throwsA(
+          isA<CloudKitChannelError>().having(
+            (e) => e.code,
+            'code',
+            'CK_MALFORMED_RESPONSE',
+          ),
+        ),
+      );
+    });
+
+    test('PlatformException on get → CloudKitChannelError', () async {
+      mockChannel((_) async {
+        throw PlatformException(
+          code: 'CK_GET_RECORD_FAILED',
+          message: 'boom',
+          details: 'nserror-details',
+        );
+      });
+      final source = MethodChannelCloudKitSource();
+      await expectLater(
+        () =>
+            source.getRecord(recordType: 'HealthSpike', recordName: 'spike-1'),
+        throwsA(
+          isA<CloudKitChannelError>().having(
+            (e) => e.code,
+            'code',
+            'CK_GET_RECORD_FAILED',
+          ),
+        ),
+      );
+    });
+  });
+
+  group('round-trip through encode → decode on the same channel', () {
+    test('every value type survives an encode → decode cycle', () async {
+      // Capture the Dart-side encoded payload, then synthesize a
+      // plausible Swift-side response with the same field shape and
+      // assert decode → original record. This proves the Dart encoder
+      // and Dart decoder agree on the wire contract — the Swift side
+      // is covered by the separate device-verification step.
+      late Map<String, Object?> savedArgs;
+      mockChannel((call) async {
+        if (call.method == 'saveRecord') {
+          savedArgs = Map<String, Object?>.from(call.arguments as Map);
+          return null;
+        }
+        if (call.method == 'getRecord') {
+          // Synthesize the Swift-side response from the save args.
+          return <String, Object?>{
+            'recordType': savedArgs['recordType'],
+            'recordName': savedArgs['recordName'],
+            'fields': savedArgs['fields'],
+          };
+        }
+        return null;
+      });
+
+      final source = MethodChannelCloudKitSource();
+      final original = CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'spike-1',
+        fields: {
+          's': const CKString('hello'),
+          'i': const CKInt(9007199254740992),
+          'd': const CKDouble(3.141592653589793),
+          'b': const CKBool(false),
+          't': CKDateTime(DateTime.utc(2026, 4, 24, 12, 34, 56, 789)),
+        },
+      );
+
+      await source.saveRecord(original);
+      final fetched = await source.getRecord(
+        recordType: 'HealthSpike',
+        recordName: 'spike-1',
+      );
+
+      expect(fetched, equals(original));
+    });
+  });
 }


### PR DESCRIPTION
## Summary
Extends the S7.1 walking skeleton with `saveRecord` + `getRecord` that round-trip a `CloudKitRecord` across the Flutter method channel without losing type fidelity on any of String / Int / Double / Bool / DateTime. Spike gap #1 (`Map<String,String>` write surface → stringified doubles + dates) is now a trust-rule violation we have code to prevent, rather than an open hazard.

**Channel contract** (documented at the top of `method_channel_cloud_kit_source.dart` + `CloudKitRecordCodec.swift`):

Each field crosses the channel as a 2-element `[typeTag, raw]` list where `typeTag` ∈ `{string, int, double, bool, dateTime}`.
- `string` → String
- `int` → int, stored via `NSNumber(value: Int64)` so 2^53-precision survives
- `double` → double, stored via `NSNumber(value: Double)` so IEEE 754 bit pattern survives
- `bool` → bool, stored via `NSNumber(value: Bool)` (CFBoolean-distinguished on read-back)
- `dateTime` → int milliseconds-since-epoch (UTC); Swift converts via `Date(timeIntervalSince1970: ms/1000.0)`

Unknown typeTag or malformed wire shape → `CloudKitChannelError` (no silent fallback to String). Record-not-found (`CKError.unknownItem`) → Dart `null` for clean get-by-id semantics.

## Scope
**In:** single-record save + get-by-id, private DB, default zone. Dart façade + MethodChannel impl + Fake. Swift `CloudKitRecordCodec` + `SaveRecordHandler` + `GetRecordHandler`.
**Out:** record zones (S7.3 / #71), batch modify / conflict resolution (S7.4), asset + reference types, any query / listByType.

## Files touched
- **New Swift:** `ios/Runner/CloudKit/{CloudKitRecordCodec,SaveRecordHandler,GetRecordHandler}.swift` — wired into `CloudKitBridge`'s dispatch + `ios/Runner.xcodeproj/project.pbxproj`.
- **Modified Swift:** `ios/Runner/CloudKit/CloudKitBridge.swift` grows two cases (saveRecord, getRecord) and two handler properties.
- **New Dart types:** `CloudKitRecord`, sealed `CloudKitValue` + `CKString` / `CKInt` / `CKDouble` / `CKBool` / `CKDateTime` subtypes with value-based `==` / `hashCode`.
- **Modified Dart:** `lib/sources/cloudkit/{cloud_kit_source,method_channel_cloud_kit_source,fake_cloud_kit_source}.dart`.

## Trust rules
- **No silent fallback.** Every error path surfaces as a typed Dart exception (`CloudKitChannelError` with a named `code`). Unknown typeTag → `CK_UNKNOWN_TYPE_TAG`. Malformed field → `CK_MALFORMED_FIELD`. Malformed response → `CK_MALFORMED_RESPONSE`. Native save/get failures → `CK_SAVE_RECORD_FAILED` / `CK_GET_RECORD_FAILED`.
- **No silent mutation of totals.** Type fidelity is the whole point of this PR — `CKDouble(3.14)` saved and fetched returns `CKDouble(3.14)`, not `CKString("3.14")`.
- **No fire-and-forget writes.** `saveRecord` returns `Future<void>` that completes only when the native side has acknowledged the save.
- **Arch guardrail** (`test/arch/data_access_boundary_test.dart`) passes: only the `_source.dart` façade is imported by anything outside `lib/sources/cloudkit/`; feature code is untouched.

## Test plan
- [x] `flutter pub get` clean
- [x] `flutter analyze` clean (0 issues)
- [x] `flutter test --timeout=60s` — **402/402 passing** (376 → 402, +26 new tests scoped to S7.2)
- [x] `flutter build ios --debug --no-codesign` — 30.8s, clean (pbxproj additions compile)
- [x] `dart format` run on only the files touched (per Skills.md rule)
- [ ] **Founder post-merge device verification** (iPhone 15 signed into iCloud, container registered per Runbooks.md): run a developer-only harness or the next sprint's mapper to exercise a real round-trip with a throwaway `HealthSpike` record. This PR cannot exercise a real CloudKit container on CI (no iCloud there); the channel contract is proved via fake + mock-channel tests.

### New tests (26 added)
- `CloudKitValue` equality + hash across all 5 subtypes; heterogeneous subtypes never compare equal.
- `CloudKitRecord` equality / hash: iteration-order independence; differs on type, name, field value.
- `FakeCloudKitSource`: round-trip preserving equality, null on missing, upsert on resave, recordType-namespaces-recordName, configured error surfacing.
- `MethodChannel` encode: asserts each of the 5 typeTag wire forms on `saveRecord`.
- `MethodChannel` decode: asserts each typeTag decodes to the right subtype (DateTime surfaces as UTC, ms-accurate); unknown typeTag → `CK_UNKNOWN_TYPE_TAG`; malformed field → `CK_MALFORMED_FIELD`; type mismatch for declared tag → `CK_MALFORMED_FIELD`; non-map response → `CK_MALFORMED_RESPONSE`; null response → null record.
- End-to-end: encode → synthesized channel response → decode round-trips the original record.

## Deps
**Zero new deps.** Pure Dart sealed classes + stdlib method channel + `CKRecord` typed setters.

## Closes
Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)