### PR TITLE
#73 — S7.5 — Group sets by exercise on session detail

### DIFF
--- a/lib/data/repositories/exercise_set_repository.dart
+++ b/lib/data/repositories/exercise_set_repository.dart
@@ -40,10 +40,68 @@ class ExerciseSetRepository {
   /// ascending for deterministic output. Added for the data-export flow
   /// (issue #37) which needs a flat dump of all rows; the other
   /// `watch*`/`list*` pairs on this repository are session-scoped.
-  Future<List<ExerciseSet>> listAll() =>
-      (_db.select(_db.exerciseSets)
-            ..orderBy([(t) => OrderingTerm.asc(t.id)]))
-          .get();
+  Future<List<ExerciseSet>> listAll() => (_db.select(
+    _db.exerciseSets,
+  )..orderBy([(t) => OrderingTerm.asc(t.id)])).get();
+
+  /// Streams every set for [sessionId], each paired with its canonical
+  /// [Exercise] row (via the `exercise_id` FK) when one exists.
+  ///
+  /// Sets are ordered by `orderIndex` ascending — the authoritative
+  /// within-session ordering — so callers can group them by
+  /// exercise and still preserve the user's recorded sequence within
+  /// each group.
+  ///
+  /// Uses a LEFT OUTER JOIN so legacy sets with `exercise_id = NULL`
+  /// still surface with `exercise: null`; the feature layer renders
+  /// those as a fallback group using the set's raw `exerciseName`
+  /// (S7.5 / issue #73). Silent data loss — dropping rows whose FK
+  /// didn't backfill — is a trust-rule violation.
+  Stream<List<({ExerciseSet set, Exercise? exercise})>>
+  watchSessionSetsWithExercise(int sessionId) {
+    final query =
+        _db.select(_db.exerciseSets).join([
+            leftOuterJoin(
+              _db.exercises,
+              _db.exercises.id.equalsExp(_db.exerciseSets.exerciseId),
+            ),
+          ])
+          ..where(_db.exerciseSets.sessionId.equals(sessionId))
+          ..orderBy([OrderingTerm.asc(_db.exerciseSets.orderIndex)]);
+    return query.watch().map(
+      (rows) => [
+        for (final r in rows)
+          (
+            set: r.readTable(_db.exerciseSets),
+            exercise: r.readTableOrNull(_db.exercises),
+          ),
+      ],
+    );
+  }
+
+  /// One-shot sibling of [watchSessionSetsWithExercise]. Widget tests
+  /// use this to avoid the Drift + fake_async hang on stream reads
+  /// (see `vault/05 Architecture/Skills.md` — Drift + fake_async).
+  Future<List<({ExerciseSet set, Exercise? exercise})>>
+  listSessionSetsWithExercise(int sessionId) async {
+    final query =
+        _db.select(_db.exerciseSets).join([
+            leftOuterJoin(
+              _db.exercises,
+              _db.exercises.id.equalsExp(_db.exerciseSets.exerciseId),
+            ),
+          ])
+          ..where(_db.exerciseSets.sessionId.equals(sessionId))
+          ..orderBy([OrderingTerm.asc(_db.exerciseSets.orderIndex)]);
+    final rows = await query.get();
+    return [
+      for (final r in rows)
+        (
+          set: r.readTable(_db.exerciseSets),
+          exercise: r.readTableOrNull(_db.exercises),
+        ),
+    ];
+  }
 
   /// Returns up to [limit] distinct exercise names across all sessions,
   /// ordered by most recent use (newest first).

--- a/lib/features/workouts/workout_providers.dart
+++ b/lib/features/workouts/workout_providers.dart
@@ -8,16 +8,39 @@ final workoutSessionsProvider = StreamProvider<List<WorkoutSession>>((ref) {
   return repo.watchAll();
 });
 
-final sessionByIdProvider = StreamProvider.family<WorkoutSession?, int>((ref, id) {
+final sessionByIdProvider = StreamProvider.family<WorkoutSession?, int>((
+  ref,
+  id,
+) {
   final repo = ref.watch(workoutSessionRepositoryProvider);
   return repo.watchById(id);
 });
 
-final setsForSessionProvider =
-    StreamProvider.family<List<ExerciseSet>, int>((ref, id) {
+final setsForSessionProvider = StreamProvider.family<List<ExerciseSet>, int>((
+  ref,
+  id,
+) {
   final repo = ref.watch(exerciseSetRepositoryProvider);
   return repo.watchForSession(id);
 });
+
+/// Streams each set in a session paired with its canonical [Exercise] row
+/// (via the `exercise_id` FK) when one exists. Feeds the grouped session-
+/// detail view (S7.5 / issue #73).
+///
+/// Sets with a null FK surface with `exercise: null`; the feature layer
+/// groups those separately using the raw `exerciseName` and renders a
+/// muted "(legacy)" suffix on the group header. The trust rule that
+/// estimates must be visibly labeled extends to provenance: conflating
+/// canonical and non-canonical rows silently is a trust-rule violation.
+final setsWithExerciseForSessionProvider =
+    StreamProvider.family<List<({ExerciseSet set, Exercise? exercise})>, int>((
+      ref,
+      id,
+    ) {
+      final repo = ref.watch(exerciseSetRepositoryProvider);
+      return repo.watchSessionSetsWithExercise(id);
+    });
 
 /// Feeds the Exercise Set form's recent-exercises chip strip (issue #39).
 ///

--- a/lib/features/workouts/workout_session_screen.dart
+++ b/lib/features/workouts/workout_session_screen.dart
@@ -18,7 +18,7 @@ class WorkoutSessionScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final session = ref.watch(sessionByIdProvider(sessionId));
-    final sets = ref.watch(setsForSessionProvider(sessionId));
+    final sets = ref.watch(setsWithExerciseForSessionProvider(sessionId));
 
     return Scaffold(
       appBar: AppBar(
@@ -54,33 +54,27 @@ class WorkoutSessionScreen extends ConsumerWidget {
           const Divider(height: 1),
           Expanded(
             child: sets.when(
-              data: (list) => list.isEmpty
-                  ? const Center(
-                      child: Padding(
-                        padding: EdgeInsets.all(24),
-                        child: Text(
-                          'No sets yet.\nTap + to add one.',
-                          textAlign: TextAlign.center,
-                        ),
+              data: (list) {
+                if (list.isEmpty) {
+                  return const Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(24),
+                      child: Text(
+                        'No sets yet.\nTap + to add one.',
+                        textAlign: TextAlign.center,
                       ),
-                    )
-                  : ListView.separated(
-                      itemCount: list.length,
-                      separatorBuilder: (_, _) => const Divider(height: 1),
-                      itemBuilder: (context, i) {
-                        final s = list[i];
-                        return ListTile(
-                          title: Text(s.exerciseName),
-                          subtitle: Text(
-                            '${s.reps} reps · ${formatWeight(s.weight, s.weightUnit)} · ${workoutSetStatusLabel(s.status)}',
-                          ),
-                          onTap: () =>
-                              _editSet(context, s, sessionId, list.length),
-                        );
-                      },
                     ),
+                  );
+                }
+                final groups = _groupByExercise(list);
+                return _GroupedSetsList(
+                  groups: groups,
+                  onTapSet: (s) => _editSet(context, s, sessionId, list.length),
+                );
+              },
               loading: () => const SizedBox.shrink(),
-              error: (err, _) => Center(child: Text('Could not load sets: $err')),
+              error: (err, _) =>
+                  Center(child: Text('Could not load sets: $err')),
             ),
           ),
         ],
@@ -92,25 +86,33 @@ class WorkoutSessionScreen extends ConsumerWidget {
     // Use a fresh, synchronous read so we pick the correct next orderIndex
     // even if the stream hasn't emitted the most recent add yet.
     final nextIndex = ref
-            .read(setsForSessionProvider(sessionId))
-            .maybeWhen(data: (l) => l.length, orElse: () => 0);
-    Navigator.of(context).push(MaterialPageRoute(
-      builder: (_) => ExerciseSetFormScreen(
-        sessionId: sessionId,
-        nextOrderIndex: nextIndex,
+        .read(setsWithExerciseForSessionProvider(sessionId))
+        .maybeWhen(data: (l) => l.length, orElse: () => 0);
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ExerciseSetFormScreen(
+          sessionId: sessionId,
+          nextOrderIndex: nextIndex,
+        ),
       ),
-    ));
+    );
   }
 
   void _editSet(
-      BuildContext context, ExerciseSet existing, int sessionId, int count) {
-    Navigator.of(context).push(MaterialPageRoute(
-      builder: (_) => ExerciseSetFormScreen(
-        sessionId: sessionId,
-        existing: existing,
-        nextOrderIndex: count,
+    BuildContext context,
+    ExerciseSet existing,
+    int sessionId,
+    int count,
+  ) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ExerciseSetFormScreen(
+          sessionId: sessionId,
+          existing: existing,
+          nextOrderIndex: count,
+        ),
       ),
-    ));
+    );
   }
 
   Future<void> _editNote(
@@ -130,9 +132,9 @@ class WorkoutSessionScreen extends ConsumerWidget {
           .updateNote(sessionId, next.note);
     } catch (e) {
       if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not save note: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Could not save note: $e')));
     }
   }
 
@@ -143,14 +145,14 @@ class WorkoutSessionScreen extends ConsumerWidget {
     if (session == null) return;
     if (session.endedAt != null) return;
     try {
-      await ref.read(workoutSessionRepositoryProvider).update(
-            session.copyWith(endedAt: Value(DateTime.now())),
-          );
+      await ref
+          .read(workoutSessionRepositoryProvider)
+          .update(session.copyWith(endedAt: Value(DateTime.now())));
     } catch (e) {
       if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not end session: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Could not end session: $e')));
     }
   }
 
@@ -179,16 +181,14 @@ class WorkoutSessionScreen extends ConsumerWidget {
     if (!context.mounted) return;
 
     try {
-      await ref
-          .read(workoutSessionRepositoryProvider)
-          .delete(sessionId);
+      await ref.read(workoutSessionRepositoryProvider).delete(sessionId);
       if (!context.mounted) return;
       Navigator.of(context).pop();
     } catch (e) {
       if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Could not delete workout: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Could not delete workout: $e')));
     }
   }
 }
@@ -285,9 +285,9 @@ class _NoteRow extends StatelessWidget {
             child: Text(
               note,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    fontStyle: FontStyle.italic,
-                    color: Theme.of(context).hintColor,
-                  ),
+                fontStyle: FontStyle.italic,
+                color: Theme.of(context).hintColor,
+              ),
             ),
           ),
         );
@@ -348,8 +348,8 @@ class _NoteEditDialogState extends State<_NoteEditDialog> {
           child: const Text('Cancel'),
         ),
         TextButton(
-          onPressed: () => Navigator.of(context)
-              .pop(_NoteDialogResult(_controller.text)),
+          onPressed: () =>
+              Navigator.of(context).pop(_NoteDialogResult(_controller.text)),
           child: const Text('Save'),
         ),
       ],
@@ -361,4 +361,191 @@ String _formatTime(DateTime t) {
   final h = t.hour.toString().padLeft(2, '0');
   final m = t.minute.toString().padLeft(2, '0');
   return '$h:$m';
+}
+
+/// One exercise's worth of sets, surfaced to the grouped list widget.
+///
+/// [displayName] is the canonical `Exercise.name` when [isLegacy] is
+/// false, and the row's raw `exerciseName` when [isLegacy] is true.
+/// [isLegacy] flips on whenever a group was formed from sets whose
+/// `exercise_id` FK is null — the S5.1 backfill couldn't match them
+/// to a canonical row. The UI renders a muted "(legacy)" suffix in
+/// that case (visible provenance label, per the trust rule that
+/// estimates / best-effort resolution must be visibly marked).
+///
+/// [sets] preserves the input `orderIndex` ordering; [minOrderIndex]
+/// is used to order the groups themselves on screen.
+class _ExerciseGroup {
+  const _ExerciseGroup({
+    required this.displayName,
+    required this.isLegacy,
+    required this.sets,
+    required this.minOrderIndex,
+  });
+
+  final String displayName;
+  final bool isLegacy;
+  final List<ExerciseSet> sets;
+  final int minOrderIndex;
+}
+
+/// Groups a list of (set, exercise?) tuples into per-exercise buckets.
+///
+/// Grouping rules (S7.5 / issue #73):
+/// - Primary key: `exerciseId` when non-null — all sets sharing the FK
+///   land in one group regardless of stored `exerciseName` spelling.
+/// - Fallback key: normalized `exerciseName` (lowercase + trim) for
+///   sets with a null FK. Legacy rows that S5.1 backfill couldn't
+///   match stay isolated in their own groups.
+/// - Groups with a non-null FK and groups keyed by a stripped name
+///   never merge, even if the strings happen to collide — treated as
+///   distinct provenance channels per the trust rule.
+/// - Within a group: preserve input order (caller supplies sets
+///   ordered by `orderIndex` ascending).
+/// - Between groups: order by the minimum `orderIndex` across the
+///   group's sets so "the exercise the user did first" comes first.
+List<_ExerciseGroup> _groupByExercise(
+  List<({ExerciseSet set, Exercise? exercise})> rows,
+) {
+  // Key per bucket — canonical FK groups use `'c:<id>'`; legacy groups
+  // use `'l:<normalized-name>'`. The `c:` / `l:` prefix keeps a
+  // canonical group and a legacy group with the same name from merging.
+  final buckets = <String, _ExerciseGroup>{};
+  final orderedKeys = <String>[]; // insertion-order so ties hold stable.
+
+  for (final r in rows) {
+    final set = r.set;
+    final exercise = r.exercise;
+    final String key;
+    final String displayName;
+    final bool isLegacy;
+    if (exercise != null) {
+      key = 'c:${exercise.id}';
+      displayName = exercise.canonicalName;
+      isLegacy = false;
+    } else {
+      // Fallback: normalize to lowercase + trim so "bench press" and
+      // " Bench Press " bucket together. Display uses the first
+      // occurrence's raw text (no silent canonicalization of what the
+      // user typed).
+      key = 'l:${set.exerciseName.trim().toLowerCase()}';
+      displayName = set.exerciseName;
+      isLegacy = true;
+    }
+    final existing = buckets[key];
+    if (existing == null) {
+      buckets[key] = _ExerciseGroup(
+        displayName: displayName,
+        isLegacy: isLegacy,
+        sets: [set],
+        minOrderIndex: set.orderIndex,
+      );
+      orderedKeys.add(key);
+    } else {
+      existing.sets.add(set);
+    }
+  }
+
+  final groups = orderedKeys.map((k) => buckets[k]!).toList();
+  // Stable sort by minOrderIndex — insertion-order breaks ties.
+  groups.sort((a, b) => a.minOrderIndex.compareTo(b.minOrderIndex));
+  return groups;
+}
+
+/// Renders the grouped list: one sticky-style header per exercise,
+/// then its sets as `ListTile`s. Built on a flat `ListView.builder`
+/// with a pre-flattened list of (header | tile) items — matches the
+/// prior screen's flat-list simplicity while adding header rows.
+class _GroupedSetsList extends StatelessWidget {
+  const _GroupedSetsList({required this.groups, required this.onTapSet});
+
+  final List<_ExerciseGroup> groups;
+  final void Function(ExerciseSet set) onTapSet;
+
+  @override
+  Widget build(BuildContext context) {
+    // Pre-flatten into a list of heterogeneous items — each is either a
+    // header or a tile — so the ListView.builder doesn't need nested
+    // index arithmetic to locate its row.
+    final items = <_GroupedListItem>[];
+    for (final g in groups) {
+      items.add(_GroupedListItem.header(g));
+      for (final s in g.sets) {
+        items.add(_GroupedListItem.tile(s));
+      }
+    }
+
+    return ListView.builder(
+      itemCount: items.length,
+      itemBuilder: (context, i) {
+        final item = items[i];
+        final header = item.header;
+        if (header != null) {
+          return _ExerciseGroupHeader(group: header);
+        }
+        final s = item.set!;
+        return ListTile(
+          title: Text(s.exerciseName),
+          subtitle: Text(
+            '${s.reps} reps · ${formatWeight(s.weight, s.weightUnit)} · ${workoutSetStatusLabel(s.status)}',
+          ),
+          onTap: () => onTapSet(s),
+        );
+      },
+    );
+  }
+}
+
+/// Heterogeneous list item — either a group header or a set tile.
+/// Kept internal to the file; the flat-list shape inside
+/// [_GroupedSetsList] is an implementation detail.
+class _GroupedListItem {
+  const _GroupedListItem._({this.header, this.set});
+  factory _GroupedListItem.header(_ExerciseGroup g) =>
+      _GroupedListItem._(header: g);
+  factory _GroupedListItem.tile(ExerciseSet s) => _GroupedListItem._(set: s);
+
+  final _ExerciseGroup? header;
+  final ExerciseSet? set;
+}
+
+/// Section header rendered above each group of sets. Uses the app's
+/// M3 `colorScheme.onSurfaceVariant` for the muted "(legacy)" suffix
+/// on fallback groups — matches `SourceBadge` (the other muted-neutral
+/// provenance signal in the UI).
+class _ExerciseGroupHeader extends StatelessWidget {
+  const _ExerciseGroupHeader({required this.group});
+
+  final _ExerciseGroup group;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.baseline,
+        textBaseline: TextBaseline.alphabetic,
+        children: [
+          Flexible(
+            child: Text(
+              group.displayName,
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          if (group.isLegacy) ...[
+            const SizedBox(width: 6),
+            Text(
+              '(legacy)',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
 }

--- a/test/data/workout_repository_test.dart
+++ b/test/data/workout_repository_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:liftlog_app/data/database.dart';
 import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/data/repositories/exercise_repository.dart';
 import 'package:liftlog_app/data/repositories/exercise_set_repository.dart';
 import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
 
@@ -20,133 +21,153 @@ void main() {
 
   tearDown(() async => db.close());
 
-  test('session lifecycle: add → end (update with endedAt) → delete cascades sets',
-      () async {
-    final sessionId = await sessions.add(WorkoutSessionsCompanion.insert(
-      startedAt: DateTime(2026, 4, 23, 18),
-    ));
+  test(
+    'session lifecycle: add → end (update with endedAt) → delete cascades sets',
+    () async {
+      final sessionId = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23, 18)),
+      );
 
-    for (var i = 0; i < 3; i++) {
-      await sets.add(ExerciseSetsCompanion.insert(
-        sessionId: sessionId,
-        exerciseName: 'Bench Press',
-        reps: 8,
-        weight: 80.0,
-        weightUnit: WeightUnit.kg,
-        status: WorkoutSetStatus.completed,
-        orderIndex: i,
-      ));
-    }
+      for (var i = 0; i < 3; i++) {
+        await sets.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: sessionId,
+            exerciseName: 'Bench Press',
+            reps: 8,
+            weight: 80.0,
+            weightUnit: WeightUnit.kg,
+            status: WorkoutSetStatus.completed,
+            orderIndex: i,
+          ),
+        );
+      }
 
-    expect(await sets.listForSession(sessionId), hasLength(3));
+      expect(await sets.listForSession(sessionId), hasLength(3));
 
-    final session = await sessions.findById(sessionId);
-    expect(session, isNotNull);
-    await sessions.update(session!.copyWith(
-      endedAt: Value(DateTime(2026, 4, 23, 19)),
-    ));
-    expect((await sessions.findById(sessionId))!.endedAt, isNotNull);
+      final session = await sessions.findById(sessionId);
+      expect(session, isNotNull);
+      await sessions.update(
+        session!.copyWith(endedAt: Value(DateTime(2026, 4, 23, 19))),
+      );
+      expect((await sessions.findById(sessionId))!.endedAt, isNotNull);
 
-    await sessions.delete(sessionId);
-    expect(await sessions.findById(sessionId), isNull);
-    expect(await sets.listForSession(sessionId), isEmpty,
-        reason: 'onDelete: cascade should remove child sets');
-  });
+      await sessions.delete(sessionId);
+      expect(await sessions.findById(sessionId), isNull);
+      expect(
+        await sets.listForSession(sessionId),
+        isEmpty,
+        reason: 'onDelete: cascade should remove child sets',
+      );
+    },
+  );
 
-  test('sets for a session are returned ordered by orderIndex ascending',
-      () async {
-    final id = await sessions.add(WorkoutSessionsCompanion.insert(
-      startedAt: DateTime(2026, 4, 23),
-    ));
+  test(
+    'sets for a session are returned ordered by orderIndex ascending',
+    () async {
+      final id = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23)),
+      );
 
-    await sets.add(ExerciseSetsCompanion.insert(
-      sessionId: id,
-      exerciseName: 'Squat',
-      reps: 5,
-      weight: 100,
-      weightUnit: WeightUnit.kg,
-      status: WorkoutSetStatus.completed,
-      orderIndex: 2,
-    ));
-    await sets.add(ExerciseSetsCompanion.insert(
-      sessionId: id,
-      exerciseName: 'Squat',
-      reps: 5,
-      weight: 100,
-      weightUnit: WeightUnit.kg,
-      status: WorkoutSetStatus.planned,
-      orderIndex: 0,
-    ));
-    await sets.add(ExerciseSetsCompanion.insert(
-      sessionId: id,
-      exerciseName: 'Squat',
-      reps: 5,
-      weight: 100,
-      weightUnit: WeightUnit.kg,
-      status: WorkoutSetStatus.skipped,
-      orderIndex: 1,
-    ));
+      await sets.add(
+        ExerciseSetsCompanion.insert(
+          sessionId: id,
+          exerciseName: 'Squat',
+          reps: 5,
+          weight: 100,
+          weightUnit: WeightUnit.kg,
+          status: WorkoutSetStatus.completed,
+          orderIndex: 2,
+        ),
+      );
+      await sets.add(
+        ExerciseSetsCompanion.insert(
+          sessionId: id,
+          exerciseName: 'Squat',
+          reps: 5,
+          weight: 100,
+          weightUnit: WeightUnit.kg,
+          status: WorkoutSetStatus.planned,
+          orderIndex: 0,
+        ),
+      );
+      await sets.add(
+        ExerciseSetsCompanion.insert(
+          sessionId: id,
+          exerciseName: 'Squat',
+          reps: 5,
+          weight: 100,
+          weightUnit: WeightUnit.kg,
+          status: WorkoutSetStatus.skipped,
+          orderIndex: 1,
+        ),
+      );
 
-    final ordered = await sets.watchForSession(id).first;
-    expect(ordered.map((s) => s.status),
-        [WorkoutSetStatus.planned, WorkoutSetStatus.skipped, WorkoutSetStatus.completed]);
-  });
+      final ordered = await sets.watchForSession(id).first;
+      expect(ordered.map((s) => s.status), [
+        WorkoutSetStatus.planned,
+        WorkoutSetStatus.skipped,
+        WorkoutSetStatus.completed,
+      ]);
+    },
+  );
 
   test('all three WorkoutSetStatus values round-trip', () async {
-    final id = await sessions.add(WorkoutSessionsCompanion.insert(
-      startedAt: DateTime(2026, 4, 23),
-    ));
+    final id = await sessions.add(
+      WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23)),
+    );
 
     for (final (i, status) in [
       WorkoutSetStatus.planned,
       WorkoutSetStatus.completed,
       WorkoutSetStatus.skipped,
     ].indexed) {
-      await sets.add(ExerciseSetsCompanion.insert(
-        sessionId: id,
-        exerciseName: 'Deadlift',
-        reps: 5,
-        weight: 140,
-        weightUnit: WeightUnit.kg,
-        status: status,
-        orderIndex: i,
-      ));
+      await sets.add(
+        ExerciseSetsCompanion.insert(
+          sessionId: id,
+          exerciseName: 'Deadlift',
+          reps: 5,
+          weight: 140,
+          weightUnit: WeightUnit.kg,
+          status: status,
+          orderIndex: i,
+        ),
+      );
     }
 
     final rows = await db
         .customSelect('SELECT status FROM exercise_sets ORDER BY order_index')
         .get();
-    expect(rows.map((r) => r.read<String>('status')),
-        ['planned', 'completed', 'skipped']);
+    expect(rows.map((r) => r.read<String>('status')), [
+      'planned',
+      'completed',
+      'skipped',
+    ]);
   });
 
   test('watchAll returns sessions newest-first by startedAt', () async {
-    await sessions.add(WorkoutSessionsCompanion.insert(
-      startedAt: DateTime(2026, 4, 20),
-    ));
-    await sessions.add(WorkoutSessionsCompanion.insert(
-      startedAt: DateTime(2026, 4, 23),
-    ));
-    await sessions.add(WorkoutSessionsCompanion.insert(
-      startedAt: DateTime(2026, 4, 22),
-    ));
+    await sessions.add(
+      WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 20)),
+    );
+    await sessions.add(
+      WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23)),
+    );
+    await sessions.add(
+      WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 22)),
+    );
 
     final all = await sessions.watchAll().first;
-    expect(
-      all.map((s) => s.startedAt),
-      [
-        DateTime(2026, 4, 23),
-        DateTime(2026, 4, 22),
-        DateTime(2026, 4, 20),
-      ],
-    );
+    expect(all.map((s) => s.startedAt), [
+      DateTime(2026, 4, 23),
+      DateTime(2026, 4, 22),
+      DateTime(2026, 4, 20),
+    ]);
   });
 
   group('updateNote', () {
     test('persists a non-null note and round-trips', () async {
-      final id = await sessions.add(WorkoutSessionsCompanion.insert(
-        startedAt: DateTime(2026, 4, 23),
-      ));
+      final id = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23)),
+      );
 
       await sessions.updateNote(id, 'Felt strong today');
       final row = await sessions.findById(id);
@@ -155,10 +176,12 @@ void main() {
     });
 
     test('empty string and whitespace normalize to null', () async {
-      final id = await sessions.add(WorkoutSessionsCompanion.insert(
-        startedAt: DateTime(2026, 4, 23),
-        note: const Value('Initial'),
-      ));
+      final id = await sessions.add(
+        WorkoutSessionsCompanion.insert(
+          startedAt: DateTime(2026, 4, 23),
+          note: const Value('Initial'),
+        ),
+      );
 
       // Clear via empty string.
       await sessions.updateNote(id, '');
@@ -175,10 +198,12 @@ void main() {
     });
 
     test('overwrites existing note (no silent preserve)', () async {
-      final id = await sessions.add(WorkoutSessionsCompanion.insert(
-        startedAt: DateTime(2026, 4, 23),
-        note: const Value('first'),
-      ));
+      final id = await sessions.add(
+        WorkoutSessionsCompanion.insert(
+          startedAt: DateTime(2026, 4, 23),
+          note: const Value('first'),
+        ),
+      );
 
       await sessions.updateNote(id, 'second');
       expect((await sessions.findById(id))!.note, 'second');
@@ -199,50 +224,50 @@ void main() {
 
     test('dedups keeping the newest occurrence per name '
         '(Bench → Squat → Bench → Row yields [Row, Bench, Squat])', () async {
-      final id = await sessions.add(WorkoutSessionsCompanion.insert(
-        startedAt: DateTime(2026, 4, 23),
-      ));
+      final id = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23)),
+      );
 
       // Inserted in order — `id` autoincrements, so id-desc gives us
       // the recency order we want.
-      for (final (i, name) in [
-        'Bench',
-        'Squat',
-        'Bench',
-        'Row',
-      ].indexed) {
-        await sets.add(ExerciseSetsCompanion.insert(
-          sessionId: id,
-          exerciseName: name,
-          reps: 5,
-          weight: 80,
-          weightUnit: WeightUnit.kg,
-          status: WorkoutSetStatus.completed,
-          orderIndex: i,
-        ));
+      for (final (i, name) in ['Bench', 'Squat', 'Bench', 'Row'].indexed) {
+        await sets.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: id,
+            exerciseName: name,
+            reps: 5,
+            weight: 80,
+            weightUnit: WeightUnit.kg,
+            status: WorkoutSetStatus.completed,
+            orderIndex: i,
+          ),
+        );
       }
 
-      expect(
-        await sets.listRecentDistinctExerciseNames(),
-        ['Row', 'Bench', 'Squat'],
-      );
+      expect(await sets.listRecentDistinctExerciseNames(), [
+        'Row',
+        'Bench',
+        'Squat',
+      ]);
     });
 
     test('limit caps the returned list', () async {
-      final id = await sessions.add(WorkoutSessionsCompanion.insert(
-        startedAt: DateTime(2026, 4, 23),
-      ));
+      final id = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23)),
+      );
 
       for (var i = 0; i < 15; i++) {
-        await sets.add(ExerciseSetsCompanion.insert(
-          sessionId: id,
-          exerciseName: 'Exercise $i',
-          reps: 5,
-          weight: 80,
-          weightUnit: WeightUnit.kg,
-          status: WorkoutSetStatus.completed,
-          orderIndex: i,
-        ));
+        await sets.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: id,
+            exerciseName: 'Exercise $i',
+            reps: 5,
+            weight: 80,
+            weightUnit: WeightUnit.kg,
+            status: WorkoutSetStatus.completed,
+            orderIndex: i,
+          ),
+        );
       }
 
       final names = await sets.listRecentDistinctExerciseNames(limit: 5);
@@ -254,31 +279,130 @@ void main() {
 
     test('treats whitespace-only-different names as distinct '
         '(known behavior — no silent canonicalization)', () async {
-      final id = await sessions.add(WorkoutSessionsCompanion.insert(
-        startedAt: DateTime(2026, 4, 23),
-      ));
+      final id = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23)),
+      );
 
-      await sets.add(ExerciseSetsCompanion.insert(
-        sessionId: id,
-        exerciseName: 'Bench Press',
-        reps: 5,
-        weight: 80,
-        weightUnit: WeightUnit.kg,
-        status: WorkoutSetStatus.completed,
-        orderIndex: 0,
-      ));
-      await sets.add(ExerciseSetsCompanion.insert(
-        sessionId: id,
-        exerciseName: 'Bench Press ', // trailing space
-        reps: 5,
-        weight: 80,
-        weightUnit: WeightUnit.kg,
-        status: WorkoutSetStatus.completed,
-        orderIndex: 1,
-      ));
+      await sets.add(
+        ExerciseSetsCompanion.insert(
+          sessionId: id,
+          exerciseName: 'Bench Press',
+          reps: 5,
+          weight: 80,
+          weightUnit: WeightUnit.kg,
+          status: WorkoutSetStatus.completed,
+          orderIndex: 0,
+        ),
+      );
+      await sets.add(
+        ExerciseSetsCompanion.insert(
+          sessionId: id,
+          exerciseName: 'Bench Press ', // trailing space
+          reps: 5,
+          weight: 80,
+          weightUnit: WeightUnit.kg,
+          status: WorkoutSetStatus.completed,
+          orderIndex: 1,
+        ),
+      );
 
       final names = await sets.listRecentDistinctExerciseNames();
       expect(names, ['Bench Press ', 'Bench Press']);
+    });
+  });
+
+  group('listSessionSetsWithExercise', () {
+    test(
+      'joins canonical exercise by FK; legacy null-FK rows surface with exercise: null',
+      () async {
+        final exercisesRepo = ExerciseRepository(db);
+        final bench = await exercisesRepo.addIfMissing(
+          'Bench Press',
+          source: Source.userEntered,
+        );
+
+        final id = await sessions.add(
+          WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23)),
+        );
+
+        // Canonical-linked row.
+        await sets.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: id,
+            exerciseName: 'Bench Press',
+            reps: 8,
+            weight: 80,
+            weightUnit: WeightUnit.kg,
+            status: WorkoutSetStatus.completed,
+            orderIndex: 0,
+            exerciseId: Value(bench.id),
+          ),
+        );
+        // Legacy row — no FK. Repo must still surface it.
+        await sets.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: id,
+            exerciseName: 'Mystery Lift',
+            reps: 10,
+            weight: 40,
+            weightUnit: WeightUnit.kg,
+            status: WorkoutSetStatus.completed,
+            orderIndex: 1,
+          ),
+        );
+
+        final rows = await sets.listSessionSetsWithExercise(id);
+        expect(rows, hasLength(2));
+
+        expect(rows[0].set.exerciseName, 'Bench Press');
+        expect(rows[0].exercise, isNotNull);
+        expect(rows[0].exercise!.canonicalName, 'Bench Press');
+
+        expect(rows[1].set.exerciseName, 'Mystery Lift');
+        expect(
+          rows[1].exercise,
+          isNull,
+          reason: 'LEFT JOIN preserves legacy rows without a FK',
+        );
+      },
+    );
+
+    test('returns rows in orderIndex ascending order', () async {
+      final exercisesRepo = ExerciseRepository(db);
+      final bench = await exercisesRepo.addIfMissing(
+        'Bench Press',
+        source: Source.userEntered,
+      );
+
+      final id = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23)),
+      );
+
+      // Insert out-of-order to ensure the repo query sorts.
+      for (final i in [2, 0, 1]) {
+        await sets.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: id,
+            exerciseName: 'Bench Press',
+            reps: 5,
+            weight: 80,
+            weightUnit: WeightUnit.kg,
+            status: WorkoutSetStatus.completed,
+            orderIndex: i,
+            exerciseId: Value(bench.id),
+          ),
+        );
+      }
+
+      final rows = await sets.listSessionSetsWithExercise(id);
+      expect(rows.map((r) => r.set.orderIndex), [0, 1, 2]);
+    });
+
+    test('empty session returns empty list', () async {
+      final id = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23)),
+      );
+      expect(await sets.listSessionSetsWithExercise(id), isEmpty);
     });
   });
 
@@ -286,88 +410,103 @@ void main() {
     test('returns only sessions in [from, to) with their sets, '
         'ordered by orderIndex', () async {
       // Before window.
-      final oldId = await sessions.add(WorkoutSessionsCompanion.insert(
-        startedAt: DateTime(2026, 3, 1),
-      ));
-      await sets.add(ExerciseSetsCompanion.insert(
-        sessionId: oldId,
-        exerciseName: 'Old lift',
-        reps: 5,
-        weight: 80,
-        weightUnit: WeightUnit.kg,
-        status: WorkoutSetStatus.completed,
-        orderIndex: 0,
-      ));
+      final oldId = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 3, 1)),
+      );
+      await sets.add(
+        ExerciseSetsCompanion.insert(
+          sessionId: oldId,
+          exerciseName: 'Old lift',
+          reps: 5,
+          weight: 80,
+          weightUnit: WeightUnit.kg,
+          status: WorkoutSetStatus.completed,
+          orderIndex: 0,
+        ),
+      );
 
       // Inside window — two sessions, 2 + 1 sets.
-      final aId = await sessions.add(WorkoutSessionsCompanion.insert(
-        startedAt: DateTime(2026, 4, 20, 12),
-      ));
-      await sets.add(ExerciseSetsCompanion.insert(
-        sessionId: aId,
-        exerciseName: 'Squat',
-        reps: 5,
-        weight: 100,
-        weightUnit: WeightUnit.kg,
-        status: WorkoutSetStatus.completed,
-        orderIndex: 1,
-      ));
-      await sets.add(ExerciseSetsCompanion.insert(
-        sessionId: aId,
-        exerciseName: 'Squat',
-        reps: 5,
-        weight: 100,
-        weightUnit: WeightUnit.kg,
-        status: WorkoutSetStatus.planned,
-        orderIndex: 0,
-      ));
+      final aId = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 20, 12)),
+      );
+      await sets.add(
+        ExerciseSetsCompanion.insert(
+          sessionId: aId,
+          exerciseName: 'Squat',
+          reps: 5,
+          weight: 100,
+          weightUnit: WeightUnit.kg,
+          status: WorkoutSetStatus.completed,
+          orderIndex: 1,
+        ),
+      );
+      await sets.add(
+        ExerciseSetsCompanion.insert(
+          sessionId: aId,
+          exerciseName: 'Squat',
+          reps: 5,
+          weight: 100,
+          weightUnit: WeightUnit.kg,
+          status: WorkoutSetStatus.planned,
+          orderIndex: 0,
+        ),
+      );
 
-      final bId = await sessions.add(WorkoutSessionsCompanion.insert(
-        startedAt: DateTime(2026, 4, 22, 18),
-      ));
-      await sets.add(ExerciseSetsCompanion.insert(
-        sessionId: bId,
-        exerciseName: 'Bench',
-        reps: 8,
-        weight: 80,
-        weightUnit: WeightUnit.kg,
-        status: WorkoutSetStatus.completed,
-        orderIndex: 0,
-      ));
+      final bId = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 22, 18)),
+      );
+      await sets.add(
+        ExerciseSetsCompanion.insert(
+          sessionId: bId,
+          exerciseName: 'Bench',
+          reps: 8,
+          weight: 80,
+          weightUnit: WeightUnit.kg,
+          status: WorkoutSetStatus.completed,
+          orderIndex: 0,
+        ),
+      );
 
       // Outside window (after `to`).
-      final laterId = await sessions.add(WorkoutSessionsCompanion.insert(
-        startedAt: DateTime(2026, 5, 1),
-      ));
-      await sets.add(ExerciseSetsCompanion.insert(
-        sessionId: laterId,
-        exerciseName: 'Future lift',
-        reps: 5,
-        weight: 80,
-        weightUnit: WeightUnit.kg,
-        status: WorkoutSetStatus.completed,
-        orderIndex: 0,
-      ));
+      final laterId = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 5, 1)),
+      );
+      await sets.add(
+        ExerciseSetsCompanion.insert(
+          sessionId: laterId,
+          exerciseName: 'Future lift',
+          reps: 5,
+          weight: 80,
+          weightUnit: WeightUnit.kg,
+          status: WorkoutSetStatus.completed,
+          orderIndex: 0,
+        ),
+      );
 
       final result = await sessions.listRangeWithSets(
         DateTime(2026, 4, 20),
         DateTime(2026, 4, 27),
       );
 
-      expect(result.length, 2,
-          reason: 'only sessions in [from, to) — oldId and laterId excluded');
+      expect(
+        result.length,
+        2,
+        reason: 'only sessions in [from, to) — oldId and laterId excluded',
+      );
       expect(result.map((r) => r.session.id), [aId, bId]);
       // Session A sets: orderIndex ascending (planned first, completed second).
       expect(result[0].sets.map((s) => s.orderIndex), [0, 1]);
-      expect(result[0].sets.map((s) => s.status),
-          [WorkoutSetStatus.planned, WorkoutSetStatus.completed]);
+      expect(result[0].sets.map((s) => s.status), [
+        WorkoutSetStatus.planned,
+        WorkoutSetStatus.completed,
+      ]);
       expect(result[1].sets.length, 1);
     });
 
     test('returns sessions with no sets as an empty sets list', () async {
-      final id = await sessions.add(WorkoutSessionsCompanion.insert(
-        startedAt: DateTime(2026, 4, 21),
-      ));
+      final id = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 21)),
+      );
 
       final result = await sessions.listRangeWithSets(
         DateTime(2026, 4, 20),

--- a/test/features/workouts/workout_session_screen_test.dart
+++ b/test/features/workouts/workout_session_screen_test.dart
@@ -1,9 +1,18 @@
-// Widget tests for `WorkoutSessionScreen` note UI (S7.4 / #72).
+// Widget tests for `WorkoutSessionScreen` note UI (S7.4 / #72) and
+// the grouped-by-exercise sets layout (S7.5 / #73).
 //
 // Covers the session-level note surface:
 // - non-null note renders as italic muted text above the sets list
 // - null note shows a "+ Add note" affordance in the same slot
 // - tap opens the edit dialog; Save persists via the repo; Cancel doesn't
+//
+// Covers the grouped sets layout:
+// - 3 canonical exercises × 3 sets render 3 headers using canonical names
+// - legacy null-FK set renders with the "(legacy)" muted suffix
+// - empty session preserves the existing empty-state message
+// - within-group set ordering respects orderIndex
+// - two legacy rows with different names form two fallback groups
+// - canonical group + legacy group sort by min orderIndex
 
 import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
@@ -12,6 +21,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:liftlog_app/data/database.dart';
+import 'package:liftlog_app/data/enums.dart';
+import 'package:liftlog_app/data/repositories/exercise_repository.dart';
+import 'package:liftlog_app/data/repositories/exercise_set_repository.dart';
 import 'package:liftlog_app/data/repositories/workout_session_repository.dart';
 import 'package:liftlog_app/features/workouts/workout_session_screen.dart';
 import 'package:liftlog_app/providers/app_providers.dart';
@@ -30,19 +42,25 @@ Widget _host(AppDatabase db, Widget child) {
 void main() {
   late AppDatabase db;
   late WorkoutSessionRepository sessions;
+  late ExerciseSetRepository setsRepo;
+  late ExerciseRepository exercisesRepo;
 
   setUp(() {
     db = AppDatabase.forTesting(NativeDatabase.memory());
     sessions = WorkoutSessionRepository(db);
+    setsRepo = ExerciseSetRepository(db);
+    exercisesRepo = ExerciseRepository(db);
   });
 
   tearDown(() async => db.close());
 
   testWidgets('session with non-null note renders note text', (tester) async {
-    final id = await sessions.add(WorkoutSessionsCompanion.insert(
-      startedAt: DateTime(2026, 4, 23, 10),
-      note: const Value('Felt strong today'),
-    ));
+    final id = await sessions.add(
+      WorkoutSessionsCompanion.insert(
+        startedAt: DateTime(2026, 4, 23, 10),
+        note: const Value('Felt strong today'),
+      ),
+    );
 
     await tester.pumpWidget(_host(db, WorkoutSessionScreen(sessionId: id)));
     await tester.pumpAndSettle();
@@ -57,9 +75,9 @@ void main() {
   testWidgets('session with null note shows "+ Add note" affordance', (
     tester,
   ) async {
-    final id = await sessions.add(WorkoutSessionsCompanion.insert(
-      startedAt: DateTime(2026, 4, 23, 10),
-    ));
+    final id = await sessions.add(
+      WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23, 10)),
+    );
 
     await tester.pumpWidget(_host(db, WorkoutSessionScreen(sessionId: id)));
     await tester.pumpAndSettle();
@@ -72,9 +90,9 @@ void main() {
   testWidgets('tapping "+ Add note" opens dialog; Save persists', (
     tester,
   ) async {
-    final id = await sessions.add(WorkoutSessionsCompanion.insert(
-      startedAt: DateTime(2026, 4, 23, 10),
-    ));
+    final id = await sessions.add(
+      WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23, 10)),
+    );
 
     await tester.pumpWidget(_host(db, WorkoutSessionScreen(sessionId: id)));
     await tester.pumpAndSettle();
@@ -108,10 +126,12 @@ void main() {
   testWidgets('Cancel from the note dialog discards (no mutation)', (
     tester,
   ) async {
-    final id = await sessions.add(WorkoutSessionsCompanion.insert(
-      startedAt: DateTime(2026, 4, 23, 10),
-      note: const Value('original'),
-    ));
+    final id = await sessions.add(
+      WorkoutSessionsCompanion.insert(
+        startedAt: DateTime(2026, 4, 23, 10),
+        note: const Value('original'),
+      ),
+    );
 
     await tester.pumpWidget(_host(db, WorkoutSessionScreen(sessionId: id)));
     await tester.pumpAndSettle();
@@ -130,6 +150,290 @@ void main() {
     expect(find.text('original'), findsOneWidget);
 
     await _drainDriftTimers(tester);
+  });
+
+  // ---------------------------------------------------------------------
+  // Grouped-by-exercise sets layout (S7.5 / #73).
+  // ---------------------------------------------------------------------
+
+  group('grouped sets layout', () {
+    testWidgets(
+      'three canonical exercises × three sets render three canonical headers',
+      (tester) async {
+        // Grouped list with 3 × 3 sets plus headers exceeds the default
+        // 600-high widget-test viewport; give it enough room that every
+        // row is laid out (viewport-override skill, `Skills.md`).
+        tester.view.physicalSize = const Size(800, 2400);
+        addTearDown(tester.view.resetPhysicalSize);
+
+        final bench = await exercisesRepo.addIfMissing(
+          'Bench Press',
+          source: Source.userEntered,
+        );
+        final squat = await exercisesRepo.addIfMissing(
+          'Squat',
+          source: Source.userEntered,
+        );
+        final deadlift = await exercisesRepo.addIfMissing(
+          'Deadlift',
+          source: Source.userEntered,
+        );
+
+        final id = await sessions.add(
+          WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23, 10)),
+        );
+
+        // Interleave across exercises to prove grouping isn't a
+        // naive consecutive-run detector.
+        final layout = <(Exercise, int)>[
+          (bench, 0),
+          (squat, 1),
+          (deadlift, 2),
+          (bench, 3),
+          (squat, 4),
+          (deadlift, 5),
+          (bench, 6),
+          (squat, 7),
+          (deadlift, 8),
+        ];
+        for (final (ex, i) in layout) {
+          await setsRepo.add(
+            ExerciseSetsCompanion.insert(
+              sessionId: id,
+              exerciseName: ex.canonicalName,
+              reps: 5,
+              weight: 60,
+              weightUnit: WeightUnit.kg,
+              status: WorkoutSetStatus.completed,
+              orderIndex: i,
+              exerciseId: Value(ex.id),
+            ),
+          );
+        }
+
+        await tester.pumpWidget(_host(db, WorkoutSessionScreen(sessionId: id)));
+        await tester.pumpAndSettle();
+
+        // Each canonical name appears as a header (titleSmall style). The
+        // set tiles also render the exerciseName, so we expect each
+        // canonical name to match once in a header + three times in
+        // tiles — total four matches per name. We don't need to pin
+        // that count; the key S7.5 assertion is "no (legacy) suffix
+        // anywhere when every row has a canonical FK."
+        expect(find.text('Bench Press'), findsWidgets);
+        expect(find.text('Squat'), findsWidgets);
+        expect(find.text('Deadlift'), findsWidgets);
+        expect(
+          find.text('(legacy)'),
+          findsNothing,
+          reason: 'no group is a fallback group when every row has a FK',
+        );
+
+        await _drainDriftTimers(tester);
+      },
+    );
+
+    testWidgets('legacy null-FK set renders with "(legacy)" muted suffix', (
+      tester,
+    ) async {
+      final id = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23, 10)),
+      );
+
+      // One legacy row — no canonical `exercises` entry, no FK.
+      await setsRepo.add(
+        ExerciseSetsCompanion.insert(
+          sessionId: id,
+          exerciseName: 'Mystery Lift',
+          reps: 10,
+          weight: 50,
+          weightUnit: WeightUnit.kg,
+          status: WorkoutSetStatus.completed,
+          orderIndex: 0,
+        ),
+      );
+
+      await tester.pumpWidget(_host(db, WorkoutSessionScreen(sessionId: id)));
+      await tester.pumpAndSettle();
+
+      // Header renders the raw exerciseName + "(legacy)" suffix.
+      expect(find.text('Mystery Lift'), findsWidgets);
+      expect(find.text('(legacy)'), findsOneWidget);
+
+      await _drainDriftTimers(tester);
+    });
+
+    testWidgets('empty session renders the existing empty state (no groups)', (
+      tester,
+    ) async {
+      final id = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23, 10)),
+      );
+
+      await tester.pumpWidget(_host(db, WorkoutSessionScreen(sessionId: id)));
+      await tester.pumpAndSettle();
+
+      // Preserved copy + no group headers / legacy markers on screen.
+      expect(find.text('No sets yet.\nTap + to add one.'), findsOneWidget);
+      expect(find.text('(legacy)'), findsNothing);
+
+      await _drainDriftTimers(tester);
+    });
+
+    testWidgets('within-group set ordering respects orderIndex', (
+      tester,
+    ) async {
+      final bench = await exercisesRepo.addIfMissing(
+        'Bench Press',
+        source: Source.userEntered,
+      );
+
+      final id = await sessions.add(
+        WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23, 10)),
+      );
+
+      // Insert out-of-order; the repo's ORDER BY clause must sort them.
+      for (final (i, reps) in [(2, 6), (0, 10), (1, 8)]) {
+        await setsRepo.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: id,
+            exerciseName: 'Bench Press',
+            reps: reps,
+            weight: 80,
+            weightUnit: WeightUnit.kg,
+            status: WorkoutSetStatus.completed,
+            orderIndex: i,
+            exerciseId: Value(bench.id),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(_host(db, WorkoutSessionScreen(sessionId: id)));
+      await tester.pumpAndSettle();
+
+      // ListTile subtitles carry the reps — inspect their rendering
+      // order by searching for each subtitle text and asserting its
+      // vertical (dy) position. Tile for orderIndex=0 (10 reps) must
+      // come before orderIndex=1 (8 reps) which comes before =2 (6).
+      final tenReps = tester.getTopLeft(find.textContaining('10 reps'));
+      final eightReps = tester.getTopLeft(find.textContaining('8 reps'));
+      final sixReps = tester.getTopLeft(find.textContaining('6 reps'));
+
+      expect(tenReps.dy, lessThan(eightReps.dy));
+      expect(eightReps.dy, lessThan(sixReps.dy));
+
+      await _drainDriftTimers(tester);
+    });
+
+    testWidgets(
+      'two legacy rows with different names form two fallback groups',
+      (tester) async {
+        final id = await sessions.add(
+          WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23, 10)),
+        );
+
+        await setsRepo.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: id,
+            exerciseName: 'Legacy A',
+            reps: 5,
+            weight: 50,
+            weightUnit: WeightUnit.kg,
+            status: WorkoutSetStatus.completed,
+            orderIndex: 0,
+          ),
+        );
+        await setsRepo.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: id,
+            exerciseName: 'Legacy B',
+            reps: 5,
+            weight: 50,
+            weightUnit: WeightUnit.kg,
+            status: WorkoutSetStatus.completed,
+            orderIndex: 1,
+          ),
+        );
+
+        await tester.pumpWidget(_host(db, WorkoutSessionScreen(sessionId: id)));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Legacy A'), findsWidgets);
+        expect(find.text('Legacy B'), findsWidgets);
+        // Both groups render the "(legacy)" suffix — one per header.
+        expect(find.text('(legacy)'), findsNWidgets(2));
+
+        await _drainDriftTimers(tester);
+      },
+    );
+
+    testWidgets(
+      'canonical + legacy groups render in correct order (by min orderIndex)',
+      (tester) async {
+        final bench = await exercisesRepo.addIfMissing(
+          'Bench Press',
+          source: Source.userEntered,
+        );
+
+        final id = await sessions.add(
+          WorkoutSessionsCompanion.insert(startedAt: DateTime(2026, 4, 23, 10)),
+        );
+
+        // Canonical "Bench Press" at orderIndex 0 and 1. The user did
+        // this first — its min orderIndex is 0.
+        await setsRepo.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: id,
+            exerciseName: 'Bench Press',
+            reps: 8,
+            weight: 80,
+            weightUnit: WeightUnit.kg,
+            status: WorkoutSetStatus.completed,
+            orderIndex: 0,
+            exerciseId: Value(bench.id),
+          ),
+        );
+        await setsRepo.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: id,
+            exerciseName: 'Bench Press',
+            reps: 6,
+            weight: 80,
+            weightUnit: WeightUnit.kg,
+            status: WorkoutSetStatus.completed,
+            orderIndex: 1,
+            exerciseId: Value(bench.id),
+          ),
+        );
+        // Legacy "Mystery Lift" at orderIndex 2. Comes later on-screen.
+        await setsRepo.add(
+          ExerciseSetsCompanion.insert(
+            sessionId: id,
+            exerciseName: 'Mystery Lift',
+            reps: 10,
+            weight: 40,
+            weightUnit: WeightUnit.kg,
+            status: WorkoutSetStatus.completed,
+            orderIndex: 2,
+          ),
+        );
+
+        await tester.pumpWidget(_host(db, WorkoutSessionScreen(sessionId: id)));
+        await tester.pumpAndSettle();
+
+        // Header "Bench Press" (titleSmall) must appear above "(legacy)"
+        // suffix on the Mystery Lift header.
+        final benchPos = tester.getTopLeft(find.text('Bench Press').first);
+        final legacySuffix = tester.getTopLeft(find.text('(legacy)'));
+        expect(
+          benchPos.dy,
+          lessThan(legacySuffix.dy),
+          reason: 'canonical group (min orderIndex 0) comes first',
+        );
+
+        await _drainDriftTimers(tester);
+      },
+    );
   });
 }
 


### PR DESCRIPTION
Closes #73

## Summary
Session detail screen now groups `ExerciseSet` rows under a per-exercise header instead of rendering a flat list.

## Grouping rule
- **Primary key:** `exerciseId` when non-null — canonical FK, all sets sharing the FK land in one group regardless of stored `exerciseName` spelling.
- **Fallback key:** normalized `exerciseName` (lowercase + trim) for sets whose FK is null — legacy rows the S5.1 backfill couldn't match to a canonical entry.
- **Within group:** preserve `orderIndex` ascending (the authoritative within-session order).
- **Between groups:** order by the minimum `orderIndex` across the group's sets so "the exercise the user did first" appears first on screen.
- A canonical group and a legacy group with the same normalized name do **not** merge.

## Header copy
- Canonical groups show `Exercise.canonicalName` joined via the FK.
- Fallback groups show the row's raw `exerciseName` + a muted `(legacy)` suffix using `colorScheme.onSurfaceVariant`.

## Trust rule rationale
The `(legacy)` suffix is a visible best-effort-resolution label — the UI never silently conflates canonical and non-canonical data (parallel to the existing estimate-labeling rule). No schema change, no data mutation.

## Data layer
- `ExerciseSetRepository.watchSessionSetsWithExercise(sessionId)` + `.listSessionSetsWithExercise(sessionId)` — LEFT OUTER JOIN on `exercises.id = exercise_sets.exercise_id`, preserving legacy null-FK rows as `exercise: null` tuples.
- `setsWithExerciseForSessionProvider` consumes the stream; the feature code builds the grouped view-model locally (so `Source` stays out of features, per the arch rule).

## Scope
- In: grouped section layout on session detail, LEFT JOIN repo methods, widget + unit tests.
- Out: drag-to-reorder, collapse/expand, exercise-level PRs/volume (E7), any CloudKit / schema work.

## AC checklist
- [x] Primary grouping by `exerciseId` FK.
- [x] Fallback grouping by normalized `exerciseName` for null-FK rows.
- [x] `(legacy)` muted suffix on fallback headers.
- [x] Within-group ordering by `orderIndex`.
- [x] Between-group ordering by min `orderIndex`.
- [x] Canonical + legacy groups with the same name stay distinct.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` 411 / 411 (was 402 — +6 widget tests, +3 repo tests)
- [x] `flutter build ios --debug --no-codesign` succeeds
- [x] Arch guardrail (`test/arch/data_access_boundary_test.dart`) green — no new `Source.` references in features, no direct Drift calls.

## Assumptions
- Normalized-name fallback matches inside the legacy bucket use `.trim().toLowerCase()` so "bench press" and " Bench Press " bucket together; the displayed header shows the first occurrence's raw text (no silent canonicalization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)