### PR TITLE
#71 — S7.3 — CloudKit record zones + zone-scoped record IDs

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		CE01B72100000002000CE002 /* CloudKitRecordCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01B72000000002000CE002 /* CloudKitRecordCodec.swift */; };
 		CE01B72300000002000CE002 /* SaveRecordHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01B72200000002000CE002 /* SaveRecordHandler.swift */; };
 		CE01B72500000002000CE002 /* GetRecordHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01B72400000002000CE002 /* GetRecordHandler.swift */; };
+		CE01B73100000003000CE003 /* EnsureZoneHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE01B73000000003000CE003 /* EnsureZoneHandler.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -78,6 +79,7 @@
 		CE01B72000000002000CE002 /* CloudKitRecordCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitRecordCodec.swift; sourceTree = "<group>"; };
 		CE01B72200000002000CE002 /* SaveRecordHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveRecordHandler.swift; sourceTree = "<group>"; };
 		CE01B72400000002000CE002 /* GetRecordHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRecordHandler.swift; sourceTree = "<group>"; };
+		CE01B73000000003000CE003 /* EnsureZoneHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnsureZoneHandler.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -166,6 +168,7 @@
 				CE01B72000000002000CE002 /* CloudKitRecordCodec.swift */,
 				CE01B72200000002000CE002 /* SaveRecordHandler.swift */,
 				CE01B72400000002000CE002 /* GetRecordHandler.swift */,
+				CE01B73000000003000CE003 /* EnsureZoneHandler.swift */,
 			);
 			path = CloudKit;
 			sourceTree = "<group>";
@@ -412,6 +415,7 @@
 				CE01B72100000002000CE002 /* CloudKitRecordCodec.swift in Sources */,
 				CE01B72300000002000CE002 /* SaveRecordHandler.swift in Sources */,
 				CE01B72500000002000CE002 /* GetRecordHandler.swift in Sources */,
+				CE01B73100000003000CE003 /* EnsureZoneHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/CloudKit/CloudKitBridge.swift
+++ b/ios/Runner/CloudKit/CloudKitBridge.swift
@@ -13,9 +13,10 @@
 // Trust-rule notes mirroring `cloud_kit_source.dart`:
 // * No silent fallback. Errors surface as `FlutterError` with a typed
 //   code string the Dart side can match.
-// * S7.1 shipped `getAccountStatus`; S7.2 (this file) adds
-//   `saveRecord` + `getRecord` for the typed-record round-trip. Zones
-//   remain S7.3 (#71).
+// * S7.1 shipped `getAccountStatus`; S7.2 added `saveRecord` +
+//   `getRecord` for the typed-record round-trip. S7.3 (#71) adds
+//   `ensureZoneExists` and extends save/get with an optional
+//   `zoneName` arg (see `CloudKitRecordCodec.swift` header).
 
 import Flutter
 import Foundation
@@ -39,6 +40,7 @@ public final class CloudKitBridge {
     private let accountStatusHandler = CloudKitAccountStatusHandler()
     private let saveRecordHandler = SaveRecordHandler()
     private let getRecordHandler = GetRecordHandler()
+    private let ensureZoneHandler = EnsureZoneHandler()
 
     /// Binds the CloudKit channel against [binaryMessenger]. Typically
     /// the root `FlutterViewController`'s messenger.
@@ -76,6 +78,8 @@ public final class CloudKitBridge {
             saveRecordHandler.handle(arguments: call.arguments, result: result)
         case "getRecord":
             getRecordHandler.handle(arguments: call.arguments, result: result)
+        case "ensureZoneExists":
+            ensureZoneHandler.handle(arguments: call.arguments, result: result)
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/ios/Runner/CloudKit/CloudKitRecordCodec.swift
+++ b/ios/Runner/CloudKit/CloudKitRecordCodec.swift
@@ -1,4 +1,4 @@
-// CloudKit typed record codec — issue #70 (S7.2).
+// CloudKit typed record codec — issue #70 (S7.2), extended in #71 (S7.3).
 //
 // Translates between Flutter's channel map representation and
 // CloudKit's `CKRecord`. The Dart side owns the `CloudKitRecord` value
@@ -24,10 +24,28 @@
 //   Save method args map:
 //     { "recordType": String,
 //       "recordName": String,
+//       "zoneName":   String?   — S7.3: optional. Null/missing = default
+//                                  zone (back-compat with S7.2). Non-nil
+//                                  = CKRecordZone.ID(zoneName: ...,
+//                                    ownerName: CKCurrentUserDefaultName).
 //       "fields": [String: [Any]]  (each value is [typeTag, raw]) }
 //
+//   Get method args map:
+//     { "recordType": String,
+//       "recordName": String,
+//       "zoneName":   String?   — same semantics as save. }
+//
 //   Get method response (or null on record-not-found):
-//     same shape as save args.
+//     { "recordType": String, "recordName": String, "fields": ... }
+//     Note: response does NOT echo "zoneName"; the caller already knows
+//     which zone it asked for.
+//
+//   EnsureZoneExists method args map:
+//     { "zoneName": String }
+//     Handled by `EnsureZoneHandler` (separate file) against
+//     `CKModifyRecordZonesOperation`. Idempotent — Apple's server
+//     upserts by zoneID so creating an existing zone naturally
+//     succeeds.
 //
 // Unknown typeTag on decode → throws `CloudKitCodecError.unknownTypeTag`;
 // the caller surfaces as `FlutterError(code: "CK_UNKNOWN_TYPE_TAG")`.
@@ -64,11 +82,13 @@ public enum CloudKitRecordCodec {
     static let tagBool = "bool"
     static let tagDateTime = "dateTime"
 
-    /// Decodes the inbound args map into a `CKRecord` in the default
-    /// zone (no custom zone — S7.3 adds zones).
+    /// Decodes the inbound args map into a `CKRecord`.
     ///
     /// Expected shape: `{ "recordType": String, "recordName": String,
-    /// "fields": [String: [Any]] }`.
+    /// "zoneName": String?, "fields": [String: [Any]] }`. When
+    /// `zoneName` is nil/missing the record ID uses the default zone
+    /// (S7.2 back-compat); when present it uses
+    /// `CKRecordZone.ID(zoneName: ..., ownerName: CKCurrentUserDefaultName)`.
     public static func decodeRecord(from arguments: Any?) throws -> CKRecord {
         guard let args = arguments as? [String: Any] else {
             throw CloudKitCodecError.missingKey("arguments must be a [String: Any] map")
@@ -83,13 +103,31 @@ public enum CloudKitRecordCodec {
             throw CloudKitCodecError.missingKey("fields")
         }
 
-        let recordID = CKRecord.ID(recordName: recordName)
+        // S7.3: optional zoneName. Missing → default zone. Present →
+        // custom zone under the current user.
+        let zoneName = args["zoneName"] as? String
+        let recordID = recordID(forRecordName: recordName, zoneName: zoneName)
         let record = CKRecord(recordType: recordType, recordID: recordID)
 
         for (key, value) in rawFields {
             try applyField(to: record, key: key, wire: value)
         }
         return record
+    }
+
+    /// Constructs a `CKRecord.ID` scoped either to the default zone or
+    /// to a custom zone owned by the current user.
+    ///
+    /// When `zoneName` is nil we use the no-zone-arg initializer, which
+    /// lands in the default zone (`CKRecordZone.default()`). When non-nil
+    /// we build `CKRecordZone.ID(zoneName:, ownerName: CKCurrentUserDefaultName)`.
+    /// S7.3 scope: single-user, no shared/public zones.
+    public static func recordID(forRecordName recordName: String, zoneName: String?) -> CKRecord.ID {
+        guard let zoneName = zoneName else {
+            return CKRecord.ID(recordName: recordName)
+        }
+        let zoneID = CKRecordZone.ID(zoneName: zoneName, ownerName: CKCurrentUserDefaultName)
+        return CKRecord.ID(recordName: recordName, zoneID: zoneID)
     }
 
     /// Encodes a `CKRecord` into the response map Flutter expects.

--- a/ios/Runner/CloudKit/EnsureZoneHandler.swift
+++ b/ios/Runner/CloudKit/EnsureZoneHandler.swift
@@ -1,0 +1,81 @@
+// Handler for `ensureZoneExists` — issue #71 (S7.3).
+//
+// Creates the named `CKRecordZone` in the default container's private
+// database if it does not already exist. Wraps
+// `CKModifyRecordZonesOperation` with `modifyRecordZonesResultBlock`
+// (iOS 16+). Apple's server upserts zones by zoneID, so modifying with
+// an already-existing zone naturally succeeds — this is inherently
+// idempotent, no "already exists" special case required.
+//
+// Trust-rule notes:
+// * No silent fallback. If the operation errors, surface a typed
+//   `FlutterError` so the Dart side re-raises as
+//   `CloudKitChannelError`. The Dart callers treat zone creation as a
+//   precondition for any write into a custom zone — a failure must
+//   halt the flow, not "try anyway".
+// * `qualityOfService = .userInitiated`: zone creation is blocking for
+//   the UI flow that depends on it (first-run sync bootstrap); we
+//   don't want background-priority starvation.
+// * Single-user, private DB only (S7.3 scope — CLAUDE.md: no
+//   multi-user shared zones in v2.0). Zone owner is
+//   `CKCurrentUserDefaultName`.
+
+import CloudKit
+import Flutter
+import Foundation
+
+public final class EnsureZoneHandler {
+
+    public init() {}
+
+    public func handle(
+        arguments: Any?,
+        result: @escaping FlutterResult
+    ) {
+        guard let args = arguments as? [String: Any] else {
+            result(FlutterError(
+                code: "CK_BAD_ARGS",
+                message: "ensureZoneExists arguments must be a Map",
+                details: nil
+            ))
+            return
+        }
+        guard let zoneName = args["zoneName"] as? String else {
+            result(FlutterError(
+                code: "CK_BAD_ARGS",
+                message: "ensureZoneExists arguments missing 'zoneName' String",
+                details: nil
+            ))
+            return
+        }
+
+        let zoneID = CKRecordZone.ID(
+            zoneName: zoneName,
+            ownerName: CKCurrentUserDefaultName
+        )
+        let zone = CKRecordZone(zoneID: zoneID)
+
+        let op = CKModifyRecordZonesOperation(
+            recordZonesToSave: [zone],
+            recordZoneIDsToDelete: nil
+        )
+        op.qualityOfService = .userInitiated
+        // `modifyRecordZonesResultBlock` is the iOS 16+ completion API.
+        // We surface success as Flutter `null`; any error surfaces as
+        // `FlutterError(code: "CK_ENSURE_ZONE_FAILED")`.
+        op.modifyRecordZonesResultBlock = { opResult in
+            switch opResult {
+            case .success:
+                result(nil)
+            case .failure(let error):
+                result(FlutterError(
+                    code: "CK_ENSURE_ZONE_FAILED",
+                    message: error.localizedDescription,
+                    details: String(describing: error)
+                ))
+            }
+        }
+
+        CKContainer.default().privateCloudDatabase.add(op)
+    }
+}

--- a/ios/Runner/CloudKit/GetRecordHandler.swift
+++ b/ios/Runner/CloudKit/GetRecordHandler.swift
@@ -1,10 +1,14 @@
-// Handler for `getRecord` — issue #70 (S7.2).
+// Handler for `getRecord` — issue #70 (S7.2), extended #71 (S7.3).
 //
 // Fetches a single record by name from the default container's private
-// database (default zone). Uses `CKDatabase.fetch(withRecordID:
-// completionHandler:)`. Encodes the resulting `CKRecord` via
-// `CloudKitRecordCodec` and returns it as a `[String: Any]` map to
-// Flutter.
+// database. Uses `CKDatabase.fetch(withRecordID: completionHandler:)`.
+// S7.3 adds optional `zoneName` on the args map — when absent/nil the
+// fetch targets the default zone (S7.2 back-compat); when set, the
+// record ID is scoped to `CKRecordZone.ID(zoneName: ..., ownerName:
+// CKCurrentUserDefaultName)` via
+// `CloudKitRecordCodec.recordID(forRecordName:zoneName:)`. Encodes the
+// resulting `CKRecord` via `CloudKitRecordCodec` and returns it as a
+// `[String: Any]` map to Flutter.
 //
 // Trust-rule notes:
 // * Record-not-found → `nil` result (Dart-side null). Get-by-id
@@ -57,9 +61,13 @@ public final class GetRecordHandler {
             ))
             return
         }
+        // S7.3: optional zoneName. Missing → default zone (back-compat
+        // with S7.2 probe records). Present → scope the record ID to
+        // the named custom zone under the current user.
+        let zoneName = args["zoneName"] as? String
 
         let db = CKContainer.default().privateCloudDatabase
-        let recordID = CKRecord.ID(recordName: recordName)
+        let recordID = CloudKitRecordCodec.recordID(forRecordName: recordName, zoneName: zoneName)
         db.fetch(withRecordID: recordID) { record, error in
             if let ckError = error as? CKError, ckError.code == .unknownItem {
                 // Record-not-found — Dart sees this as `null`.

--- a/ios/Runner/CloudKit/SaveRecordHandler.swift
+++ b/ios/Runner/CloudKit/SaveRecordHandler.swift
@@ -1,18 +1,20 @@
-// Handler for `saveRecord` — issue #70 (S7.2).
+// Handler for `saveRecord` — issue #70 (S7.2), extended #71 (S7.3).
 //
 // Wraps `CKDatabase.save(_:completionHandler:)` on the default
-// container's private database (default zone — zones arrive in S7.3).
-// Decodes the incoming Flutter args map into a `CKRecord` via
-// `CloudKitRecordCodec`, then pushes it to CloudKit. On completion,
-// signals success via a Flutter `null` result; on failure, surfaces a
-// typed `FlutterError` the Dart side re-raises as
-// `CloudKitChannelError`.
+// container's private database. S7.3 adds optional `zoneName` on the
+// args map — decoded by `CloudKitRecordCodec` and baked into the
+// `CKRecord.ID` at construction time. When `zoneName` is absent/nil
+// the record lands in the default zone (S7.2 back-compat); when set,
+// the record targets `CKRecordZone.ID(zoneName: ..., ownerName:
+// CKCurrentUserDefaultName)`. On completion, signals success via a
+// Flutter `null` result; on failure, surfaces a typed `FlutterError`
+// the Dart side re-raises as `CloudKitChannelError`.
 //
 // Trust-rule notes:
 // * No silent fallback: if `CKDatabase.save` fails, the Dart side sees
 //   a failure. Callers never observe a fire-and-forget save.
 // * `CKDatabase.save` overwrites by default (no change-tag check) —
-//   that's the S7.2 design. Conflict detection lands in S7.4 via
+//   that's the S7.2 design. Conflict detection lands in Sprint 8 via
 //   `CKModifyRecordsOperation` with `.ifServerRecordUnchanged`.
 
 import CloudKit

--- a/lib/sources/cloudkit/cloud_kit_source.dart
+++ b/lib/sources/cloudkit/cloud_kit_source.dart
@@ -20,8 +20,21 @@
 //   the ordering contract (it is load-bearing — Apple's order, not Dart's
 //   declaration-order whim).
 //
-// This is the walking skeleton. S7.2 (#70) adds record CRUD; S7.3 (#71)
-// adds zones. Keep this file small and honest.
+// S7.1 shipped `getAccountStatus`. S7.2 (#70) added record CRUD in the
+// default zone. S7.3 (#71, this change) introduces record zones:
+// `ensureZoneExists(zoneName:)` + optional `zoneName` on save/get. When
+// `zoneName` is null (back-compat with S7.2 probe records), the default
+// zone is used; when set, records live in the named custom zone under
+// `CKCurrentUserDefaultName`. Keep this file small and honest.
+
+/// Canonical app zone name. All real app data (post-S7.3) lives here,
+/// not the default zone. One zone keeps change-feed wiring cheap (S7.5
+/// uses `CKFetchRecordZoneChangesOperation` per zone) and scopes
+/// `deleteRecordZone` to a single blast-radius for account reset.
+///
+/// S7.2 shipped probe records into the default zone — those are
+/// disposable orphans post-S7.3; see Runbooks.md for cleanup.
+const String kLiftLogZoneName = 'LiftLogZone';
 
 /// CloudKit account status, mirroring Apple's `CKAccountStatus`.
 ///
@@ -123,7 +136,28 @@ abstract class CloudKitSource {
   /// platform error or unrecognised raw value.
   Future<CloudKitAccountStatus> getAccountStatus();
 
-  /// Saves [record] to the private database (default zone).
+  /// Creates the custom record zone named [zoneName] in the private
+  /// database if it does not already exist. Idempotent — a second call
+  /// for the same name is a no-op.
+  ///
+  /// On iOS the underlying call is `CKModifyRecordZonesOperation`
+  /// against `CKContainer.default().privateCloudDatabase`. CloudKit
+  /// treats the op as an upsert by zone ID, so creating an existing
+  /// zone succeeds naturally (no special-case "already exists" mapping
+  /// required). Any real failure (network, auth, entitlement) surfaces
+  /// as [CloudKitChannelError].
+  ///
+  /// Zones are owned by the current user
+  /// (`CKCurrentUserDefaultName`) — S7.3 does not support shared /
+  /// public zones (explicit v2 non-goal; see CLAUDE.md).
+  Future<void> ensureZoneExists({required String zoneName});
+
+  /// Saves [record] to the private database.
+  ///
+  /// When [zoneName] is null, the record lands in the default zone —
+  /// kept for back-compat with S7.2 probe records. Callers handling
+  /// real app data should pass [kLiftLogZoneName] and ensure the zone
+  /// exists first via [ensureZoneExists].
   ///
   /// On iOS the underlying call is
   /// `CKDatabase.save(_:completionHandler:)` on
@@ -134,10 +168,16 @@ abstract class CloudKitSource {
   /// Errors surface as [CloudKitChannelError]; a `MissingPluginException`
   /// propagates unchanged. Never fire-and-forget: the returned Future
   /// completes only when the native side has acknowledged the save.
-  Future<void> saveRecord(CloudKitRecord record);
+  Future<void> saveRecord(CloudKitRecord record, {String? zoneName});
 
   /// Fetches a single record by [recordType] + [recordName] from the
-  /// private database (default zone).
+  /// private database.
+  ///
+  /// When [zoneName] is null, the fetch targets the default zone (S7.2
+  /// back-compat). When set, the record ID is scoped to the named
+  /// custom zone under `CKCurrentUserDefaultName`. A record saved in
+  /// the default zone is NOT visible from a custom zone and vice
+  /// versa — zone scoping is absolute.
   ///
   /// Returns `null` when CloudKit reports the record does not exist
   /// (native-side maps `CKError.unknownItem` to a null result). Any
@@ -150,6 +190,7 @@ abstract class CloudKitSource {
   Future<CloudKitRecord?> getRecord({
     required String recordType,
     required String recordName,
+    String? zoneName,
   });
 }
 

--- a/lib/sources/cloudkit/fake_cloud_kit_source.dart
+++ b/lib/sources/cloudkit/fake_cloud_kit_source.dart
@@ -9,6 +9,14 @@
 
 import 'cloud_kit_source.dart';
 
+/// Sentinel zone-key for records saved with `zoneName == null` (i.e.
+/// the default zone). Can't be a real CloudKit zone name — Apple's
+/// default zone name is the literal `"_defaultZone"`, but we want a
+/// marker the test tree can't accidentally collide with when it
+/// constructs a custom zone. Zero-byte prefix is safe: CKRecordZone
+/// names are alphanumeric + `-` + `_`; a NUL char is illegal.
+const String _kFakeDefaultZoneKey = '\u0000__default__';
+
 /// Stubbed [CloudKitSource] that returns whatever was handed to it.
 ///
 /// Ctor takes the initial [CloudKitAccountStatus] the fake will report
@@ -36,13 +44,30 @@ class FakeCloudKitSource implements CloudKitSource {
   /// How many times [getRecord] has been invoked.
   int getRecordCallCount = 0;
 
-  /// In-memory record store keyed by `(recordType, recordName)`. Keeps
-  /// type-by-type namespacing honest — two records with the same name
-  /// but different types don't collide (mirrors CKRecord.ID semantics).
+  /// How many times [ensureZoneExists] has been invoked.
+  int ensureZoneExistsCallCount = 0;
+
+  /// In-memory record store keyed by `(zoneKey, recordType, recordName)`.
+  /// `zoneKey` is [_kFakeDefaultZoneKey] for null (default zone) or the
+  /// zoneName string for a custom zone. Records in different zones do
+  /// not collide — mirrors `CKRecord.ID(zoneID:)` semantics on the real
+  /// CloudKit side. Before S7.3 this was two-part (type + name) only.
   final Map<String, CloudKitRecord> _store = {};
 
-  String _key(String recordType, String recordName) =>
-      '$recordType\u0000$recordName';
+  /// Zones created via [ensureZoneExists]. Tracked so tests can assert
+  /// idempotency. Real CloudKit state survives process restart; this
+  /// fake only tracks within the current object lifetime, which is
+  /// fine because tests always instantiate a fresh fake.
+  final Set<String> _zones = {};
+
+  String _key(String? zoneName, String recordType, String recordName) {
+    final zoneKey = zoneName ?? _kFakeDefaultZoneKey;
+    return '$zoneKey\u0000$recordType\u0000$recordName';
+  }
+
+  /// Exposes the set of created zones for test assertions. Returns an
+  /// unmodifiable view so callers can't mutate internal state.
+  Set<String> get createdZones => Set.unmodifiable(_zones);
 
   /// Swap the account status the fake will return on subsequent calls.
   /// Not called by production code — test-only seam.
@@ -57,21 +82,31 @@ class FakeCloudKitSource implements CloudKitSource {
   }
 
   @override
-  Future<void> saveRecord(CloudKitRecord record) async {
+  Future<void> ensureZoneExists({required String zoneName}) async {
+    ensureZoneExistsCallCount += 1;
+    if (_error != null) throw _error;
+    // Idempotent — a second call for the same name is a no-op. Matches
+    // CloudKit's `CKModifyRecordZonesOperation` upsert semantics.
+    _zones.add(zoneName);
+  }
+
+  @override
+  Future<void> saveRecord(CloudKitRecord record, {String? zoneName}) async {
     saveRecordCallCount += 1;
     if (_error != null) throw _error;
     // Upsert — matches the real CloudKit default `save` semantics
     // (S7.2 scope: no conflict detection, S7.4 adds batch + policy).
-    _store[_key(record.recordType, record.recordName)] = record;
+    _store[_key(zoneName, record.recordType, record.recordName)] = record;
   }
 
   @override
   Future<CloudKitRecord?> getRecord({
     required String recordType,
     required String recordName,
+    String? zoneName,
   }) async {
     getRecordCallCount += 1;
     if (_error != null) throw _error;
-    return _store[_key(recordType, recordName)];
+    return _store[_key(zoneName, recordType, recordName)];
   }
 }

--- a/lib/sources/cloudkit/method_channel_cloud_kit_source.dart
+++ b/lib/sources/cloudkit/method_channel_cloud_kit_source.dart
@@ -15,12 +15,26 @@
 //   [CloudKitChannelError] so feature code never imports
 //   `package:flutter/services.dart` just to catch a platform error.
 //
-// Wire protocol (S7.2 / #70) — MUST match `CloudKitRecordCodec.swift`:
+// Wire protocol (S7.2 / #70, extended S7.3 / #71) — MUST match
+// `CloudKitRecordCodec.swift`:
+//
+//   ensureZoneExists (S7.3):
+//     args    = { "zoneName": String }
+//     returns: null on success; `FlutterError` on failure (re-raised as
+//              [CloudKitChannelError]). Idempotent — creating an
+//              existing zone succeeds naturally (CloudKit upserts by
+//              zone ID).
 //
 //   saveRecord:
 //     args = {
 //       "recordType": String,
 //       "recordName": String,
+//       "zoneName":   String?  — S7.3: optional. When omitted/null,
+//                                 Swift uses the default zone (back-compat
+//                                 with S7.2 probe records). When set,
+//                                 Swift uses
+//                                 CKRecordZone.ID(zoneName: ...,
+//                                   ownerName: CKCurrentUserDefaultName).
 //       "fields": Map<String, List> where each value is
 //                 a 2-element List<dynamic> of the form [typeTag, raw],
 //                 typeTag ∈ {"string","int","double","bool","dateTime"},
@@ -36,10 +50,16 @@
 //     returns: null
 //
 //   getRecord:
-//     args    = { "recordType": String, "recordName": String }
+//     args    = {
+//       "recordType": String,
+//       "recordName": String,
+//       "zoneName":   String?  — same semantics as saveRecord.
+//     }
 //     returns: null if record does not exist (CKError.unknownItem);
 //              otherwise Map with the same shape as saveRecord's args
-//              (including "recordType" + "recordName" + "fields").
+//              (including "recordType" + "recordName" + "fields"). Note
+//              that the returned map does NOT echo "zoneName"; the
+//              caller already knows which zone it asked for.
 //
 // Unknown typeTag on decode → [CloudKitChannelError]. No fallback to
 // String: the spike showed that lossy path is exactly the trust-rule
@@ -68,6 +88,9 @@ const String _kSaveRecord = 'saveRecord';
 
 /// Method name for `getRecord`.
 const String _kGetRecord = 'getRecord';
+
+/// Method name for `ensureZoneExists` (S7.3).
+const String _kEnsureZoneExists = 'ensureZoneExists';
 
 // Wire typeTags. Mirrored on the Swift side in `CloudKitRecordCodec`.
 const String _kTagString = 'string';
@@ -124,17 +147,41 @@ class MethodChannelCloudKitSource implements CloudKitSource {
   }
 
   @override
-  Future<void> saveRecord(CloudKitRecord record) async {
+  Future<void> ensureZoneExists({required String zoneName}) async {
+    try {
+      await _channel.invokeMethod<void>(_kEnsureZoneExists, <String, Object?>{
+        'zoneName': zoneName,
+      });
+    } on PlatformException catch (e) {
+      throw CloudKitChannelError(
+        code: e.code,
+        message: e.message ?? '',
+        details: e.details,
+      );
+    }
+  }
+
+  @override
+  Future<void> saveRecord(CloudKitRecord record, {String? zoneName}) async {
     final encodedFields = <String, List<Object?>>{};
     for (final entry in record.fields.entries) {
       encodedFields[entry.key] = _encodeValue(entry.value);
     }
+    // Build the args map explicitly. When `zoneName` is null we omit
+    // the key entirely rather than sending a `"zoneName": null` — the
+    // Swift side reads it as `args["zoneName"] as? String` which
+    // treats missing and null identically, but omitting keeps the wire
+    // clean and matches the S7.2 back-compat contract.
+    final args = <String, Object?>{
+      'recordType': record.recordType,
+      'recordName': record.recordName,
+      'fields': encodedFields,
+    };
+    if (zoneName != null) {
+      args['zoneName'] = zoneName;
+    }
     try {
-      await _channel.invokeMethod<void>(_kSaveRecord, <String, Object?>{
-        'recordType': record.recordType,
-        'recordName': record.recordName,
-        'fields': encodedFields,
-      });
+      await _channel.invokeMethod<void>(_kSaveRecord, args);
     } on PlatformException catch (e) {
       throw CloudKitChannelError(
         code: e.code,
@@ -148,13 +195,18 @@ class MethodChannelCloudKitSource implements CloudKitSource {
   Future<CloudKitRecord?> getRecord({
     required String recordType,
     required String recordName,
+    String? zoneName,
   }) async {
+    final args = <String, Object?>{
+      'recordType': recordType,
+      'recordName': recordName,
+    };
+    if (zoneName != null) {
+      args['zoneName'] = zoneName;
+    }
     final Object? raw;
     try {
-      raw = await _channel.invokeMethod<Object?>(_kGetRecord, <String, Object?>{
-        'recordType': recordType,
-        'recordName': recordName,
-      });
+      raw = await _channel.invokeMethod<Object?>(_kGetRecord, args);
     } on PlatformException catch (e) {
       throw CloudKitChannelError(
         code: e.code,

--- a/test/sources/cloud_kit_source_test.dart
+++ b/test/sources/cloud_kit_source_test.dart
@@ -339,4 +339,191 @@ void main() {
       );
     });
   });
+
+  group('kLiftLogZoneName constant', () {
+    // Load-bearing: the Dart façade exports this as the canonical app
+    // zone name; Runbooks.md + feature code references the literal
+    // "LiftLogZone". If this ever changes, CloudKit records land in a
+    // different zone on next run — an incident, not a refactor. Pin it.
+    test('equals "LiftLogZone"', () {
+      expect(kLiftLogZoneName, 'LiftLogZone');
+    });
+  });
+
+  group('FakeCloudKitSource — ensureZoneExists', () {
+    test('first call creates the zone; createdZones reflects it', () async {
+      final fake = FakeCloudKitSource();
+      expect(fake.createdZones, isEmpty);
+
+      await fake.ensureZoneExists(zoneName: kLiftLogZoneName);
+
+      expect(fake.createdZones, contains(kLiftLogZoneName));
+      expect(fake.createdZones, hasLength(1));
+      expect(fake.ensureZoneExistsCallCount, 1);
+    });
+
+    test('second call with the same name is a no-op (idempotent)', () async {
+      final fake = FakeCloudKitSource();
+      await fake.ensureZoneExists(zoneName: kLiftLogZoneName);
+      await fake.ensureZoneExists(zoneName: kLiftLogZoneName);
+
+      // Still one zone created; call count reflects both invocations.
+      expect(fake.createdZones, hasLength(1));
+      expect(fake.createdZones, contains(kLiftLogZoneName));
+      expect(fake.ensureZoneExistsCallCount, 2);
+    });
+
+    test('distinct zone names create distinct zones', () async {
+      // Forward-looking: S7.3 only uses one zone, but the fake keeps
+      // its tracking general so a future multi-zone strategy doesn't
+      // need another test scaffold.
+      final fake = FakeCloudKitSource();
+      await fake.ensureZoneExists(zoneName: 'LiftLogZone');
+      await fake.ensureZoneExists(zoneName: 'SomeOtherZone');
+
+      expect(fake.createdZones, hasLength(2));
+      expect(fake.createdZones, contains('LiftLogZone'));
+      expect(fake.createdZones, contains('SomeOtherZone'));
+    });
+
+    test('configured error surfaces on ensureZoneExists', () async {
+      final err = Exception('network down');
+      final fake = FakeCloudKitSource(error: err);
+      expect(
+        () => fake.ensureZoneExists(zoneName: kLiftLogZoneName),
+        throwsA(same(err)),
+      );
+    });
+
+    test('createdZones view is unmodifiable', () {
+      // Defensive: callers can't mutate internal fake state by
+      // reaching into the accessor's returned set.
+      final fake = FakeCloudKitSource();
+      expect(
+        () => fake.createdZones.add('sneaky'),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+
+  group('FakeCloudKitSource — zone-scoped CRUD', () {
+    test('round-trip with explicit zoneName preserves the record', () async {
+      final fake = FakeCloudKitSource();
+      await fake.ensureZoneExists(zoneName: kLiftLogZoneName);
+
+      const saved = CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'spike-1',
+        fields: {'kcal': CKInt(612)},
+      );
+      await fake.saveRecord(saved, zoneName: kLiftLogZoneName);
+
+      final fetched = await fake.getRecord(
+        recordType: 'HealthSpike',
+        recordName: 'spike-1',
+        zoneName: kLiftLogZoneName,
+      );
+      expect(fetched, equals(saved));
+    });
+
+    test(
+      'record saved in default zone is NOT visible from LiftLogZone',
+      () async {
+        // Trust rule: zone scoping is absolute. A record in the default
+        // zone must not bleed into a custom zone — otherwise cleanup
+        // of S7.2 probe records wouldn't be isolable.
+        final fake = FakeCloudKitSource();
+        const record = CloudKitRecord(
+          recordType: 'HealthSpike',
+          recordName: 'spike-1',
+          fields: {'v': CKInt(1)},
+        );
+        // Save into default zone (zoneName omitted == null).
+        await fake.saveRecord(record);
+
+        // Default-zone fetch sees it.
+        expect(
+          await fake.getRecord(
+            recordType: 'HealthSpike',
+            recordName: 'spike-1',
+          ),
+          equals(record),
+        );
+        // LiftLogZone fetch does NOT.
+        expect(
+          await fake.getRecord(
+            recordType: 'HealthSpike',
+            recordName: 'spike-1',
+            zoneName: kLiftLogZoneName,
+          ),
+          isNull,
+        );
+      },
+    );
+
+    test(
+      'record saved in LiftLogZone is NOT visible from default zone',
+      () async {
+        final fake = FakeCloudKitSource();
+        const record = CloudKitRecord(
+          recordType: 'HealthSpike',
+          recordName: 'spike-1',
+          fields: {'v': CKInt(1)},
+        );
+        await fake.saveRecord(record, zoneName: kLiftLogZoneName);
+
+        // Custom-zone fetch sees it.
+        expect(
+          await fake.getRecord(
+            recordType: 'HealthSpike',
+            recordName: 'spike-1',
+            zoneName: kLiftLogZoneName,
+          ),
+          equals(record),
+        );
+        // Default-zone fetch does NOT.
+        expect(
+          await fake.getRecord(
+            recordType: 'HealthSpike',
+            recordName: 'spike-1',
+          ),
+          isNull,
+        );
+      },
+    );
+
+    test(
+      'same record name in different zones stores different records',
+      () async {
+        // Complementary to the isolation tests above: saves to each
+        // zone keep their own copy.
+        final fake = FakeCloudKitSource();
+        const defaultRec = CloudKitRecord(
+          recordType: 'HealthSpike',
+          recordName: 'same',
+          fields: {'v': CKInt(1)},
+        );
+        const customRec = CloudKitRecord(
+          recordType: 'HealthSpike',
+          recordName: 'same',
+          fields: {'v': CKInt(2)},
+        );
+        await fake.saveRecord(defaultRec);
+        await fake.saveRecord(customRec, zoneName: kLiftLogZoneName);
+
+        expect(
+          await fake.getRecord(recordType: 'HealthSpike', recordName: 'same'),
+          equals(defaultRec),
+        );
+        expect(
+          await fake.getRecord(
+            recordType: 'HealthSpike',
+            recordName: 'same',
+            zoneName: kLiftLogZoneName,
+          ),
+          equals(customRec),
+        );
+      },
+    );
+  });
 }

--- a/test/sources/method_channel_cloud_kit_source_test.dart
+++ b/test/sources/method_channel_cloud_kit_source_test.dart
@@ -396,6 +396,121 @@ void main() {
     });
   });
 
+  group('ensureZoneExists — wire contract', () {
+    test('sends "ensureZoneExists" method with the zoneName arg', () async {
+      MethodCall? observed;
+      mockChannel((call) async {
+        observed = call;
+        return null;
+      });
+      final source = MethodChannelCloudKitSource();
+      await source.ensureZoneExists(zoneName: kLiftLogZoneName);
+
+      expect(observed, isNotNull);
+      expect(observed!.method, 'ensureZoneExists');
+      final args = observed!.arguments as Map;
+      expect(args['zoneName'], kLiftLogZoneName);
+    });
+
+    test('PlatformException → CloudKitChannelError', () async {
+      mockChannel((_) async {
+        throw PlatformException(
+          code: 'CK_ENSURE_ZONE_FAILED',
+          message: 'zone create failed',
+          details: 'nserror-details',
+        );
+      });
+      final source = MethodChannelCloudKitSource();
+      await expectLater(
+        () => source.ensureZoneExists(zoneName: kLiftLogZoneName),
+        throwsA(
+          isA<CloudKitChannelError>()
+              .having((e) => e.code, 'code', 'CK_ENSURE_ZONE_FAILED')
+              .having((e) => e.message, 'message', 'zone create failed')
+              .having((e) => e.details, 'details', 'nserror-details'),
+        ),
+      );
+    });
+  });
+
+  group('saveRecord — zoneName wire arg', () {
+    // S7.3: when a non-null zoneName is passed, it must ride in the
+    // args map. When omitted, the key must be absent (default-zone
+    // back-compat with S7.2 probe records).
+    test('zoneName included in args when caller passes it', () async {
+      MethodCall? observed;
+      mockChannel((call) async {
+        observed = call;
+        return null;
+      });
+      final source = MethodChannelCloudKitSource();
+      const record = CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'spike-1',
+        fields: {'v': CKInt(1)},
+      );
+      await source.saveRecord(record, zoneName: kLiftLogZoneName);
+
+      final args = observed!.arguments as Map;
+      expect(args['zoneName'], kLiftLogZoneName);
+      expect(args['recordType'], 'HealthSpike');
+      expect(args['recordName'], 'spike-1');
+    });
+
+    test('zoneName key omitted when caller does not pass it', () async {
+      MethodCall? observed;
+      mockChannel((call) async {
+        observed = call;
+        return null;
+      });
+      final source = MethodChannelCloudKitSource();
+      const record = CloudKitRecord(
+        recordType: 'HealthSpike',
+        recordName: 'spike-1',
+        fields: {'v': CKInt(1)},
+      );
+      // No zoneName arg — S7.2 back-compat path.
+      await source.saveRecord(record);
+
+      final args = observed!.arguments as Map;
+      expect(args.containsKey('zoneName'), isFalse);
+    });
+  });
+
+  group('getRecord — zoneName wire arg', () {
+    test('zoneName included in args when caller passes it', () async {
+      MethodCall? observed;
+      mockChannel((call) async {
+        observed = call;
+        return null; // record-not-found is fine; we only care about args.
+      });
+      final source = MethodChannelCloudKitSource();
+      await source.getRecord(
+        recordType: 'HealthSpike',
+        recordName: 'spike-1',
+        zoneName: kLiftLogZoneName,
+      );
+
+      final args = observed!.arguments as Map;
+      expect(args['zoneName'], kLiftLogZoneName);
+      expect(args['recordType'], 'HealthSpike');
+      expect(args['recordName'], 'spike-1');
+    });
+
+    test('zoneName key omitted when caller does not pass it', () async {
+      MethodCall? observed;
+      mockChannel((call) async {
+        observed = call;
+        return null;
+      });
+      final source = MethodChannelCloudKitSource();
+      await source.getRecord(recordType: 'HealthSpike', recordName: 'spike-1');
+
+      final args = observed!.arguments as Map;
+      expect(args.containsKey('zoneName'), isFalse);
+    });
+  });
+
   group('round-trip through encode → decode on the same channel', () {
     test('every value type survives an encode → decode cycle', () async {
       // Capture the Dart-side encoded payload, then synthesize a


### PR DESCRIPTION
Closes #71.

## Summary

- Adds `CloudKitSource.ensureZoneExists(zoneName:)` — idempotent `CKRecordZone` create in the private DB, wraps `CKModifyRecordZonesOperation` with `modifyRecordZonesResultBlock` (iOS 16+) and `.userInitiated` QoS.
- Extends `saveRecord` + `getRecord` with an optional `zoneName`. When null → default zone (back-compat with S7.2 probe records). When set → `CKRecordZone.ID(zoneName:, ownerName: CKCurrentUserDefaultName)`.
- Exports `const String kLiftLogZoneName = 'LiftLogZone'` as the canonical app zone. All real app data (Sprint 8+) lives here; S7.2 probe records in the default zone are disposable orphans.
- Native `EnsureZoneHandler.swift` (new) + `CloudKitBridge` dispatch wired through. `CloudKitRecordCodec.recordID(forRecordName:zoneName:)` is the single construction point for zone-scoped `CKRecord.ID`.

## Channel contract (zone-scoping summary)

```
ensureZoneExists:
  args    = { "zoneName": String }
  returns = null on success; FlutterError → CloudKitChannelError on failure.
            Idempotent (CloudKit upserts zones by zoneID).

saveRecord / getRecord:
  args gain optional "zoneName": String?
    - omitted/null → default zone (S7.2 back-compat)
    - non-nil      → CKRecordZone.ID(zoneName:, ownerName: CKCurrentUserDefaultName)
  getRecord response does NOT echo "zoneName" — caller knows which zone it asked for.
```

## Defaults picked (noted for PM)

- **Omit `zoneName` key entirely when null** rather than sending `"zoneName": null`. Swift reads `args["zoneName"] as? String` which treats missing and null identically, so both work; omitting keeps the wire clean and keeps S7.2 trace dumps unchanged.
- **No default value on `ensureZoneExists(zoneName:)` parameter.** Callers must pass `kLiftLogZoneName` explicitly so any future second zone (if we ever add one) doesn't silently target the wrong name.
- **Fake `createdZones` exposed as unmodifiable view.** Defensive — tests can assert set membership without being able to mutate internal state.

## Trust rules

- **No silent fallback.** `ensureZoneExists` errors surface as typed `CloudKitChannelError`. "Already exists" is naturally a success (CloudKit upsert semantics); every other failure throws.
- **Detect, report, and halt.** Dart callers treat zone creation as a precondition for zone-scoped writes — a failure must halt the flow, not "try anyway".
- **Zone scoping is absolute.** A record in the default zone is invisible from `LiftLogZone` and vice versa — enforced both on the real CloudKit side (Apple's semantics) and in the fake (`(zoneKey, recordType, recordName)` key).

## Verification

- `flutter analyze` — clean.
- `flutter test` — **411 → 427 (+16 new)**. All green.
- `flutter build ios --debug --no-codesign` — green.
- `flutter clean` run to avoid stale iphoneos artifacts.
- Arch guardrail (`test/arch/data_access_boundary_test.dart`) — green (no feature code touched).

## Scope discipline

- Single zone only (`LiftLogZone`). Multi-zone strategy is out of scope.
- No zone deletion, no zone-scoped queries, no batch modify. Those are Sprint 8+.
- No feature code (`lib/features/**`) touched. No new runtime deps.

## Runbook note

Vault is gitignored, so the Runbooks.md update doesn't appear in this diff — it's applied locally under "CloudKit container setup" section. Short note: S7.2 default-zone probe orphans are disposable post-S7.3 (delete via CloudKit Console, or ignore — they don't affect zone-scoped reads).

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test --timeout=60s` all green (427 tests)
- [x] `flutter build ios --debug --no-codesign` builds
- [ ] Device-verification: founder runs on iPhone 15 with CloudKit container provisioned (per Runbooks.md) — expects `ensureZoneExists(zoneName: kLiftLogZoneName)` to succeed idempotently, and a round-trip save/get in the custom zone to preserve the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)